### PR TITLE
Cycle 30 lawful repair transport commutator criterionを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -28,3 +28,4 @@ import Formal.AG.Research.QualitySurface.ComponentDefectPropagation
 import Formal.AG.Research.QualitySurface.SourceRefExactFoldLocus
 import Formal.AG.Research.QualitySurface.VisibleRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.SourceRefTableLawObstruction
+import Formal.AG.Research.QualitySurface.LawfulRepairTransportCommutator

--- a/Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean
+++ b/Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean
@@ -1,0 +1,302 @@
+import Formal.AG.Research.QualitySurface.SourceRefPacketTransport
+import Formal.AG.Research.QualitySurface.CodebaseTraceRepairTrajectory
+import Formal.AG.Research.QualitySurface.SourceRefExactVisualization
+
+/-!
+Cycle 30 evidence for `G-aat-quality-surface-01`.
+
+This file gives a sufficient criterion for a lawful source-ref repair/transport
+commutator.  The criterion is stated using component laws: bidirectional packet
+transport laws, visible-surface preservation, obligation preservation, and
+repair-action naturality at the action-field level.  It does not assume route
+endpoint equality, packet zero holonomy, tuple zero holonomy, or source-ref exact
+visualization.  Those are conclusions.  The result is relative to supplied
+finite source-ref packets, declared repair actions, and explicit packet-to-tuple
+bridges; it does not assert global repair planning, canonical transport, source
+extraction completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace LawfulRepairTransportCommutator
+
+open CodebaseTracePacket
+open CodebaseTraceRepairTrajectory
+open CodebaseTraceHolonomyPacket
+open SourceRefPacketTransport
+open SourceRefExactVisualizationCriterion
+
+/-! ## Lawful repair/transport square data -/
+
+/-- Packet update preserves visible scalar and verdict. -/
+def PreservesSourceRefVisibleSurface (τ : PacketUpdate) : Prop :=
+  ∀ packet, SameVisibleSurface (τ.map packet) packet
+
+/-- Packet update preserves the source-ref obligation component. -/
+def PreservesSourceRefObligation (τ : PacketUpdate) : Prop :=
+  ∀ packet, (τ.map packet).obligation = packet.obligation
+
+/--
+Repair-action data are transported naturally at the action-field level.  This
+does not mention route endpoint equality or packet holonomy.
+-/
+structure RepairActionTransportNaturality
+    (action transportedAction : SourceRefRepairAction) : Prop where
+  support_iff :
+    ∀ atom, transportedAction.repairSupport atom ↔ action.repairSupport atom
+  table_eq :
+    ∀ atom, transportedAction.repairedSourceRefTable atom =
+      action.repairedSourceRefTable atom
+  obligation_eq :
+    transportedAction.repairedObligation = action.repairedObligation
+
+/-- Bundled sufficient laws for a lawful repair/transport square. -/
+structure LawfulRepairTransportSquare
+    (τ : PacketUpdate)
+    (action transportedAction : SourceRefRepairAction) : Prop where
+  transport_laws : BidirectionalSourceRefPacketTransport τ
+  visible_preserves : PreservesSourceRefVisibleSurface τ
+  obligation_preserves : PreservesSourceRefObligation τ
+  action_naturality :
+    RepairActionTransportNaturality action transportedAction
+
+/-! ## Route endpoints -/
+
+/-- Route endpoint for repair followed by transport. -/
+def repairThenTransportPacket
+    (τ : PacketUpdate) (action : SourceRefRepairAction)
+    (packet : SourceRefPacket) : SourceRefPacket :=
+  τ.map (repairPacket action packet)
+
+/-- Route endpoint for transport followed by repair. -/
+def transportThenRepairPacket
+    (τ : PacketUpdate) (transportedAction : SourceRefRepairAction)
+    (packet : SourceRefPacket) : SourceRefPacket :=
+  repairPacket transportedAction (τ.map packet)
+
+/-! ## Visible and protected commutation -/
+
+/-- Lawful repair/transport squares commute at the visible packet surface. -/
+theorem repairTransport_visiblePacketSurface_of_lawful
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (packet : SourceRefPacket) :
+    supportSurfaceReading.Equivalent
+      (repairThenTransportPacket τ action packet)
+      (transportThenRepairPacket τ transportedAction packet) := by
+  constructor
+  · constructor
+    · calc
+        (repairThenTransportPacket τ action packet).visibleScalarReading =
+            (repairPacket action packet).visibleScalarReading :=
+          (hlawful.visible_preserves
+            (repairPacket action packet)).1
+        _ = packet.visibleScalarReading := rfl
+        _ = (τ.map packet).visibleScalarReading :=
+          (hlawful.visible_preserves packet).1.symm
+        _ =
+            (transportThenRepairPacket τ transportedAction packet).visibleScalarReading :=
+          rfl
+    · calc
+        (repairThenTransportPacket τ action packet).verdict =
+            (repairPacket action packet).verdict :=
+          (hlawful.visible_preserves
+            (repairPacket action packet)).2
+        _ = packet.verdict := rfl
+        _ = (τ.map packet).verdict :=
+          (hlawful.visible_preserves packet).2.symm
+        _ =
+            (transportThenRepairPacket τ transportedAction packet).verdict :=
+          rfl
+  · intro atom
+    constructor
+    · intro hsupportLeft
+      have hsupportRepaired :
+          (repairPacket action packet).codeSupport atom :=
+        hlawful.transport_laws.reflectsSupport
+          (repairPacket action packet) atom hsupportLeft
+      have hsupportTarget :
+          (τ.map packet).codeSupport atom :=
+        hlawful.transport_laws.preservesSupport
+          packet atom hsupportRepaired
+      exact hsupportTarget
+    · intro hsupportRight
+      have hsupportSource :
+          packet.codeSupport atom :=
+        hlawful.transport_laws.reflectsSupport
+          packet atom hsupportRight
+      have hsupportRepaired :
+          (repairPacket action packet).codeSupport atom :=
+        hsupportSource
+      exact hlawful.transport_laws.preservesSupport
+        (repairPacket action packet) atom hsupportRepaired
+
+/--
+Lawful repair/transport squares have zero packet holonomy.  This is derived
+from component laws, not assumed.
+-/
+theorem repairTransport_noPacketHolonomy_of_lawful
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (packet : SourceRefPacket) :
+    NoSourceRefPacketHolonomyDefect
+      (repairThenTransportPacket τ action packet)
+      (transportThenRepairPacket τ transportedAction packet) := by
+  constructor
+  · calc
+      (repairThenTransportPacket τ action packet).obligation =
+          (repairPacket action packet).obligation :=
+        hlawful.obligation_preserves
+          (repairPacket action packet)
+      _ = action.repairedObligation := rfl
+      _ = transportedAction.repairedObligation :=
+        hlawful.action_naturality.obligation_eq.symm
+      _ =
+          (transportThenRepairPacket τ transportedAction packet).obligation :=
+        rfl
+  constructor
+  · intro atom
+    constructor
+    · intro hrepairLeft
+      have hrepairRepaired :
+          (repairPacket action packet).repairFrontier atom :=
+        hlawful.transport_laws.reflectsRepair
+          (repairPacket action packet) atom hrepairLeft
+      rcases hrepairRepaired with ⟨hsupportSource, htableSource⟩
+      have hsupportTarget :
+          (τ.map packet).codeSupport atom :=
+        hlawful.transport_laws.preservesSupport
+          packet atom hsupportSource
+      have htableTarget :
+          transportedAction.repairedSourceRefTable atom = none := by
+        rw [hlawful.action_naturality.table_eq atom]
+        exact htableSource
+      exact ⟨hsupportTarget, htableTarget⟩
+    · intro hrepairRight
+      rcases hrepairRight with ⟨hsupportTarget, htableTarget⟩
+      have hsupportSource :
+          packet.codeSupport atom :=
+        hlawful.transport_laws.reflectsSupport
+          packet atom hsupportTarget
+      have htableSource :
+          action.repairedSourceRefTable atom = none := by
+        have htable := htableTarget
+        rw [hlawful.action_naturality.table_eq atom] at htable
+        exact htable
+      have hrepairRepaired :
+          (repairPacket action packet).repairFrontier atom :=
+        ⟨hsupportSource, htableSource⟩
+      exact hlawful.transport_laws.preservesRepair
+        (repairPacket action packet) atom hrepairRepaired
+  · intro atom
+    calc
+      (repairThenTransportPacket τ action packet).sourceRefTable atom =
+          (repairPacket action packet).sourceRefTable atom :=
+        hlawful.transport_laws.preservesSourceRefTable
+          (repairPacket action packet) atom
+      _ = action.repairedSourceRefTable atom := rfl
+      _ = transportedAction.repairedSourceRefTable atom :=
+        (hlawful.action_naturality.table_eq atom).symm
+      _ =
+          (transportThenRepairPacket τ transportedAction packet).sourceRefTable atom :=
+        rfl
+
+/-- Packet zero holonomy projects to tuple zero holonomy for the two routes. -/
+theorem repairTransport_tupleZeroHolonomy_of_lawful
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (packet : SourceRefPacket) :
+    TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple
+        SourceRefTupleBridge.endpointGridCertificate
+        (repairThenTransportPacket τ action packet))
+      (SourceRefTupleBridge.packetToTuple
+        SourceRefTupleBridge.endpointGridCertificate
+        (transportThenRepairPacket τ transportedAction packet)) :=
+  noPacketHolonomy_projects_to_noTupleHolonomy
+    SourceRefTupleBridge.endpointGridCertificate
+    SourceRefTupleBridge.endpointGridCertificate
+    (repairTransport_noPacketHolonomy_of_lawful hlawful packet)
+
+/-- Lawful repair/transport squares commute at the visible tuple surface. -/
+theorem repairTransport_visibleTupleSurface_of_lawful
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (packet : SourceRefPacket) :
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (repairThenTransportPacket τ action packet)
+      (transportThenRepairPacket τ transportedAction packet) :=
+  SourceRefTupleBridge.packet_supportSurface_projects_to_tuple_visible
+    (repairTransport_visiblePacketSurface_of_lawful hlawful packet)
+
+/-- Lawful repair/transport squares induce source-ref exact visualization. -/
+theorem repairTransport_sourceRefExactVisualization_of_lawful
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (packet : SourceRefPacket) :
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (repairThenTransportPacket τ action packet)
+      (transportThenRepairPacket τ transportedAction packet) :=
+  (sourceRefExactVisualization_iff_visible_packetZeroHolonomy
+    SourceRefTupleBridge.endpointGridCertificate
+    SourceRefTupleBridge.endpointGridCertificate
+    (repairThenTransportPacket τ action packet)
+    (transportThenRepairPacket τ transportedAction packet)).mpr
+    ⟨repairTransport_visibleTupleSurface_of_lawful hlawful packet,
+      repairTransport_noPacketHolonomy_of_lawful hlawful packet⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-30 theorem package: non-circular component laws for a lawful
+repair/transport square imply visible packet commutation, packet zero holonomy,
+visible tuple commutation, tuple zero holonomy, and source-ref exact
+visualization for every supplied packet.
+-/
+theorem lawfulRepairTransportCommutatorCriterion_package
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction) :
+    ∀ packet : SourceRefPacket,
+      supportSurfaceReading.Equivalent
+        (repairThenTransportPacket τ action packet)
+        (transportThenRepairPacket τ transportedAction packet) ∧
+      NoSourceRefPacketHolonomyDefect
+        (repairThenTransportPacket τ action packet)
+        (transportThenRepairPacket τ transportedAction packet) ∧
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (repairThenTransportPacket τ action packet)
+        (transportThenRepairPacket τ transportedAction packet) ∧
+      TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+        (SourceRefTupleBridge.packetToTuple
+          SourceRefTupleBridge.endpointGridCertificate
+          (repairThenTransportPacket τ action packet))
+        (SourceRefTupleBridge.packetToTuple
+          SourceRefTupleBridge.endpointGridCertificate
+          (transportThenRepairPacket τ transportedAction packet)) ∧
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (repairThenTransportPacket τ action packet)
+        (transportThenRepairPacket τ transportedAction packet) := by
+  intro packet
+  exact ⟨repairTransport_visiblePacketSurface_of_lawful hlawful packet,
+    repairTransport_noPacketHolonomy_of_lawful hlawful packet,
+    repairTransport_visibleTupleSurface_of_lawful hlawful packet,
+    repairTransport_tupleZeroHolonomy_of_lawful hlawful packet,
+    repairTransport_sourceRefExactVisualization_of_lawful hlawful packet⟩
+
+end LawfulRepairTransportCommutator
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-lawful-repair-transport-commutator-criterion.md
+++ b/research/ideas/g-aat-quality-surface-01-lawful-repair-transport-commutator-criterion.md
@@ -1,0 +1,130 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: certificate-transport / repair-potential / traceability / invariance / obstruction
+expected_base_score: 65
+expected_evidence_multiplier: 2.0
+expected_final_score: 130
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle30
+tags: [quality-surface, repair, transport, commutator, source-ref, exactness]
+created: 2026-06-20
+cycle: 30
+lean: Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean
+---
+
+# Lawful repair/transport commutator criterion
+
+## 主張
+
+有限 `SourceRefPacket`、`PacketUpdate τ`、source repair action、transported repair action に対し、
+`τ` が bidirectional source-ref packet transport、visible surface preservation、obligation preservation を満たし、
+repair action data が action field の水準で
+`repairSupport`、`repairedSourceRefTable`、`repairedObligation` を preserve するなら、
+`τ.map (repairPacket action packet)` と `repairPacket transportedAction (τ.map packet)` は
+packet protected zero-holonomy を持つ。さらにこの二経路 endpoint は visible packet / tuple surface で一致し、
+source-ref exact visualization になる。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- Cycle 17: `Formal/AG/Research/QualitySurface/SourceRefPacketTransport.lean`
+- Cycle 21 / 25: `Formal/AG/Research/QualitySurface/CodebaseTraceRepairTrajectory.lean`,
+  `Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean`
+- Cycle 24: `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
+- Cycle 28 / 29: `Formal/AG/Research/QualitySurface/VisibleRepairTransportCommutator.lean`,
+  `Formal/AG/Research/QualitySurface/SourceRefTableLawObstruction.lean`
+
+## 非自明性
+
+Cycle 28 は visible commutation が protected commutation を含意しないことを示し、Cycle 29 は source-ref table law
+の独立性を示した。この候補は逆向きに、どの protected laws を持てば repair/transport square が本当に exact に
+なるかを示す。endpoint equality や `NoSourceRefPacketHolonomyDefect` を仮定せず、transport law と repair action
+data の naturality から結論を導く。
+
+## 数学的興味
+
+repair と transport の可換性を、visible surface の見た目ではなく、source-ref table、repair frontier、
+obligation、support の component laws に分解した criterion として読む。これは repair-potential と
+certificate-transport を同じ finite holonomy calculus に入れる positive theorem である。
+
+## GOAL への前進
+
+Cycle 28/29 の obstruction frontier を、lawful repair/transport commutator が source-ref exact visualization を
+生む十分条件へ反転し、Quality Surface の repair/transport exactness criterion を固定する。
+
+## SCORE 見込み
+
+- `score_reason`: repair、transport、exact visualization、source-ref holonomy を一つの bounded criterion に統合する closure result として base 65。既存 finite packet machinery 上の十分条件であり、必要十分や selected localization ではない。
+- `dullness_risk`: medium。`NoSourceRefPacketHolonomyDefect` や route endpoint equality を compatibility として定義したら失格。`RepairActionTransportNaturality` は repair action field だけで書き、component laws から zero holonomy を導く。
+- `proof_or_evidence_plan`: `PreservesSourceRefVisibleSurface`、`PreservesSourceRefObligation`、`RepairActionTransportNaturality`、`LawfulRepairTransportSquare` を定義する。`RepairActionTransportNaturality` は `repairSupport` iff、`repairedSourceRefTable` pointwise equality、`repairedObligation` equality のみを含み、route endpoint equality や zero-holonomy を含めない。二経路 endpoint を定義し、visible packet equivalence、packet zero holonomy、tuple visible equivalence、source-ref exact visualization を証明する。
+
+## CS / SWE への帰結
+
+repair と transport を組み合わせる workflow で、どの metadata preservation law があれば順序差を exact に扱えるかを
+明示できる。visible commutation だけでは足りないが、source-ref table、repair frontier、obligation、support の
+component laws が揃えば protected commutator は zero になる。
+
+## 証明・根拠
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean`
+
+Declarations:
+
+- `PreservesSourceRefVisibleSurface`
+- `PreservesSourceRefObligation`
+- `RepairActionTransportNaturality`
+- `LawfulRepairTransportSquare`
+- `repairThenTransportPacket`
+- `transportThenRepairPacket`
+- `repairTransport_visiblePacketSurface_of_lawful`
+- `repairTransport_noPacketHolonomy_of_lawful`
+- `repairTransport_tupleZeroHolonomy_of_lawful`
+- `repairTransport_visibleTupleSurface_of_lawful`
+- `repairTransport_sourceRefExactVisualization_of_lawful`
+- `lawfulRepairTransportCommutatorCriterion_package`
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/lawful_repair_transport_commutator_axioms.lean`: pass; all reported declarations depend on no axioms
+- independent axiom audit: pass; no `sorryAx`, nonstandard axioms, `propext`, `Classical.choice`, or `Quot.sound`
+- independent formalization-quality audit: pass; `LawfulRepairTransportSquare` is non-circular and does not assume endpoint equality, packet zero holonomy, tuple zero holonomy, or source-ref exact visualization
+
+visible_projection: visible packet surface と packet-induced tuple visible surface。
+
+protected_structure: support、source-ref table、repair frontier、obligation、packet holonomy。
+
+exactness_or_minimality_claim: lawful criterion は sufficient condition。endpoint equality や zero holonomy を仮定せず、transport laws と repair action field naturality から導く。
+
+nonfaithfulness_or_failure_mode: Cycle 28/29 の failure は、この criterion の visible-only / table-law failure として外側に残る。
+
+previous_cycle_delta: Cycle 28/29 の negative obstructions を positive lawful criterion に反転する。
+
+## 審判メモ
+
+- 厳密性: initial `revise`。`RepairActionTransportNaturality` を抽象名のままにすると endpoint equality / zero-holonomy を仮定に隠す risk がある。repair action field の support/table/obligation law として明文化し、base 65 / final 130 に下げる。
+- 研究価値: `accept`、base 75。Cycle 28/29 の negative obstruction を positive criterion へ反転し、repair reachability と certificate transport を一つの criterion に圧縮する。
+- repo 全体価値: `accept`、base 70。Research sandbox の finite source-ref calculus を「反例集」から「使える transport law」へ進める。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-visible-repair-transport-commutator-counterexample.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-table-law-sharp-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-packet-transport.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 30 G1 で作成。
+- 2026-06-20: G2 initial review。A は `revise`、B/C は `accept`。repair action field naturality を非循環に明文化し、base 65 / final 130 に下げた。
+- 2026-06-20: G2-A recheck `accept`。base 65 / final 130 で picked。
+- 2026-06-20: G3 Lean verification pass。対象 Lean、`FormalAGResearch`、axiom harness、独立公理検査、独立形式化品質監査が pass。
+- 2026-06-20: G3.5 sync audit pass。candidate card / Lean declarations / report entry は同期済み。
+- 2026-06-20: G4 SCORE audit confirm。base 65、evidence multiplier 2.0、penalty 0、final SCORE 130。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 3560
+- total SCORE: 3690
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -35,8 +35,9 @@
   - traceability / obstruction / invariance / certificate-transport / quality-surface: 120
   - traceability / repair-potential / certificate-transport / obstruction / ridge-fold: 140
   - traceability / certificate-transport / obstruction / invariance / quality-surface: 120
+  - certificate-transport / repair-potential / traceability / invariance / obstruction: 130
 - evidence portfolio:
-  - proved-in-research: 29
+  - proved-in-research: 30
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1281,9 +1282,55 @@ support、missing locus、repair frontier、obligation、visible packet / tuple 
 finite token vocabulary、finite source-ref packet、explicit packet-to-tuple bridge に相対化され、global source-reference
 namespace、source extraction completeness、ArchMap correctness、任意 codebase traceability、実コード全体の品質判定は結論しない。
 
+## Cycle 30: Lawful repair/transport commutator criterion
+
+```text
+candidate: Lawful repair/transport commutator criterion
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 65
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 130
+category: certificate-transport/repair-potential/traceability/invariance/obstruction
+goal_delta: repair/transport square の component laws と repair action field naturality から、二経路 endpoint の packet zero holonomy と source-ref exact visualization を導く十分条件を固定した。
+project_value_delta: Cycle 28/29 の negative obstruction を positive lawful criterion へ反転し、visible commutation ではなく protected component laws が exact visualization を保証する境界を追加した。
+formalization_quality: pass。`LawfulRepairTransportSquare` は endpoint equality、packet zero holonomy、tuple zero holonomy、source-ref exact visualization を仮定せず、bidirectional transport laws、visible preservation、obligation preservation、repair action field naturality から結論を導く。全 declaration は axiom-free / sorry-free。
+open_questions: necessity / minimality direction、selected commutator localization、support law が実際に効く extended repair-action semantics。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean` は、
+repair followed by transport と transport followed by repair の二経路 endpoint を定義し、lawful な finite
+source-ref repair/transport square の十分条件を与える。
+
+仮定は次の component laws に分かれる。
+
+- `BidirectionalSourceRefPacketTransport`: support、missing locus、repair frontier、source-ref table の transport law。
+- `PreservesSourceRefVisibleSurface`: visible scalar / verdict preservation。
+- `PreservesSourceRefObligation`: obligation preservation。
+- `RepairActionTransportNaturality`: repair action field の `repairSupport` iff、`repairedSourceRefTable` pointwise equality、`repairedObligation` equality。
+
+Lean 証拠は次を固定する。
+
+- `repairTransport_visiblePacketSurface_of_lawful`: 二経路 endpoint は visible packet surface で一致する。
+- `repairTransport_noPacketHolonomy_of_lawful`: 二経路 endpoint は packet protected zero-holonomy を持つ。
+- `repairTransport_tupleZeroHolonomy_of_lawful`: packet zero holonomy は tuple zero holonomy へ射影される。
+- `repairTransport_visibleTupleSurface_of_lawful`: visible packet agreement は packet-induced tuple visible surface へ射影される。
+- `repairTransport_sourceRefExactVisualization_of_lawful`: 二経路 endpoint は source-ref exact visualization を持つ。
+- `lawfulRepairTransportCommutatorCriterion_package`: 任意 supplied packet に対して visible packet commutation、packet zero holonomy、visible tuple commutation、tuple zero holonomy、source-ref exact visualization を束ねる。
+
+この結果により、Cycle 28 の visible-only failure と Cycle 29 の table-law obstruction は、lawful criterion の外側に
+位置づけられる。visible commutation だけでは不十分だが、source-ref table、repair frontier、obligation、visible
+surface、repair action field naturality が揃うと、repair/transport commutator は protected zero になり、source-ref
+exact visualization へ上がる。主張は supplied finite source-ref packets、declared repair actions、explicit
+packet-to-tuple bridge に相対化され、global repair planning、canonical transport、source extraction completeness、
+ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 29 後の total SCORE は 3560 である。
-次に進める場合は、lawful repair/transport commutator criterion、
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 30 後の total SCORE は 3690 である。
+次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
-または obligation preservation law を含む拡張 transport structure を狙う。
+または support law が実際に効く extended repair-action semantics を狙う。


### PR DESCRIPTION
## 概要

Cycle 30 として `Lawful repair/transport commutator criterion` を追加します。

`BidirectionalSourceRefPacketTransport`、visible surface preservation、obligation preservation、repair action field naturality から、repair followed by transport と transport followed by repair の二経路 endpoint が visible packet / tuple surface で一致し、packet / tuple zero holonomy と source-ref exact visualization を持つことを証明しました。

Tracking Issue は research-loop の状態正本なので閉じません。

Refs #2348

## 証明した定理

- `PreservesSourceRefVisibleSurface`
- `PreservesSourceRefObligation`
- `RepairActionTransportNaturality`
- `LawfulRepairTransportSquare`
- `repairThenTransportPacket`
- `transportThenRepairPacket`
- `repairTransport_visiblePacketSurface_of_lawful`
- `repairTransport_noPacketHolonomy_of_lawful`
- `repairTransport_tupleZeroHolonomy_of_lawful`
- `repairTransport_visibleTupleSurface_of_lawful`
- `repairTransport_sourceRefExactVisualization_of_lawful`
- `lawfulRepairTransportCommutatorCriterion_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-lawful-repair-transport-commutator-criterion.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/lawful_repair_transport_commutator_axioms.lean`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean:201,207` warning のみ）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local absolute path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（既存 report の `sorry-free` 記述のみ）

## チェックリスト

- [x] tracking Issue のため `Refs #2348` を本文に記載した
- [x] Lean status は `proved-in-research` として候補カードと report に明記した
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
