### PR TITLE
研究: source-ref repair holonomy annihilation を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -23,3 +23,4 @@ import Formal.AG.Research.QualitySurface.CodebaseTraceRepairTrajectory
 import Formal.AG.Research.QualitySurface.TupleHolonomyDefect
 import Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket
 import Formal.AG.Research.QualitySurface.SourceRefExactVisualization
+import Formal.AG.Research.QualitySurface.SourceRefRepairHolonomy

--- a/Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean
+++ b/Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean
@@ -1,0 +1,203 @@
+import Formal.AG.Research.QualitySurface.CodebaseTraceRepairTrajectory
+import Formal.AG.Research.QualitySurface.SourceRefExactVisualization
+
+/-!
+Cycle 25 evidence for `G-aat-quality-surface-01`.
+
+This file reads the supplied exact source-ref repair action as a finite
+holonomy-annihilation step: before repair, the visible packet-to-tuple surface
+is flat but source-ref exactness fails; after the declared exact fill, the
+repaired packet agrees with the full packet on protected source-ref data, so
+packet holonomy, tuple holonomy, and source-ref exact visualization are
+restored.  The claim is relative to the supplied finite packet family, the
+declared repair action, and the explicit packet-to-tuple bridge.  It does not
+assert arbitrary repair reachability, source extraction completeness, ArchMap
+correctness, a canonical extractor, a global transport law, or whole-codebase
+quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SourceRefRepairHolonomyAnnihilation
+
+open CodebaseTracePacket
+open CodebaseTraceRepairTrajectory
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+
+/-! ## Post-repair protected-data agreement -/
+
+/-- The full packet and repaired storage packet have the same visible surface. -/
+theorem full_storageRepair_supportSurface_equivalent :
+    supportSurfaceReading.Equivalent fullPacket storageRepairPacket := by
+  constructor
+  · exact ⟨rfl, rfl⟩
+  · intro atom
+    constructor <;> intro _hsupport <;> trivial
+
+/--
+After the exact storage repair, the repaired packet agrees with the full packet
+on obligation, repair frontier, and source-ref table.
+-/
+theorem storageRepairPacket_sameProtectedData_fullPacket :
+    SameSourceRefPacketProtectedData fullPacket storageRepairPacket := by
+  constructor
+  · rfl
+  constructor
+  · intro atom
+    constructor
+    · intro hfrontier
+      exact False.elim hfrontier
+    · intro hfrontier
+      change codebaseSupport atom ∧ fullSourceRefTable atom = none at hfrontier
+      rcases hfrontier with ⟨_hsupport, htable⟩
+      cases atom <;> cases htable
+  · intro atom
+    cases atom <;> rfl
+
+/-- The exact storage repair annihilates packet-level source-ref holonomy. -/
+theorem storageRepairPacket_noPacketHolonomy_fullPacket :
+    NoSourceRefPacketHolonomyDefect fullPacket storageRepairPacket :=
+  storageRepairPacket_sameProtectedData_fullPacket
+
+/-! ## Packet-to-tuple exact visualization after repair -/
+
+/-- Post-repair packets induce the same visible tuple visualization. -/
+theorem storageRepairPacket_tupleVisible_equivalent :
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket storageRepairPacket :=
+  SourceRefTupleBridge.packet_supportSurface_projects_to_tuple_visible
+    full_storageRepair_supportSurface_equivalent
+
+/-- Packet zero holonomy after repair induces tuple zero holonomy. -/
+theorem storageRepairPacket_noTupleHolonomy_fullPacket :
+    TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple
+        SourceRefTupleBridge.endpointGridCertificate fullPacket)
+      (SourceRefTupleBridge.packetToTuple
+        SourceRefTupleBridge.endpointGridCertificate storageRepairPacket) :=
+  noPacketHolonomy_projects_to_noTupleHolonomy
+    SourceRefTupleBridge.endpointGridCertificate
+    SourceRefTupleBridge.endpointGridCertificate
+    storageRepairPacket_noPacketHolonomy_fullPacket
+
+/-- The repaired packet pair is source-ref exact at the packet-to-tuple view. -/
+theorem storageRepairPacket_sourceRefExactVisualization :
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket storageRepairPacket :=
+  ⟨storageRepairPacket_tupleVisible_equivalent,
+    storageRepairPacket_noTupleHolonomy_fullPacket⟩
+
+/-! ## Before/after contrast -/
+
+/--
+The selected repair step turns a lossy full/partial visualization into a
+source-ref exact full/repaired visualization.
+-/
+theorem repairRestores_sourceRefExactVisualization :
+    ¬ SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket partialPacket ∧
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket storageRepairPacket :=
+  ⟨full_partial_packetTuple_not_sourceRefExact,
+    storageRepairPacket_sourceRefExactVisualization⟩
+
+/--
+The exact fill repair kills the protected packet holonomy visible in the
+full/partial packet pair.
+-/
+theorem repairAnnihilates_packetHolonomy :
+    HasSourceRefPacketHolonomyDefect fullPacket partialPacket ∧
+      NoSourceRefPacketHolonomyDefect fullPacket storageRepairPacket :=
+  ⟨full_partial_packet_hasHolonomyDefect,
+    storageRepairPacket_noPacketHolonomy_fullPacket⟩
+
+/--
+The visible surface alone does not see the holonomy-annihilation step: the
+partial and repaired packets have the same support-surface reading, while the
+full/partial pair is non-exact and the full/repaired pair is exact.
+-/
+theorem repairHolonomy_before_after_contrast :
+    supportSurfaceReading.Equivalent partialPacket storageRepairPacket ∧
+      LossyPacketToTupleVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket partialPacket ∧
+      ¬ SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket partialPacket ∧
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket storageRepairPacket ∧
+      HasSourceRefPacketHolonomyDefect fullPacket partialPacket ∧
+      NoSourceRefPacketHolonomyDefect fullPacket storageRepairPacket :=
+  ⟨repairTrajectory_visibleSurface_preserved,
+    full_partial_packetTuple_lossyVisualization,
+    full_partial_packetTuple_not_sourceRefExact,
+    storageRepairPacket_sourceRefExactVisualization,
+    full_partial_packet_hasHolonomyDefect,
+    storageRepairPacket_noPacketHolonomy_fullPacket⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-25 theorem package: the supplied exact storage repair action annihilates
+the finite source-ref packet holonomy and restores source-ref exact
+visualization, even though the visible surface by itself does not expose the
+protected before/after change.
+-/
+theorem sourceRefRepairHolonomyAnnihilation_package :
+    FillsExactlyMissingSourceRefs storageRepairAction partialPacket ∧
+      supportSurfaceReading.Equivalent partialPacket storageRepairPacket ∧
+      (¬ ∃ atom, SourceRefMissingLocus storageRepairPacket atom) ∧
+      (¬ ∃ atom, storageRepairPacket.repairFrontier atom) ∧
+      RepairFrontierExact storageRepairPacket ∧
+      SourceRefAvailableOn storageRepairPacket.codeSupport
+        storageRepairPacket.sourceRefTable ∧
+      SameSourceRefPacketProtectedData fullPacket storageRepairPacket ∧
+      NoSourceRefPacketHolonomyDefect fullPacket storageRepairPacket ∧
+      TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+        (SourceRefTupleBridge.packetToTuple
+          SourceRefTupleBridge.endpointGridCertificate fullPacket)
+        (SourceRefTupleBridge.packetToTuple
+          SourceRefTupleBridge.endpointGridCertificate storageRepairPacket) ∧
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket storageRepairPacket ∧
+      LossyPacketToTupleVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket partialPacket ∧
+      ¬ SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket partialPacket ∧
+      HasSourceRefPacketHolonomyDefect fullPacket partialPacket :=
+  ⟨storageRepairAction_exactly_fills_missingRefs,
+    repairTrajectory_visibleSurface_preserved,
+    repairTrajectory_missingLocus_collapses,
+    repairTrajectory_repairFrontier_collapses,
+    repairTrajectory_repairFrontierExact,
+    repairTrajectory_available_on_support,
+    storageRepairPacket_sameProtectedData_fullPacket,
+    storageRepairPacket_noPacketHolonomy_fullPacket,
+    storageRepairPacket_noTupleHolonomy_fullPacket,
+    storageRepairPacket_sourceRefExactVisualization,
+    full_partial_packetTuple_lossyVisualization,
+    full_partial_packetTuple_not_sourceRefExact,
+    full_partial_packet_hasHolonomyDefect⟩
+
+end SourceRefRepairHolonomyAnnihilation
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-source-ref-repair-holonomy-annihilation.md
+++ b/research/ideas/g-aat-quality-surface-01-source-ref-repair-holonomy-annihilation.md
@@ -1,0 +1,136 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: traceability / repair-potential / certificate-transport / obstruction / invariance
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle25
+tags: [quality-surface, source-ref, repair, holonomy, exact-visualization]
+created: 2026-06-20
+cycle: 25
+lean: Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean
+---
+
+# Finite source-ref repair holonomy annihilation restores exact visualization
+
+## 主張
+
+Supplied finite source-ref packet pair と exact fill repair action に相対化して、
+repair 前の visible packet-to-tuple surface は flat でも protected packet holonomy を持ち、
+repair 後は full packet と protected data が一致するため packet zero holonomy、tuple zero holonomy、
+source-ref exact visualization が同時に復元される。
+
+より正確には、`partialPacket` から `storageRepairAction` によって得た repaired packet は
+`fullPacket` と同じ obligation、repair frontier、source-ref table を持つ。したがって
+`NoSourceRefPacketHolonomyDefect fullPacket storageRepairPacket` が成立し、packet-induced tuple でも
+`NoTupleHolonomyDefect` が成立する。さらに visible tuple surface equivalence と合わせて
+`SourceRefExactVisualization` が成立する。一方、repair 前の `fullPacket / partialPacket` pair は
+visible flat だが source-ref exact ではない。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- Cycle 21: `Formal/AG/Research/QualitySurface/CodebaseTraceRepairTrajectory.lean`
+- Cycle 23: `Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean`
+- Cycle 24: `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
+- `research/reports/G-aat-quality-surface-01.md` の Cycle 21, 23, 24 と Next Frontier。
+
+この候補は transport square までを主張しない。ここで固定するのは repair action が protected source-ref
+holonomy を annihilate し、exact visualization を復元する finite before/after diagram である。
+
+## 非自明性
+
+単に repair trajectory と holonomy detector を並べるだけではなく、exact fill repair が
+hidden packet holonomy class を消す操作として働くことを、packet zero defect、tuple zero defect、
+source-ref exact visualization の三つの水準で同時に固定する。visible surface だけでは repair 前後の
+protected holonomy 消滅を読めないため、loss-aware visualization の検出条件とも接続する。
+
+## 数学的興味
+
+repair を値の更新ではなく、protected source-ref holonomy を annihilate する finite before/after diagram として読める。
+これにより repair-potential、traceability、certificate transport、loss-aware visualization が同一の
+finite certificate geometry の中で接続される。
+
+## GOAL への前進
+
+finite codebase trace example を、static holonomy witness から repair action による exact visualization
+restoration へ持ち上げ、traceability / repair-potential / certificate-transport / obstruction / invariance
+カテゴリを同時に前進させる。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 21 の repair trajectory と Cycle 23/24 の packet holonomy / exact visualization を統合し、repair-holonomy annihilation と exact visualization restoration を Lean-proved にする。transport law までは主張しないため base 60 とする。
+- `dullness_risk`: medium。既存 theorem の conjunction だけなら dull。repair 後の protected data agreement、packet zero、tuple zero、source-ref exact restoration、repair 前 non-exact との対比を一つの finite diagram として出す必要がある。
+- `proof_or_evidence_plan`: 新規 Research Lean file で repaired packet と full packet の protected-data agreementを証明し、`NoSourceRefPacketHolonomyDefect`、`NoTupleHolonomyDefect`、`SourceRefExactVisualization`、pre/post exactness contrast、visible nonfaithfulness package を証明する。
+
+## CS / SWE への帰結
+
+source-ref 欠落の repair は、表面上の scalar / verdict / support surface を変えないまま hidden quality
+certificate geometry を正規化できる。tooling や UI へ移植する場合は、supplied finite packet、declared
+repair action、packet-to-tuple bridge、source-ref exact visualization の仮定に相対化する。
+
+## 証明・根拠
+
+Lean では `CodebaseTraceRepairTrajectory.storageRepairPacket` を post-state として使い、
+`CodebaseTracePacket.fullPacket` と obligation / repair frontier / source-ref table が一致することを
+case analysis で示した。そこから Cycle 23 の packet zero defect、Cycle 24 の packet-to-tuple zero iff と
+source-ref exact visualization criterion を使い、repair 後に exact visualization が復元されることを証明した。
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean`
+
+Declarations:
+
+- `storageRepairPacket_sameProtectedData_fullPacket`
+- `storageRepairPacket_noPacketHolonomy_fullPacket`
+- `storageRepairPacket_noTupleHolonomy_fullPacket`
+- `storageRepairPacket_sourceRefExactVisualization`
+- `repairAnnihilates_packetHolonomy`
+- `repairRestores_sourceRefExactVisualization`
+- `repairHolonomy_before_after_contrast`
+- `sourceRefRepairHolonomyAnnihilation_package`
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/source_ref_repair_holonomy_axioms.lean`: pass; all reported declarations depend on no axioms
+- independent axiom audit: pass; no `sorryAx`, nonstandard axioms, `propext`, `Classical.choice`, or `Quot.sound`
+- independent formalization-quality audit: pass; statement matches revised candidate, is not too weak / too strong / vacuous, and keeps the finite repair-holonomy boundary without reintroducing transport-commutator or whole-codebase claims
+
+visible_projection: support-surface / packet-induced visible tuple surface。
+
+protected_structure: obligation、repair frontier、source-ref table、packet holonomy defect、tuple holonomy defect。
+
+exactness_or_minimality_claim: supplied exact fill repair action 後、post packet は full packet と protected-data
+zero holonomyになる。repair support は pre-state missing locus と一致する。
+
+nonfaithfulness_or_failure_mode: repair 前後で visible packet surface は preserved だが、source-ref exactness と
+protected holonomy は変わる。visible-only visualization は repair による holonomy annihilation を検出しない。
+
+previous_cycle_delta: Cycle 24 の static exact-vs-lossy detector を、Cycle 21 の repair trajectory に沿った
+exact visualization restoration theorem へ進める。
+
+## 審判メモ
+
+- 厳密性: initial `revise`; expected score を base 60 / final 120 に下げ、transport commutator ではなく repair-holonomy annihilation として主張を限定することを要求。修正後 `accept`。
+- 研究価値: initial `revise`; static detector から repair action による exact visualization restoration へ進める価値は認めるが、commutator 名は過剰。修正後 `accept`。
+- repo 全体価値: initial `accept` with score reduction request; paper seed / future tooling explanation surface として価値あり。修正後、base 60 / final 120 で `accept`。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-codebase-trace-repair-trajectory.md`
+- `research/ideas/g-aat-quality-surface-01-finite-codebase-trace-holonomy-packet.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-exact-visualization.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 25 G1 で作成。
+- 2026-06-20: G4 SCORE audit confirmed base 60 / multiplier 2.0 / penalty 0 / final 120.

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 2920
+- total SCORE: 3040
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -30,8 +30,9 @@
   - profile-curvature / certificate-transport / invariance / obstruction / traceability: 120
   - traceability / profile-curvature / certificate-transport / computability / repair-potential: 120
   - traceability / certificate-transport / invariance / computability / quality-surface: 120
+  - traceability / repair-potential / certificate-transport / obstruction / invariance: 120
 - evidence portfolio:
-  - proved-in-research: 24
+  - proved-in-research: 25
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1062,8 +1063,52 @@ source-ref exactness を要求すれば hidden packet holonomy は tuple protect
 selected endpoint tuple に相対化され、source extraction completeness、ArchMap correctness、canonical packet
 extractor、任意 codebase traceability、実コード全体の品質判定は結論しない。
 
+## Cycle 25: Finite source-ref repair holonomy annihilation restores exact visualization
+
+```text
+candidate: Finite source-ref repair holonomy annihilation restores exact visualization
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: traceability/repair-potential/certificate-transport/obstruction/invariance
+goal_delta: supplied exact source-ref repair action を hidden packet holonomy を消す before/after diagram として固定し、repair 後に packet zero holonomy、tuple zero holonomy、source-ref exact visualization が復元されることを示した。
+project_value_delta: Cycle 21 の repair trajectory、Cycle 23 の packet holonomy、Cycle 24 の exact visualization detector を report / paper 用の repair-holonomy annihilation package に統合した。
+formalization_quality: pass。post-repair protected-data agreement、packet zero holonomy、tuple zero holonomy、source-ref exact visualization restoration、pre-repair lossy non-exact contrast が axiom-free / sorry-free で証明されている。
+open_questions: genuine repair/transport commutator、component defect composition law、selected decomposition を越える grid localization calculus。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean` は、
+Cycle 21 の supplied storage repair action を、finite source-ref packet holonomy を消す操作として読む。
+repair 前の `fullPacket / partialPacket` pair は visible packet-to-tuple surface では flat だが source-ref exact
+ではない。一方、`partialPacket` に `storageRepairAction` を適用した `storageRepairPacket` は、
+`fullPacket` と protected data で一致する。
+
+Lean 証拠は次を固定する。
+
+- `storageRepairPacket_sameProtectedData_fullPacket`: repaired packet は full packet と obligation、
+  repair frontier、source-ref table で一致する。
+- `storageRepairPacket_noPacketHolonomy_fullPacket`: post-repair pair は packet zero holonomy を持つ。
+- `storageRepairPacket_noTupleHolonomy_fullPacket`: packet-to-tuple bridge を通して tuple zero holonomy が成立する。
+- `storageRepairPacket_sourceRefExactVisualization`: post-repair pair は source-ref exact visualization である。
+- `repairRestores_sourceRefExactVisualization`: pre-repair full/partial pair は non-exact だが、full/repaired pair は exact である。
+- `repairAnnihilates_packetHolonomy`: pre-repair packet holonomy defect は repair 後に zero defect へ消える。
+- `repairHolonomy_before_after_contrast`: visible support surface は repair 前後の protected holonomy annihilation を検出しない。
+- `sourceRefRepairHolonomyAnnihilation_package`: exact fill、visible preservation、post-repair missing/frontier collapse、
+  protected-data agreement、exact visualization restoration、pre-repair lossy holonomy を束ねる theorem package。
+
+この結果により、finite codebase trace repair は単なる source-ref table 更新ではなく、hidden source-ref packet
+holonomy を annihilate し exact visualization を復元する certificate-geometric step として扱える。主張は
+supplied finite packet family、declared exact fill repair action、explicit packet-to-tuple bridge、selected endpoint
+tuple に相対化され、任意 repair reachability、source extraction completeness、ArchMap correctness、canonical
+extractor、global transport law、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 24 後の total SCORE は 2920 である。
-次に進める場合は、finite codebase trace holonomy packet の transport / repair commutator、component defect の合成則、
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 25 後の total SCORE は 3040 である。
+次に進める場合は、genuine finite repair/transport commutator、component defect の合成則、
 または selected decomposition を越える grid localization calculus を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 Cycle 25 として、supplied exact source-ref repair action が hidden packet holonomy を消し、packet zero holonomy / tuple zero holonomy / source-ref exact visualization を復元する finite before/after diagram を Research sandbox に追加しました。

tracking Issue は research-loop の状態正本なので、この PR では close しません。

## 証明した定理

- `SourceRefRepairHolonomyAnnihilation.full_storageRepair_supportSurface_equivalent`
- `SourceRefRepairHolonomyAnnihilation.storageRepairPacket_sameProtectedData_fullPacket`
- `SourceRefRepairHolonomyAnnihilation.storageRepairPacket_noPacketHolonomy_fullPacket`
- `SourceRefRepairHolonomyAnnihilation.storageRepairPacket_tupleVisible_equivalent`
- `SourceRefRepairHolonomyAnnihilation.storageRepairPacket_noTupleHolonomy_fullPacket`
- `SourceRefRepairHolonomyAnnihilation.storageRepairPacket_sourceRefExactVisualization`
- `SourceRefRepairHolonomyAnnihilation.repairRestores_sourceRefExactVisualization`
- `SourceRefRepairHolonomyAnnihilation.repairAnnihilates_packetHolonomy`
- `SourceRefRepairHolonomyAnnihilation.repairHolonomy_before_after_contrast`
- `SourceRefRepairHolonomyAnnihilation.sourceRefRepairHolonomyAnnihilation_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-source-ref-repair-holonomy-annihilation.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/source_ref_repair_holonomy_axioms.lean`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning 2件のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue は tracking Issue のため `Closes #N` ではなく `Refs #2348` とした
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
