### PR TITLE
Cycle 27 source-ref exact fold locusを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -25,3 +25,4 @@ import Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket
 import Formal.AG.Research.QualitySurface.SourceRefExactVisualization
 import Formal.AG.Research.QualitySurface.SourceRefRepairHolonomy
 import Formal.AG.Research.QualitySurface.ComponentDefectPropagation
+import Formal.AG.Research.QualitySurface.SourceRefExactFoldLocus

--- a/Formal/AG/Research/QualitySurface/SourceRefExactFoldLocus.lean
+++ b/Formal/AG/Research/QualitySurface/SourceRefExactFoldLocus.lean
@@ -1,0 +1,291 @@
+import Formal.AG.Research.QualitySurface.SourceRefRepairHolonomy
+import Formal.AG.Research.QualitySurface.ComponentDefectPropagation
+
+/-!
+Cycle 27 evidence for `G-aat-quality-surface-01`.
+
+This file defines the source-ref exact fold locus for packet-induced tuple
+visualizations: visible tuple data agrees while source-ref exact visualization
+fails.  The locus is characterized by visible agreement plus packet holonomy
+defect, propagates along source-ref exact legs, and is exited by the supplied
+exact storage repair.  The claim is relative to supplied finite source-ref
+packets, explicit packet-to-tuple bridges, and the declared repair action; it
+does not assert a global fold theory, canonical extraction, source extraction
+completeness, ArchMap correctness, arbitrary codebase traceability, or
+whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SourceRefExactFoldLocusTheory
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+open SourceRefRepairHolonomyAnnihilation
+open ComponentHolonomyDefectPropagation
+
+abbrev TupleProfile :=
+  SourceRefExactVisualizationCriterion.TupleProfile
+
+/-! ## Fold-locus definition and visible composition -/
+
+/--
+The source-ref exact fold locus: the packet-induced tuple visible surface
+agrees, but source-ref exact visualization fails.
+-/
+def SourceRefExactFoldLocus {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    (left right : SourceRefPacket) : Prop :=
+  TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+    ¬ SourceRefExactVisualization gridLeft gridRight left right
+
+/-- Visible packet-induced tuple equivalence is symmetric. -/
+theorem tupleVisibleVisualizationEquivalent_symm {p : TupleProfile}
+    {gridLeft gridRight : ProfileGridHolonomy.CertificateAt p}
+    {left right : SourceRefPacket}
+    (hvisible :
+      TupleVisibleVisualizationEquivalent gridLeft gridRight left right) :
+    TupleVisibleVisualizationEquivalent gridRight gridLeft right left := by
+  exact ⟨hvisible.1.symm, hvisible.2.1.symm, by
+    intro atom
+    exact Iff.symm (hvisible.2.2 atom)⟩
+
+/-- Visible packet-induced tuple equivalence composes along a finite chain. -/
+theorem tupleVisibleVisualizationEquivalent_trans {p : TupleProfile}
+    {gridLeft gridMiddle gridRight : ProfileGridHolonomy.CertificateAt p}
+    {left middle right : SourceRefPacket}
+    (hleft :
+      TupleVisibleVisualizationEquivalent gridLeft gridMiddle left middle)
+    (hright :
+      TupleVisibleVisualizationEquivalent gridMiddle gridRight middle right) :
+    TupleVisibleVisualizationEquivalent gridLeft gridRight left right := by
+  exact ⟨Eq.trans hleft.1 hright.1,
+    Eq.trans hleft.2.1 hright.2.1,
+    by
+      intro atom
+      exact Iff.trans (hleft.2.2 atom) (hright.2.2 atom)⟩
+
+/-- Source-ref exact visualization gives packet-level zero holonomy. -/
+theorem packetZero_of_sourceRefExactVisualization {p : TupleProfile}
+    {gridLeft gridRight : ProfileGridHolonomy.CertificateAt p}
+    {left right : SourceRefPacket}
+    (hexact : SourceRefExactVisualization gridLeft gridRight left right) :
+    NoSourceRefPacketHolonomyDefect left right :=
+  tupleZeroHolonomy_reflects_packetZeroHolonomy
+    gridLeft gridRight hexact.2
+
+/-- Packet-level zero holonomy is symmetric. -/
+theorem noSourceRefPacketHolonomyDefect_symm
+    {left right : SourceRefPacket}
+    (hzero : NoSourceRefPacketHolonomyDefect left right) :
+    NoSourceRefPacketHolonomyDefect right left :=
+  ⟨hzero.1.symm,
+    by
+      intro atom
+      exact Iff.symm (hzero.2.1 atom),
+    by
+      intro atom
+      exact (hzero.2.2 atom).symm⟩
+
+/-! ## Characterization and witnesses -/
+
+/--
+Inside a visible packet-induced tuple fiber, source-ref exact fold membership
+is exactly packet-level protected holonomy.
+-/
+theorem sourceRefExactFold_iff_visible_packetDefect {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    (left right : SourceRefPacket) :
+    SourceRefExactFoldLocus gridLeft gridRight left right ↔
+      TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+        HasSourceRefPacketHolonomyDefect left right := by
+  constructor
+  · intro hfold
+    refine ⟨hfold.1, ?_⟩
+    intro hzero
+    exact hfold.2
+      ((sourceRefExactVisualization_iff_visible_packetZeroHolonomy
+        gridLeft gridRight left right).mpr ⟨hfold.1, hzero⟩)
+  · intro hvisibleDefect
+    exact ⟨hvisibleDefect.1, by
+      intro hexact
+      exact hvisibleDefect.2
+        (packetZero_of_sourceRefExactVisualization hexact)⟩
+
+/-- The full/partial packet pair lies in the source-ref exact fold locus. -/
+theorem full_partial_sourceRefExactFoldLocus :
+    SourceRefExactFoldLocus
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket partialPacket :=
+  ⟨full_partial_packetTuple_lossyVisualization.1,
+    full_partial_packetTuple_not_sourceRefExact⟩
+
+/-! ## Propagation along source-ref exact legs -/
+
+/-- Fold-locus membership propagates across a source-ref exact leg on the left. -/
+theorem sourceRefExactFoldLocus_propagates_left_of_exact {p : TupleProfile}
+    {gridLeft gridMiddle gridRight : ProfileGridHolonomy.CertificateAt p}
+    {left middle right : SourceRefPacket}
+    (hexact : SourceRefExactVisualization gridLeft gridMiddle left middle)
+    (hfold : SourceRefExactFoldLocus gridMiddle gridRight middle right) :
+    SourceRefExactFoldLocus gridLeft gridRight left right := by
+  refine ⟨tupleVisibleVisualizationEquivalent_trans hexact.1 hfold.1, ?_⟩
+  intro hexactEndpoint
+  have hzeroLeftMiddle :
+      NoSourceRefPacketHolonomyDefect left middle :=
+    packetZero_of_sourceRefExactVisualization hexact
+  have hzeroLeftRight :
+      NoSourceRefPacketHolonomyDefect left right :=
+    packetZero_of_sourceRefExactVisualization hexactEndpoint
+  have hzeroMiddleRight :
+      NoSourceRefPacketHolonomyDefect middle right :=
+    noSourceRefPacketHolonomyDefect_trans
+      (noSourceRefPacketHolonomyDefect_symm hzeroLeftMiddle)
+      hzeroLeftRight
+  have hvisibleMiddleRight :
+      TupleVisibleVisualizationEquivalent gridMiddle gridRight middle right :=
+    tupleVisibleVisualizationEquivalent_trans
+      (tupleVisibleVisualizationEquivalent_symm hexact.1)
+      hexactEndpoint.1
+  exact hfold.2
+    ⟨hvisibleMiddleRight,
+      noPacketHolonomy_projects_to_noTupleHolonomy
+        gridMiddle gridRight hzeroMiddleRight⟩
+
+/-- Fold-locus membership propagates across a source-ref exact leg on the right. -/
+theorem sourceRefExactFoldLocus_propagates_right_of_exact {p : TupleProfile}
+    {gridLeft gridMiddle gridRight : ProfileGridHolonomy.CertificateAt p}
+    {left middle right : SourceRefPacket}
+    (hfold : SourceRefExactFoldLocus gridLeft gridMiddle left middle)
+    (hexact : SourceRefExactVisualization gridMiddle gridRight middle right) :
+    SourceRefExactFoldLocus gridLeft gridRight left right := by
+  refine ⟨tupleVisibleVisualizationEquivalent_trans hfold.1 hexact.1, ?_⟩
+  intro hexactEndpoint
+  have hzeroMiddleRight :
+      NoSourceRefPacketHolonomyDefect middle right :=
+    packetZero_of_sourceRefExactVisualization hexact
+  have hzeroLeftRight :
+      NoSourceRefPacketHolonomyDefect left right :=
+    packetZero_of_sourceRefExactVisualization hexactEndpoint
+  have hzeroLeftMiddle :
+      NoSourceRefPacketHolonomyDefect left middle :=
+    noSourceRefPacketHolonomyDefect_trans
+      hzeroLeftRight
+      (noSourceRefPacketHolonomyDefect_symm hzeroMiddleRight)
+  have hvisibleLeftMiddle :
+      TupleVisibleVisualizationEquivalent gridLeft gridMiddle left middle :=
+    tupleVisibleVisualizationEquivalent_trans
+      hexactEndpoint.1
+      (tupleVisibleVisualizationEquivalent_symm hexact.1)
+  exact hfold.2
+    ⟨hvisibleLeftMiddle,
+      noPacketHolonomy_projects_to_noTupleHolonomy
+        gridLeft gridMiddle hzeroLeftMiddle⟩
+
+/-! ## Component obstruction and repair exit -/
+
+/-- A packet component defect inside a visible fiber creates a fold-locus point. -/
+theorem packetComponentDefect_obstructs_sourceRefExactFold {p : TupleProfile}
+    {gridLeft gridRight : ProfileGridHolonomy.CertificateAt p}
+    {left right : SourceRefPacket}
+    {component : SourceRefPacketProtectedComponent}
+    (hvisible :
+      TupleVisibleVisualizationEquivalent gridLeft gridRight left right)
+    (hdefect : SourceRefPacketHolonomyDefect left right component) :
+    SourceRefExactFoldLocus gridLeft gridRight left right :=
+  ⟨hvisible,
+    packetHolonomyDefect_obstructs_sourceRefExactVisualization hdefect⟩
+
+/-- The propagated packet component defect gives a tuple-level fold obstruction. -/
+theorem propagatedPacketDefect_obstructs_sourceRefExactFold
+    {p : TupleProfile}
+    {gridLeft gridMiddle gridRight : ProfileGridHolonomy.CertificateAt p}
+    {left middle right : SourceRefPacket}
+    {component : SourceRefPacketProtectedComponent}
+    (hexact : SourceRefExactVisualization gridLeft gridMiddle left middle)
+    (hvisible :
+      TupleVisibleVisualizationEquivalent gridLeft gridRight left right)
+    (hdefect : SourceRefPacketHolonomyDefect middle right component) :
+    SourceRefExactFoldLocus gridLeft gridRight left right := by
+  have hzero :
+      NoSourceRefPacketHolonomyDefect left middle :=
+    packetZero_of_sourceRefExactVisualization hexact
+  exact packetComponentDefect_obstructs_sourceRefExactFold hvisible
+    ((packetComponentDefect_propagates_left_of_zero
+      hzero component).mp hdefect)
+
+/-- The supplied exact storage repair exits the full/partial fold locus. -/
+theorem storageRepairPacket_exits_sourceRefExactFoldLocus :
+    ¬ SourceRefExactFoldLocus
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket
+      CodebaseTraceRepairTrajectory.storageRepairPacket := by
+  intro hfold
+  exact hfold.2 storageRepairPacket_sourceRefExactVisualization
+
+/-! ## Theorem package -/
+
+/--
+Cycle-27 theorem package: source-ref exact fold-locus membership is visible
+equivalence plus packet holonomy defect; it has the full/partial witness,
+propagates along source-ref exact legs, is generated by component defects, and
+is exited by the supplied exact storage repair.
+-/
+theorem sourceRefExactFoldLocus_package :
+    (∀ {p : TupleProfile}
+      (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+      (left right : SourceRefPacket),
+      SourceRefExactFoldLocus gridLeft gridRight left right ↔
+        TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+          HasSourceRefPacketHolonomyDefect left right) ∧
+      SourceRefExactFoldLocus
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket partialPacket ∧
+      (∀ {p : TupleProfile}
+        {gridLeft gridMiddle gridRight : ProfileGridHolonomy.CertificateAt p}
+        {left middle right : SourceRefPacket},
+        SourceRefExactVisualization gridLeft gridMiddle left middle ->
+        SourceRefExactFoldLocus gridMiddle gridRight middle right ->
+        SourceRefExactFoldLocus gridLeft gridRight left right) ∧
+      (∀ {p : TupleProfile}
+        {gridLeft gridMiddle gridRight : ProfileGridHolonomy.CertificateAt p}
+        {left middle right : SourceRefPacket},
+        SourceRefExactFoldLocus gridLeft gridMiddle left middle ->
+        SourceRefExactVisualization gridMiddle gridRight middle right ->
+        SourceRefExactFoldLocus gridLeft gridRight left right) ∧
+      (∀ {p : TupleProfile}
+        {gridLeft gridRight : ProfileGridHolonomy.CertificateAt p}
+        {left right : SourceRefPacket}
+        {component : SourceRefPacketProtectedComponent},
+        TupleVisibleVisualizationEquivalent gridLeft gridRight left right ->
+        SourceRefPacketHolonomyDefect left right component ->
+        SourceRefExactFoldLocus gridLeft gridRight left right) ∧
+      ¬ SourceRefExactFoldLocus
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket
+        CodebaseTraceRepairTrajectory.storageRepairPacket := by
+  exact ⟨by
+      intro p gridLeft gridRight left right
+      exact sourceRefExactFold_iff_visible_packetDefect
+        gridLeft gridRight left right,
+    full_partial_sourceRefExactFoldLocus,
+    by
+      intro p gridLeft gridMiddle gridRight left middle right hexact hfold
+      exact sourceRefExactFoldLocus_propagates_left_of_exact hexact hfold,
+    by
+      intro p gridLeft gridMiddle gridRight left middle right hfold hexact
+      exact sourceRefExactFoldLocus_propagates_right_of_exact hfold hexact,
+    by
+      intro p gridLeft gridRight left right component hvisible hdefect
+      exact packetComponentDefect_obstructs_sourceRefExactFold
+        hvisible hdefect,
+    storageRepairPacket_exits_sourceRefExactFoldLocus⟩
+
+end SourceRefExactFoldLocusTheory
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-source-ref-exact-fold-locus.md
+++ b/research/ideas/g-aat-quality-surface-01-source-ref-exact-fold-locus.md
@@ -1,0 +1,119 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: traceability / obstruction / invariance / certificate-transport / quality-surface
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle27
+tags: [quality-surface, source-ref, exact-visualization, fold-locus, repair]
+created: 2026-06-20
+cycle: 27
+lean: Formal/AG/Research/QualitySurface/SourceRefExactFoldLocus.lean
+---
+
+# Source-ref exact fold-locus propagation and repair exit
+
+## 主張
+
+Packet-induced tuple pair に対して、visible tuple visualization は一致するが source-ref exact visualization は
+失敗する locus を `SourceRefExactFoldLocus` として定義する。この fold locus は、visible equivalence と
+packet-level protected holonomy defect の組と同値である。fold locus の伝播は packet zero-holonomy 単独ではなく、
+visible-compatible な source-ref exact leg に沿って主張する。
+さらに、Cycle 25 の supplied exact storage repair は full/partial の fold locus から exit し、full/repaired
+pair は source-ref exact になる。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- Cycle 24: `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
+- Cycle 25: `Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean`
+- Cycle 26: `Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean`
+
+## 非自明性
+
+単なる `¬ SourceRefExactVisualization` の再掲ではなく、visible equality、packet holonomy defect、
+zero-leg propagation、component-defect obstruction、repair exit をひとつの fold-locus calculus としてまとめる。
+これにより lossy visualization は点例ではなく、finite relation として扱える。
+
+## 数学的興味
+
+source-ref exactness は、visible packet-to-tuple quotient が protected source-ref holonomy を失う fold を検出する。
+fold locus は visible surface と protected certificate geometry のずれを表し、repair action によって locus から
+出られることが finite theorem として読める。
+
+## GOAL への前進
+
+Cycle 24 の lossy/exact detector、Cycle 25 の repair exit、Cycle 26 の component propagation を接続し、
+visible layer と protected layer を混同せずに source-ref exact fold-locus frontier を閉じる。
+
+## SCORE 見込み
+
+- `score_reason`: definition + characterization + source-ref-exact leg propagation + component obstruction + repair exit が揃えば base 60。Cycle 24/25/26 に近い finite fold calculus なので 70 以上には置かない。
+- `dullness_risk`: medium。full/partial witness の再掲だけなら低価値。zero-leg propagation と repair exit を必須にする。
+- `proof_or_evidence_plan`: 新規 Research Lean file で `SourceRefExactFoldLocus` を定義し、Cycle 24 の exactness iff から `visible ∧ HasSourceRefPacketHolonomyDefect` との同値を証明する。left/right propagation は `SourceRefExactVisualization` leg に沿って visible と protected zero の両方を明示し、Cycle 25 の `storageRepairPacket_sourceRefExactVisualization` で repair exit を示す。
+
+## CS / SWE への帰結
+
+同じ visible tuple visualization に見える packet pair でも、source-ref exactness で fold locus にいるかどうかを
+分離できる。repair action が fold locus から出る場合、UI / report は visible surface だけではなく protected
+source-ref exactness を drill-down する必要がある。
+
+## 証明・根拠
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/SourceRefExactFoldLocus.lean`
+
+Declarations:
+
+- `SourceRefExactFoldLocus`
+- `sourceRefExactFold_iff_visible_packetDefect`
+- `full_partial_sourceRefExactFoldLocus`
+- `sourceRefExactFoldLocus_propagates_left_of_exact`
+- `sourceRefExactFoldLocus_propagates_right_of_exact`
+- `packetComponentDefect_obstructs_sourceRefExactFold`
+- `propagatedPacketDefect_obstructs_sourceRefExactFold`
+- `storageRepairPacket_exits_sourceRefExactFoldLocus`
+- `sourceRefExactFoldLocus_package`
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SourceRefExactFoldLocus.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/source_ref_exact_fold_locus_axioms.lean`: pass; all reported declarations depend on no axioms
+- independent axiom audit: pass; no `sorryAx`, nonstandard axioms, `propext`, `Classical.choice`, or `Quot.sound`
+- independent formalization-quality audit: pass; propagation uses source-ref exact legs and does not claim packet-zero-only visible propagation
+
+visible_projection: packet-induced visible tuple surface。
+
+protected_structure: packet obligation / repair frontier / source-ref table、packet holonomy defect、tuple protected data。
+
+exactness_or_minimality_claim: visible equivalence の下で fold locus は packet zero holonomy の失敗と同値。伝播には source-ref exact leg を仮定する。
+
+nonfaithfulness_or_failure_mode: visible tuple equality は source-ref exact classes を識別できない。exact repair action は visible support surface を保ったまま fold locus から出る。
+
+previous_cycle_delta: Cycle 26 の component propagation を exact visualization の fold-locus frontier へ適用する。
+
+## 審判メモ
+
+- 厳密性: initial `revise`; packet zero holonomy 単独では visible equivalence を運べないため、source-ref exact / visible-compatible leg に沿う propagation へ修正し、base 60 に下げることを要求。修正後 `accept`。
+- 研究価値: initial `accept` at base 70; 修正後は source-ref exact leg propagation として base 60 / final 120 で `accept`。
+- repo 全体価値: initial `revise`; visible layer と protected holonomy layer の分離を明示することを要求。修正後 base 60 / final 120 で `accept`。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-source-ref-exact-visualization.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-repair-holonomy-annihilation.md`
+- `research/ideas/g-aat-quality-surface-01-component-holonomy-defect-propagation.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 27 G1 で作成。
+- 2026-06-20: G3.5 sync audit pass。candidate card / Lean declarations / report entry は同期済み。
+- 2026-06-20: G4 SCORE audit confirm。base 60、evidence multiplier 2.0、penalty 0、final SCORE 120。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 3180
+- total SCORE: 3300
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -32,8 +32,9 @@
   - traceability / certificate-transport / invariance / computability / quality-surface: 120
   - traceability / repair-potential / certificate-transport / obstruction / invariance: 120
   - obstruction / invariance / certificate-transport / profile-curvature / traceability: 140
+  - traceability / obstruction / invariance / certificate-transport / quality-surface: 120
 - evidence portfolio:
-  - proved-in-research: 26
+  - proved-in-research: 27
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1148,8 +1149,48 @@ Lean 証拠は次を固定する。
 source-ref packets、explicit packet-to-tuple bridge に相対化され、global additive defect group、canonical extraction、
 source extraction completeness、ArchMap correctness、任意 codebase traceability、実コード全体の品質判定は結論しない。
 
+## Cycle 27: Source-ref exact fold-locus propagation and repair exit
+
+```text
+candidate: Source-ref exact fold-locus propagation and repair exit
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: traceability/obstruction/invariance/certificate-transport/quality-surface
+goal_delta: visible tuple visualization が一致しながら source-ref exact visualization が失敗する fold locus を定義し、visible + packet holonomy defect との同値、source-ref exact leg に沿う伝播、component obstruction、repair exit を固定した。
+project_value_delta: Cycle 24 の exact/lossy detector、Cycle 25 の repair exit、Cycle 26 の component propagation を loss-aware visualization の finite fold-locus calculus として統合した。
+formalization_quality: pass。propagation は source-ref exact leg を仮定して visible と protected zero の両方を使い、packet-zero-only visible propagation は主張していない。全 declaration は axiom-free / sorry-free。
+open_questions: genuine finite repair/transport commutator、selected decomposition を越える grid/path localization calculus。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SourceRefExactFoldLocus.lean` は、
+packet-induced tuple visible surface が一致する一方で source-ref exact visualization が失敗する関係を
+`SourceRefExactFoldLocus` として定義する。fold locus は visible equivalence と packet-level protected
+holonomy defect の組と同値である。
+
+Lean 証拠は次を固定する。
+
+- `SourceRefExactFoldLocus`: visible tuple agreement plus non-exact source-ref visualization。
+- `sourceRefExactFold_iff_visible_packetDefect`: fold membership は visible agreement と packet holonomy defect の組と同値。
+- `full_partial_sourceRefExactFoldLocus`: full / partial packet pair は concrete fold-locus witness。
+- `sourceRefExactFoldLocus_propagates_left_of_exact` / `sourceRefExactFoldLocus_propagates_right_of_exact`: fold membership は source-ref exact leg に沿って left/right に伝播する。
+- `packetComponentDefect_obstructs_sourceRefExactFold`: visible fiber 内の packet component defect は fold-locus point を作る。
+- `propagatedPacketDefect_obstructs_sourceRefExactFold`: exact leg で propagated した component defect も fold obstruction になる。
+- `storageRepairPacket_exits_sourceRefExactFoldLocus`: supplied exact storage repair 後の full/repaired pair は fold locus から出る。
+- `sourceRefExactFoldLocus_package`: characterization、full/partial witness、exact-leg propagation、component obstruction、repair exit を束ねる theorem package。
+
+この結果により、source-ref exactness failure は単なる non-exact pair ではなく、visible quotient が protected
+source-ref holonomy を落とす finite fold locus として扱える。主張は supplied finite source-ref packets、
+explicit packet-to-tuple bridge、declared repair action に相対化され、global fold theory、canonical extraction、
+source extraction completeness、ArchMap correctness、任意 codebase traceability、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 26 後の total SCORE は 3180 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 27 後の total SCORE は 3300 である。
 次に進める場合は、genuine finite repair/transport commutator、
-selected decomposition を越える grid/path localization calculus、または source-ref exact fold-locus 解析を狙う。
+または selected decomposition を越える grid/path localization calculus を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 27 として、visible tuple visualization は一致するが source-ref exact visualization は失敗する有限関係を `SourceRefExactFoldLocus` として追加しました。

この PR は、fold locus を visible agreement + packet-level protected holonomy defect と同値にし、source-ref exact leg に沿う left/right 伝播、component defect からの obstruction、supplied exact storage repair による fold locus exit を Research Lean で固定します。tracking Issue は研究ループの正本なので `Closes` ではなく `Refs` にしています。

## 証明した定理

- `SourceRefExactFoldLocusTheory.SourceRefExactFoldLocus`
- `SourceRefExactFoldLocusTheory.tupleVisibleVisualizationEquivalent_symm`
- `SourceRefExactFoldLocusTheory.tupleVisibleVisualizationEquivalent_trans`
- `SourceRefExactFoldLocusTheory.packetZero_of_sourceRefExactVisualization`
- `SourceRefExactFoldLocusTheory.noSourceRefPacketHolonomyDefect_symm`
- `SourceRefExactFoldLocusTheory.sourceRefExactFold_iff_visible_packetDefect`
- `SourceRefExactFoldLocusTheory.full_partial_sourceRefExactFoldLocus`
- `SourceRefExactFoldLocusTheory.sourceRefExactFoldLocus_propagates_left_of_exact`
- `SourceRefExactFoldLocusTheory.sourceRefExactFoldLocus_propagates_right_of_exact`
- `SourceRefExactFoldLocusTheory.packetComponentDefect_obstructs_sourceRefExactFold`
- `SourceRefExactFoldLocusTheory.propagatedPacketDefect_obstructs_sourceRefExactFold`
- `SourceRefExactFoldLocusTheory.storageRepairPacket_exits_sourceRefExactFoldLocus`
- `SourceRefExactFoldLocusTheory.sourceRefExactFoldLocus_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-source-ref-exact-fold-locus.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SourceRefExactFoldLocus.lean`
- [x] `lake env lean .tmp/source_ref_exact_fold_locus_axioms.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` lint warning のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local absolute path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を本文に記載した（research-loop tracking Issue のため `Refs #2348`）
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
