### PR TITLE
研究: component holonomy defect propagation を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -24,3 +24,4 @@ import Formal.AG.Research.QualitySurface.TupleHolonomyDefect
 import Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket
 import Formal.AG.Research.QualitySurface.SourceRefExactVisualization
 import Formal.AG.Research.QualitySurface.SourceRefRepairHolonomy
+import Formal.AG.Research.QualitySurface.ComponentDefectPropagation

--- a/Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean
+++ b/Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean
@@ -1,0 +1,427 @@
+import Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket
+
+/-!
+Cycle 26 evidence for `G-aat-quality-surface-01`.
+
+This file turns tuple-level and source-ref packet-level component holonomy
+defects into a finite propagation calculus.  A zero-holonomy leg preserves and
+reflects component defects on either side, while concrete full/partial/full
+witnesses show that two nonzero component-defect legs may cancel at the
+endpoint.  The results are relative to supplied finite tuple certificates,
+source-ref packets, and the explicit packet-to-tuple bridge; they do not assert
+a global additive defect group, canonical extraction, source extraction
+completeness, ArchMap correctness, arbitrary codebase traceability, or
+whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ComponentHolonomyDefectPropagation
+
+open TraceLocus
+open TupleHolonomyDefectInvariant
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+
+abbrev TupleProfile :=
+  TupleHolonomyDefectInvariant.TupleProfile
+
+abbrev TupleCertificateAt :=
+  TupleHolonomyDefectInvariant.TupleCertificateAt
+
+/-! ## Elementary transport lemmas -/
+
+private theorem ne_eq_left_iff {α : Sort _} {a b c : α}
+    (hab : a = b) : b ≠ c ↔ a ≠ c := by
+  constructor
+  · intro hbc hac
+    exact hbc (by
+      rw [← hab]
+      exact hac)
+  · intro hac hbc
+    exact hac (by
+      rw [hab]
+      exact hbc)
+
+private theorem ne_eq_right_iff {α : Sort _} {a b c : α}
+    (hbc : b = c) : a ≠ b ↔ a ≠ c := by
+  constructor
+  · intro hab hac
+    exact hab (by
+      rw [hbc]
+      exact hac)
+  · intro hac hab
+    exact hac (by
+      rw [← hbc]
+      exact hab)
+
+private theorem not_iff_left_iff {a b c : Prop}
+    (hab : a ↔ b) : (¬ (b ↔ c)) ↔ (¬ (a ↔ c)) := by
+  constructor
+  · intro hbc hac
+    exact hbc (Iff.trans (Iff.symm hab) hac)
+  · intro hac hbc
+    exact hac (Iff.trans hab hbc)
+
+private theorem not_iff_right_iff {a b c : Prop}
+    (hbc : b ↔ c) : (¬ (a ↔ b)) ↔ (¬ (a ↔ c)) := by
+  constructor
+  · intro hab hac
+    exact hab (Iff.trans hac (Iff.symm hbc))
+  · intro hac hab
+    exact hac (Iff.trans hab hbc)
+
+/-! ## Tuple zero-defect calculus -/
+
+/-- Tuple zero holonomy is reflexive. -/
+theorem noTupleHolonomyDefect_refl {p : TupleProfile}
+    (c : TupleCertificateAt p) :
+    NoTupleHolonomyDefect c c :=
+  ⟨rfl, by intro atom; rfl, by intro atom; rfl⟩
+
+/-- Tuple zero holonomy composes along finite chains. -/
+theorem noTupleHolonomyDefect_trans {p : TupleProfile}
+    {left middle right : TupleCertificateAt p}
+    (hleft : NoTupleHolonomyDefect left middle)
+    (hright : NoTupleHolonomyDefect middle right) :
+    NoTupleHolonomyDefect left right :=
+  ⟨Eq.trans hleft.1 hright.1,
+    by
+      intro atom
+      exact Iff.trans (hleft.2.1 atom) (hright.2.1 atom),
+    by
+      intro atom
+      exact Eq.trans (hleft.2.2 atom) (hright.2.2 atom)⟩
+
+/-- A zero tuple-holonomy leg on the left preserves and reflects defects. -/
+theorem tupleComponentDefect_propagates_left_of_zero {p : TupleProfile}
+    {left middle right : TupleCertificateAt p}
+    (hzero : NoTupleHolonomyDefect left middle)
+    (component : TupleProtectedComponent) :
+    TupleHolonomyDefect middle right component ↔
+      TupleHolonomyDefect left right component := by
+  cases component with
+  | obligation =>
+      exact ne_eq_left_iff hzero.1
+  | repairFrontier atom =>
+      exact not_iff_left_iff (hzero.2.1 atom)
+  | traceField atom =>
+      exact ne_eq_left_iff (hzero.2.2 atom)
+
+/-- A zero tuple-holonomy leg on the right preserves and reflects defects. -/
+theorem tupleComponentDefect_propagates_right_of_zero {p : TupleProfile}
+    {left middle right : TupleCertificateAt p}
+    (hzero : NoTupleHolonomyDefect middle right)
+    (component : TupleProtectedComponent) :
+    TupleHolonomyDefect left middle component ↔
+      TupleHolonomyDefect left right component := by
+  cases component with
+  | obligation =>
+      exact ne_eq_right_iff hzero.1
+  | repairFrontier atom =>
+      exact not_iff_right_iff (hzero.2.1 atom)
+  | traceField atom =>
+      exact ne_eq_right_iff (hzero.2.2 atom)
+
+/-! ## Packet zero-defect calculus -/
+
+/-- Packet zero holonomy is reflexive. -/
+theorem noSourceRefPacketHolonomyDefect_refl
+    (packet : SourceRefPacket) :
+    NoSourceRefPacketHolonomyDefect packet packet :=
+  ⟨rfl, by intro atom; rfl, by intro atom; rfl⟩
+
+/-- Packet zero holonomy composes along finite chains. -/
+theorem noSourceRefPacketHolonomyDefect_trans
+    {left middle right : SourceRefPacket}
+    (hleft : NoSourceRefPacketHolonomyDefect left middle)
+    (hright : NoSourceRefPacketHolonomyDefect middle right) :
+    NoSourceRefPacketHolonomyDefect left right :=
+  ⟨Eq.trans hleft.1 hright.1,
+    by
+      intro atom
+      exact Iff.trans (hleft.2.1 atom) (hright.2.1 atom),
+    by
+      intro atom
+      exact Eq.trans (hleft.2.2 atom) (hright.2.2 atom)⟩
+
+/-- A zero packet-holonomy leg on the left preserves and reflects defects. -/
+theorem packetComponentDefect_propagates_left_of_zero
+    {left middle right : SourceRefPacket}
+    (hzero : NoSourceRefPacketHolonomyDefect left middle)
+    (component : SourceRefPacketProtectedComponent) :
+    SourceRefPacketHolonomyDefect middle right component ↔
+      SourceRefPacketHolonomyDefect left right component := by
+  cases component with
+  | obligation =>
+      exact ne_eq_left_iff hzero.1
+  | repairFrontier atom =>
+      exact not_iff_left_iff (hzero.2.1 atom)
+  | sourceRefTable atom =>
+      exact ne_eq_left_iff (hzero.2.2 atom)
+
+/-- A zero packet-holonomy leg on the right preserves and reflects defects. -/
+theorem packetComponentDefect_propagates_right_of_zero
+    {left middle right : SourceRefPacket}
+    (hzero : NoSourceRefPacketHolonomyDefect middle right)
+    (component : SourceRefPacketProtectedComponent) :
+    SourceRefPacketHolonomyDefect left middle component ↔
+      SourceRefPacketHolonomyDefect left right component := by
+  cases component with
+  | obligation =>
+      exact ne_eq_right_iff hzero.1
+  | repairFrontier atom =>
+      exact not_iff_right_iff (hzero.2.1 atom)
+  | sourceRefTable atom =>
+      exact ne_eq_right_iff (hzero.2.2 atom)
+
+/--
+Packet component defects that propagate across a zero packet leg still project
+to tuple component defects.
+-/
+theorem packetComponentDefect_projects_after_left_zero
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left middle right : SourceRefPacket}
+    {component : SourceRefPacketProtectedComponent}
+    (hzero : NoSourceRefPacketHolonomyDefect left middle)
+    (hdefect : SourceRefPacketHolonomyDefect middle right component) :
+    TupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple gridLeft left)
+      (SourceRefTupleBridge.packetToTuple gridRight right)
+      (packetComponentToTupleComponent component) :=
+  sourceRefPacketHolonomy_projects_to_tupleHolonomy
+    gridLeft gridRight
+    ((packetComponentDefect_propagates_left_of_zero
+      hzero component).mp hdefect)
+
+/-! ## Cancellation witnesses -/
+
+/-- The reverse endpoint obligation defect also holds. -/
+theorem endpointTuple_obligationReverseComponentDefect :
+    TupleHolonomyDefect
+      ProfileTupleIntegration.traceMissingEndpointTuple
+      ProfileTupleIntegration.fullEndpointTuple
+      TupleProtectedComponent.obligation := by
+  intro hsame
+  cases hsame
+
+/-- The reverse endpoint repair-frontier defect also holds. -/
+theorem endpointTuple_databaseRepairReverseComponentDefect :
+    TupleHolonomyDefect
+      ProfileTupleIntegration.traceMissingEndpointTuple
+      ProfileTupleIntegration.fullEndpointTuple
+      (TupleProtectedComponent.repairFrontier LocusAtom.database) := by
+  intro hsame
+  have hrepairFull :
+      ProfileTupleIntegration.fullEndpointTuple.repairFrontier
+        LocusAtom.database :=
+    hsame.mp
+      ProfileTupleIntegration.traceMissingEndpoint_forces_database_repair
+  exact ProfileTupleIntegration.fullEndpoint_no_database_repair hrepairFull
+
+/-- The reverse endpoint trace-field defect also holds. -/
+theorem endpointTuple_databaseTraceFieldReverseComponentDefect :
+    TupleHolonomyDefect
+      ProfileTupleIntegration.traceMissingEndpointTuple
+      ProfileTupleIntegration.fullEndpointTuple
+      (TupleProtectedComponent.traceField LocusAtom.database) := by
+  intro hsame
+  cases hsame
+
+/--
+Tuple component defects may cancel along a full/partial/full chain, so
+unrestricted "defect plus defect implies endpoint defect" is false.
+-/
+theorem tupleComponentDefects_can_cancel :
+    TupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        TupleProtectedComponent.obligation ∧
+      TupleHolonomyDefect
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        ProfileTupleIntegration.fullEndpointTuple
+        TupleProtectedComponent.obligation ∧
+      TupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        (TupleProtectedComponent.repairFrontier LocusAtom.database) ∧
+      TupleHolonomyDefect
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        ProfileTupleIntegration.fullEndpointTuple
+        (TupleProtectedComponent.repairFrontier LocusAtom.database) ∧
+      TupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        (TupleProtectedComponent.traceField LocusAtom.database) ∧
+      TupleHolonomyDefect
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        ProfileTupleIntegration.fullEndpointTuple
+        (TupleProtectedComponent.traceField LocusAtom.database) ∧
+      NoTupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.fullEndpointTuple :=
+  ⟨endpointTuple_obligationComponentDefect,
+    endpointTuple_obligationReverseComponentDefect,
+    endpointTuple_databaseRepairComponentDefect,
+    endpointTuple_databaseRepairReverseComponentDefect,
+    endpointTuple_databaseTraceFieldComponentDefect,
+    endpointTuple_databaseTraceFieldReverseComponentDefect,
+    noTupleHolonomyDefect_refl
+      ProfileTupleIntegration.fullEndpointTuple⟩
+
+/-- The reverse packet obligation defect also holds. -/
+theorem full_partial_packet_obligationReverseComponentDefect :
+    SourceRefPacketHolonomyDefect partialPacket fullPacket
+      SourceRefPacketProtectedComponent.obligation := by
+  intro hsame
+  cases hsame
+
+/-- The reverse packet repair-frontier defect also holds. -/
+theorem full_partial_packet_storageRepairReverseComponentDefect :
+    SourceRefPacketHolonomyDefect partialPacket fullPacket
+      (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) := by
+  intro hsame
+  have hrepairFull : fullPacket.repairFrontier CodeAtom.storage :=
+    hsame.mp partialTrace_forces_storage_repair
+  exact fullTrace_repair_frontier_excludes_storage hrepairFull
+
+/-- The reverse packet source-ref-table defect also holds. -/
+theorem full_partial_packet_storageSourceRefReverseComponentDefect :
+    SourceRefPacketHolonomyDefect partialPacket fullPacket
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) := by
+  intro hsame
+  cases hsame
+
+/--
+Packet component defects may also cancel along a full/partial/full chain.
+-/
+theorem packetComponentDefects_can_cancel :
+    SourceRefPacketHolonomyDefect fullPacket partialPacket
+        SourceRefPacketProtectedComponent.obligation ∧
+      SourceRefPacketHolonomyDefect partialPacket fullPacket
+        SourceRefPacketProtectedComponent.obligation ∧
+      SourceRefPacketHolonomyDefect fullPacket partialPacket
+        (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) ∧
+      SourceRefPacketHolonomyDefect partialPacket fullPacket
+        (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) ∧
+      SourceRefPacketHolonomyDefect fullPacket partialPacket
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) ∧
+      SourceRefPacketHolonomyDefect partialPacket fullPacket
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) ∧
+      NoSourceRefPacketHolonomyDefect fullPacket fullPacket :=
+  ⟨full_partial_packet_obligationComponentDefect,
+    full_partial_packet_obligationReverseComponentDefect,
+    full_partial_packet_storageRepairComponentDefect,
+    full_partial_packet_storageRepairReverseComponentDefect,
+    full_partial_packet_storageSourceRefComponentDefect,
+    full_partial_packet_storageSourceRefReverseComponentDefect,
+    noSourceRefPacketHolonomyDefect_refl fullPacket⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-26 theorem package: zero tuple/packet holonomy legs compose and propagate
+component defects, packet propagation is compatible with the packet-to-tuple
+projection, and concrete full/partial/full witnesses show that unrestricted
+defect composition can cancel at the endpoint.
+-/
+theorem componentHolonomyDefectPropagation_package :
+    (∀ {p : TupleProfile} (c : TupleCertificateAt p),
+      NoTupleHolonomyDefect c c) ∧
+      (∀ {p : TupleProfile}
+        {left middle right : TupleCertificateAt p},
+        NoTupleHolonomyDefect left middle ->
+        NoTupleHolonomyDefect middle right ->
+        NoTupleHolonomyDefect left right) ∧
+      (∀ {p : TupleProfile}
+        {left middle right : TupleCertificateAt p}
+        (_hzero : NoTupleHolonomyDefect left middle)
+        (component : TupleProtectedComponent),
+        TupleHolonomyDefect middle right component ↔
+          TupleHolonomyDefect left right component) ∧
+      (∀ {p : TupleProfile}
+        {left middle right : TupleCertificateAt p}
+        (_hzero : NoTupleHolonomyDefect middle right)
+        (component : TupleProtectedComponent),
+        TupleHolonomyDefect left middle component ↔
+          TupleHolonomyDefect left right component) ∧
+      (∀ packet : SourceRefPacket,
+        NoSourceRefPacketHolonomyDefect packet packet) ∧
+      (∀ {left middle right : SourceRefPacket},
+        NoSourceRefPacketHolonomyDefect left middle ->
+        NoSourceRefPacketHolonomyDefect middle right ->
+        NoSourceRefPacketHolonomyDefect left right) ∧
+      (∀ {left middle right : SourceRefPacket}
+        (_hzero : NoSourceRefPacketHolonomyDefect left middle)
+        (component : SourceRefPacketProtectedComponent),
+        SourceRefPacketHolonomyDefect middle right component ↔
+          SourceRefPacketHolonomyDefect left right component) ∧
+      (∀ {left middle right : SourceRefPacket}
+        (_hzero : NoSourceRefPacketHolonomyDefect middle right)
+        (component : SourceRefPacketProtectedComponent),
+        SourceRefPacketHolonomyDefect left middle component ↔
+          SourceRefPacketHolonomyDefect left right component) ∧
+      (∀ {p : TupleProfile}
+        (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+        {left middle right : SourceRefPacket}
+        {component : SourceRefPacketProtectedComponent},
+        NoSourceRefPacketHolonomyDefect left middle ->
+        SourceRefPacketHolonomyDefect middle right component ->
+        TupleHolonomyDefect
+          (SourceRefTupleBridge.packetToTuple gridLeft left)
+          (SourceRefTupleBridge.packetToTuple gridRight right)
+          (packetComponentToTupleComponent component)) ∧
+      TupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        TupleProtectedComponent.obligation ∧
+      TupleHolonomyDefect
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        ProfileTupleIntegration.fullEndpointTuple
+        TupleProtectedComponent.obligation ∧
+      NoTupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.fullEndpointTuple ∧
+      SourceRefPacketHolonomyDefect fullPacket partialPacket
+        SourceRefPacketProtectedComponent.obligation ∧
+      SourceRefPacketHolonomyDefect partialPacket fullPacket
+        SourceRefPacketProtectedComponent.obligation ∧
+      NoSourceRefPacketHolonomyDefect fullPacket fullPacket := by
+  exact ⟨by
+      intro p c
+      exact noTupleHolonomyDefect_refl c,
+    by
+      intro p left middle right hleft hright
+      exact noTupleHolonomyDefect_trans hleft hright,
+    by
+      intro p left middle right hzero component
+      exact tupleComponentDefect_propagates_left_of_zero hzero component,
+    by
+      intro p left middle right hzero component
+      exact tupleComponentDefect_propagates_right_of_zero hzero component,
+    noSourceRefPacketHolonomyDefect_refl,
+    by
+      intro left middle right hleft hright
+      exact noSourceRefPacketHolonomyDefect_trans hleft hright,
+    by
+      intro left middle right hzero component
+      exact packetComponentDefect_propagates_left_of_zero hzero component,
+    by
+      intro left middle right hzero component
+      exact packetComponentDefect_propagates_right_of_zero hzero component,
+    by
+      intro p gridLeft gridRight left middle right component hzero hdefect
+      exact packetComponentDefect_projects_after_left_zero
+        gridLeft gridRight hzero hdefect,
+    endpointTuple_obligationComponentDefect,
+    endpointTuple_obligationReverseComponentDefect,
+    noTupleHolonomyDefect_refl
+      ProfileTupleIntegration.fullEndpointTuple,
+    full_partial_packet_obligationComponentDefect,
+    full_partial_packet_obligationReverseComponentDefect,
+    noSourceRefPacketHolonomyDefect_refl fullPacket⟩
+
+end ComponentHolonomyDefectPropagation
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-component-holonomy-defect-propagation.md
+++ b/research/ideas/g-aat-quality-surface-01-component-holonomy-defect-propagation.md
@@ -1,0 +1,128 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: obstruction / invariance / certificate-transport / profile-curvature / traceability
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle26
+tags: [quality-surface, holonomy, component-defect, propagation, cancellation]
+created: 2026-06-20
+cycle: 26
+lean: Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean
+---
+
+# Component holonomy defect propagation and cancellation law
+
+## 主張
+
+Tuple-level と source-ref packet-level の component holonomy defect について、zero-holonomy leg に沿う
+propagation / cancellation law を finite triple diagram で証明する。`NoTupleHolonomyDefect a b` があれば、
+`b` と `c` の同じ component defect は `a` と `c` の component defect と同値である。同様に、
+right zero leg に沿っても defect は保存・反映される。packet-level component defect についても同じ calculus を持つ。
+
+さらに、naive な「defect + defect は endpoint defect」という合成則は成立しない。`full / partial / full`
+の finite witness では、前半と後半に同じ component defect があっても endpoint は zero defect へ戻る。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- Cycle 22: `Formal/AG/Research/QualitySurface/TupleHolonomyDefect.lean`
+- Cycle 23: `Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean`
+- Cycle 24: `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
+- Cycle 25: `Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean`
+
+## 非自明性
+
+単なる equality transitivity の名前替えにしないため、component-indexed defect の propagation theorem と、
+defect cancellation witness を同時に固定する。これにより hidden holonomy defect は一点の witness ではなく、
+zero leg に沿って移送できるが、非 zero leg 同士を無条件に合成できないことも同時に分かる。
+
+## 数学的興味
+
+hidden holonomy を component-indexed obstruction calculus として扱う入口になる。zero-holonomy leg は
+exact region の morphism として defect を保存・反映し、nonzero defect leg は cancellation しうるため
+naive な加法的 defect 合成は失敗する。
+
+## GOAL への前進
+
+Cycle 22/23 の component defect を static witness から reusable finite calculus へ進め、genuine commutator や
+selected decomposition localization の基礎部品を与える。
+
+## SCORE 見込み
+
+- `score_reason`: component defect propagation と cancellation boundary を Lean-proved calculus として固定できれば base 70。新しい finite invariant calculus だが、global commutator theorem ではないため 80 以上には置かない。
+- `dullness_risk`: medium。zero-defect transitivity だけなら dull。component-indexed propagation、packet analog、packet-to-tuple projection、cancellation witness を必須にする。
+- `proof_or_evidence_plan`: 新規 Research Lean file で tuple / packet の zero-defect reflexivity・transitivity、left/right zero leg propagation、packet defect projection after propagation、tuple/packet cancellation witnesses、package theorem を証明する。
+
+## CS / SWE への帰結
+
+loss-aware quality surface では、hidden defect を drill-down component として追跡できるが、二つの defect event を
+単純に endpoint defect へ合成してはならない。中間状態を含む trace が必要である。
+
+## 証明・根拠
+
+Lean では `TupleHolonomyDefectInvariant.NoTupleHolonomyDefect` と
+`CodebaseTraceHolonomyPacket.NoSourceRefPacketHolonomyDefect` を使う。obligation は equality、
+repair frontier は pointwise iff、trace/source-ref table は pointwise equality として、zero leg に沿う
+component defect iff を component ごとに証明した。
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean`
+
+Declarations:
+
+- `noTupleHolonomyDefect_refl`
+- `noTupleHolonomyDefect_trans`
+- `tupleComponentDefect_propagates_left_of_zero`
+- `tupleComponentDefect_propagates_right_of_zero`
+- `noSourceRefPacketHolonomyDefect_refl`
+- `noSourceRefPacketHolonomyDefect_trans`
+- `packetComponentDefect_propagates_left_of_zero`
+- `packetComponentDefect_propagates_right_of_zero`
+- `packetComponentDefect_projects_after_left_zero`
+- `tupleComponentDefects_can_cancel`
+- `packetComponentDefects_can_cancel`
+- `componentHolonomyDefectPropagation_package`
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/component_defect_propagation_axioms.lean`: pass; all reported declarations depend on no axioms
+- independent axiom audit: pass; no `sorryAx`, nonstandard axioms, `propext`, `Classical.choice`, or `Quot.sound`
+- independent formalization-quality audit: pass; statements include tuple/packet zero-defect calculus, component-indexed propagation, packet-to-tuple projection after propagation, and concrete cancellation witnesses rather than mere transitivity wrappers
+
+visible_projection: visible tuple surface / visible packet support surface。
+
+protected_structure: tuple obligation / repairFrontier / traceField、packet obligation / repairFrontier / sourceRefTable。
+
+exactness_or_minimality_claim: zero-holonomy leg は selected component defect の presence/absence を正確に保存・反映する。
+
+nonfaithfulness_or_failure_mode: visible-flat triple でも protected component defect は zero leg に沿って移送される。一方で二つの defect leg は endpoint で cancel しうるため、unrestricted defect composition は失敗する。
+
+previous_cycle_delta: Cycle 22/23 の component defect を static witness から finite calculus へ進め、Cycle 25 後に残った component defect composition law frontier を閉じる。
+
+## 審判メモ
+
+- 厳密性: `accept`; propagation 自体は equality / iff transport に近いため base 60 寄りだが、packet analog、projection compatibility、concrete cancellation witness まで含めるなら G3 へ進めてよい。
+- 研究価値: `accept`; base 70。static defect を reusable finite calculus へ持ち上げ、zero leg propagation と cancellation boundary を同時に固定する点に価値あり。
+- repo 全体価値: `accept`; base 70。component defect composition law frontier を直接閉じ、future Lean / paper seed として価値あり。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-tuple-holonomy-defect-invariant.md`
+- `research/ideas/g-aat-quality-surface-01-finite-codebase-trace-holonomy-packet.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-exact-visualization.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-repair-holonomy-annihilation.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 26 G1 で作成。
+- 2026-06-20: G4 SCORE audit confirmed base 70 / multiplier 2.0 / penalty 0 / final 140.

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 3040
+- total SCORE: 3180
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -31,8 +31,9 @@
   - traceability / profile-curvature / certificate-transport / computability / repair-potential: 120
   - traceability / certificate-transport / invariance / computability / quality-surface: 120
   - traceability / repair-potential / certificate-transport / obstruction / invariance: 120
+  - obstruction / invariance / certificate-transport / profile-curvature / traceability: 140
 - evidence portfolio:
-  - proved-in-research: 25
+  - proved-in-research: 26
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1107,8 +1108,48 @@ supplied finite packet family、declared exact fill repair action、explicit pac
 tuple に相対化され、任意 repair reachability、source extraction completeness、ArchMap correctness、canonical
 extractor、global transport law、実コード全体の品質判定は結論しない。
 
+## Cycle 26: Component holonomy defect propagation and cancellation law
+
+```text
+candidate: Component holonomy defect propagation and cancellation law
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: obstruction/invariance/certificate-transport/profile-curvature/traceability
+goal_delta: tuple / packet component holonomy defect を static witness から finite propagation calculus へ持ち上げ、zero-holonomy leg に沿う defect の保存・反映と、nonzero defect leg の cancellation boundary を固定した。
+project_value_delta: Cycle 22/23 の component defect と packet-to-tuple projection を、future commutator / selected decomposition localization の基礎 calculus として再利用できる形にした。
+formalization_quality: pass。tuple/packet zero-defect refl/trans、left/right zero-leg propagation、packet-to-tuple projection after propagation、tuple/packet full/partial/full cancellation witnesses が axiom-free / sorry-free で証明されている。
+open_questions: genuine finite repair/transport commutator、selected decomposition を越える grid/path localization calculus、fold-locus 解析。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean` は、
+Cycle 22/23 の component-indexed tuple / packet holonomy defects を finite calculus として扱う。
+zero-holonomy leg は protected data agreement であり、その leg に沿って component defect は保存・反映される。
+一方で、nonzero defect leg 同士は endpoint で cancel しうるため、unrestricted な defect composition は成立しない。
+
+Lean 証拠は次を固定する。
+
+- `noTupleHolonomyDefect_refl` / `noTupleHolonomyDefect_trans`: tuple zero holonomy は reflexive / transitive。
+- `tupleComponentDefect_propagates_left_of_zero` / `tupleComponentDefect_propagates_right_of_zero`: tuple component defect は left/right zero leg に沿って保存・反映される。
+- `noSourceRefPacketHolonomyDefect_refl` / `noSourceRefPacketHolonomyDefect_trans`: packet zero holonomy は reflexive / transitive。
+- `packetComponentDefect_propagates_left_of_zero` / `packetComponentDefect_propagates_right_of_zero`: packet component defect も left/right zero leg に沿って保存・反映される。
+- `packetComponentDefect_projects_after_left_zero`: zero leg で propagates した packet defect は packet-to-tuple bridge で tuple defect へ写る。
+- `tupleComponentDefects_can_cancel`: full / partial / full endpoint tuple chain では、obligation、database repair frontier、database trace field の各 defect が往復で存在しても endpoint は zero defect に戻る。
+- `packetComponentDefects_can_cancel`: full / partial / full source-ref packet chain でも、obligation、storage repair frontier、storage source-ref table の各 defect が往復で存在しても endpoint は zero defect に戻る。
+- `componentHolonomyDefectPropagation_package`: zero tuple/packet calculus、component propagation、packet-to-tuple projection after propagation、代表的 cancellation witness を束ねる theorem package。
+
+この結果により、hidden holonomy defect は zero leg に沿って追跡できる finite invariant になるが、nonzero defect を
+無条件に足し合わせる global defect algebra ではないことが明確になる。主張は supplied finite tuple certificates、
+source-ref packets、explicit packet-to-tuple bridge に相対化され、global additive defect group、canonical extraction、
+source extraction completeness、ArchMap correctness、任意 codebase traceability、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 25 後の total SCORE は 3040 である。
-次に進める場合は、genuine finite repair/transport commutator、component defect の合成則、
-または selected decomposition を越える grid localization calculus を狙う。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 26 後の total SCORE は 3180 である。
+次に進める場合は、genuine finite repair/transport commutator、
+selected decomposition を越える grid/path localization calculus、または source-ref exact fold-locus 解析を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 Cycle 26 として、tuple / packet component holonomy defect を zero-holonomy leg に沿って保存・反映する finite propagation calculus と、full / partial / full chain で defect が endpoint で cancel しうる有限 witness を Research sandbox に追加しました。

tracking Issue は research-loop の状態正本なので、この PR では close しません。

## 証明した定理

- `ComponentHolonomyDefectPropagation.noTupleHolonomyDefect_refl`
- `ComponentHolonomyDefectPropagation.noTupleHolonomyDefect_trans`
- `ComponentHolonomyDefectPropagation.tupleComponentDefect_propagates_left_of_zero`
- `ComponentHolonomyDefectPropagation.tupleComponentDefect_propagates_right_of_zero`
- `ComponentHolonomyDefectPropagation.noSourceRefPacketHolonomyDefect_refl`
- `ComponentHolonomyDefectPropagation.noSourceRefPacketHolonomyDefect_trans`
- `ComponentHolonomyDefectPropagation.packetComponentDefect_propagates_left_of_zero`
- `ComponentHolonomyDefectPropagation.packetComponentDefect_propagates_right_of_zero`
- `ComponentHolonomyDefectPropagation.packetComponentDefect_projects_after_left_zero`
- `ComponentHolonomyDefectPropagation.tupleComponentDefects_can_cancel`
- `ComponentHolonomyDefectPropagation.packetComponentDefects_can_cancel`
- `ComponentHolonomyDefectPropagation.componentHolonomyDefectPropagation_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-component-holonomy-defect-propagation.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/component_defect_propagation_axioms.lean`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning 2件のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue は tracking Issue のため `Closes #N` ではなく `Refs #2348` とした
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
