### PR TITLE
Cycle 32 outside-support mutation obstructionを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -30,3 +30,4 @@ import Formal.AG.Research.QualitySurface.VisibleRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.SourceRefTableLawObstruction
 import Formal.AG.Research.QualitySurface.LawfulRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.SupportLocalRepairFrontier
+import Formal.AG.Research.QualitySurface.OutsideSupportMutationObstruction

--- a/Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean
+++ b/Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean
@@ -1,0 +1,238 @@
+import Formal.AG.Research.QualitySurface.SupportLocalRepairFrontier
+import Formal.AG.Research.QualitySurface.SourceRefExactVisualization
+
+/-!
+Cycle 32 evidence for `G-aat-quality-surface-01`.
+
+This file gives a finite outside-support mutation obstruction for the
+support-local frontier restriction theorem.  The mutation action fills the
+declared storage support but changes the endpoint source-ref table outside that
+support.  The endpoint then reappears in the post-repair frontier, the frontier
+restriction formula fails, and the packet-to-tuple visualization is visibly
+flat but source-ref lossy.  The claim is relative to supplied finite source-ref
+packets and declared repair actions; it does not assert canonical repair
+planning, source extraction completeness, ArchMap correctness, or whole-codebase
+quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace OutsideSupportMutationObstruction
+
+open CodebaseTracePacket
+open CodebaseTraceRepairTrajectory
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+open SupportLocalRepairFrontier
+
+/-! ## Weak support fill and outside-support mutation -/
+
+/-- A weak fill law that only checks token supply on the declared support. -/
+def WeakSupportFillSourceRefRepair
+    (action : SourceRefRepairAction) (packet : SourceRefPacket) : Prop :=
+  ∀ atom, packet.codeSupport atom -> action.repairSupport atom ->
+    ∃ token, action.repairedSourceRefTable atom = some token
+
+/--
+Mutation action: it fills the declared storage support but deletes the endpoint
+source reference outside that support.
+-/
+def outsideSupportMutationRepairAction : SourceRefRepairAction where
+  repairSupport := storageRepairFrontier
+  repairedSourceRefTable
+    | CodeAtom.endpoint => none
+    | CodeAtom.storage => some SourceRefToken.storageRef
+    | CodeAtom.worker => some SourceRefToken.workerRef
+  repairedObligation := StateSeparation.ObligationKind.none
+
+/-- The finite packet obtained by applying the outside-support mutation. -/
+def outsideSupportMutationRepairPacket : SourceRefPacket :=
+  repairPacket outsideSupportMutationRepairAction partialPacket
+
+/-- The mutation action still fills every declared supported atom. -/
+theorem outsideSupportMutation_fillsDeclaredSupport :
+    WeakSupportFillSourceRefRepair
+      outsideSupportMutationRepairAction partialPacket := by
+  intro atom _hsupport hrepair
+  change atom = CodeAtom.storage at hrepair
+  cases hrepair
+  exact ⟨SourceRefToken.storageRef, rfl⟩
+
+/-- The mutation action is not support-local: it changes endpoint outside support. -/
+theorem outsideSupportMutation_not_supportLocal :
+    ¬ SupportLocalSourceRefRepair
+      outsideSupportMutationRepairAction partialPacket := by
+  intro hlocal
+  have hout :
+      ¬ outsideSupportMutationRepairAction.repairSupport
+        CodeAtom.endpoint := by
+    intro h
+    cases h
+  have hpreserve := hlocal.preservesOutsideSupport CodeAtom.endpoint hout
+  change (none : Option SourceRefToken) =
+    some SourceRefToken.endpointRef at hpreserve
+  cases hpreserve
+
+/-! ## Frontier obstruction -/
+
+/-- The support-external endpoint becomes a post-repair frontier atom. -/
+theorem outsideSupportMutation_endpointFrontier :
+    outsideSupportMutationRepairPacket.repairFrontier CodeAtom.endpoint :=
+  ⟨trivial, rfl⟩
+
+/-- The endpoint was not in the pre-repair frontier. -/
+theorem partialPacket_endpoint_not_frontier :
+    ¬ partialPacket.repairFrontier CodeAtom.endpoint := by
+  intro h
+  cases h
+
+/-- The Cycle-31 frontier restriction formula fails at the endpoint. -/
+theorem outsideSupportMutation_breaks_frontierRestriction :
+    ¬ ∀ atom,
+      outsideSupportMutationRepairPacket.repairFrontier atom ↔
+        partialPacket.repairFrontier atom ∧
+          ¬ outsideSupportMutationRepairAction.repairSupport atom := by
+  intro hformula
+  have hright :
+      partialPacket.repairFrontier CodeAtom.endpoint ∧
+        ¬ outsideSupportMutationRepairAction.repairSupport CodeAtom.endpoint :=
+    (hformula CodeAtom.endpoint).mp
+      outsideSupportMutation_endpointFrontier
+  exact partialPacket_endpoint_not_frontier hright.1
+
+/-! ## Visible flatness and protected defects -/
+
+/-- The full packet and mutation-repaired packet agree at the visible surface. -/
+theorem outsideSupportMutation_visiblePacketSurface :
+    supportSurfaceReading.Equivalent
+      fullPacket outsideSupportMutationRepairPacket := by
+  constructor
+  · exact ⟨rfl, rfl⟩
+  · intro atom
+    constructor <;> intro _ <;> trivial
+
+/-- The visible packet agreement projects to visible tuple agreement. -/
+theorem outsideSupportMutation_visibleTupleSurface :
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket outsideSupportMutationRepairPacket :=
+  SourceRefTupleBridge.packet_supportSurface_projects_to_tuple_visible
+    outsideSupportMutation_visiblePacketSurface
+
+/-- The mutation creates an endpoint repair-frontier component defect. -/
+theorem outsideSupportMutation_endpointRepairFrontierDefect :
+    SourceRefRepairFrontierDefectAt
+      fullPacket outsideSupportMutationRepairPacket CodeAtom.endpoint := by
+  intro hsame
+  have hfull : fullPacket.repairFrontier CodeAtom.endpoint :=
+    hsame.mpr outsideSupportMutation_endpointFrontier
+  exact hfull
+
+/-- The mutation creates an endpoint source-ref table component defect. -/
+theorem outsideSupportMutation_endpointSourceRefTableDefect :
+    SourceRefTableDefectAt
+      fullPacket outsideSupportMutationRepairPacket CodeAtom.endpoint := by
+  intro hsame
+  change some SourceRefToken.endpointRef = none at hsame
+  cases hsame
+
+/-- The endpoint repair-frontier defect is a component-indexed packet defect. -/
+theorem outsideSupportMutation_endpointRepairFrontierComponentDefect :
+    SourceRefPacketHolonomyDefect
+      fullPacket outsideSupportMutationRepairPacket
+      (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.endpoint) :=
+  outsideSupportMutation_endpointRepairFrontierDefect
+
+/-- The endpoint source-ref table defect is a component-indexed packet defect. -/
+theorem outsideSupportMutation_endpointSourceRefTableComponentDefect :
+    SourceRefPacketHolonomyDefect
+      fullPacket outsideSupportMutationRepairPacket
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) :=
+  outsideSupportMutation_endpointSourceRefTableDefect
+
+/-- The mutation creates nonzero packet holonomy. -/
+theorem outsideSupportMutation_hasPacketHolonomyDefect :
+    HasSourceRefPacketHolonomyDefect
+      fullPacket outsideSupportMutationRepairPacket :=
+  sourceRefRepairDefect_obstructs_noPacketHolonomy
+    outsideSupportMutation_endpointRepairFrontierDefect
+
+/--
+The mutation is lossy at the packet-to-tuple visualization: visible tuple data
+agree, but protected packet holonomy is nonzero.
+-/
+theorem outsideSupportMutation_lossyPacketToTupleVisualization :
+    LossyPacketToTupleVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket outsideSupportMutationRepairPacket :=
+  ⟨outsideSupportMutation_visibleTupleSurface,
+    outsideSupportMutation_hasPacketHolonomyDefect⟩
+
+/-- The protected endpoint table defect obstructs source-ref exactness. -/
+theorem outsideSupportMutation_not_sourceRefExactVisualization :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket outsideSupportMutationRepairPacket :=
+  packetHolonomyDefect_obstructs_sourceRefExactVisualization
+    outsideSupportMutation_endpointSourceRefTableComponentDefect
+
+/-! ## Theorem package -/
+
+/--
+Cycle-32 theorem package: a weak declared-support fill can still mutate a
+support-external source-ref table, creating a new outside-support frontier atom,
+breaking the Cycle-31 frontier restriction formula, and producing a visibly flat
+but source-ref lossy packet-to-tuple visualization.
+-/
+theorem outsideSupportMutationObstruction_package :
+    WeakSupportFillSourceRefRepair
+        outsideSupportMutationRepairAction partialPacket ∧
+      ¬ SupportLocalSourceRefRepair
+        outsideSupportMutationRepairAction partialPacket ∧
+      outsideSupportMutationRepairPacket.repairFrontier CodeAtom.endpoint ∧
+      ¬ partialPacket.repairFrontier CodeAtom.endpoint ∧
+      (¬ ∀ atom,
+        outsideSupportMutationRepairPacket.repairFrontier atom ↔
+          partialPacket.repairFrontier atom ∧
+            ¬ outsideSupportMutationRepairAction.repairSupport atom) ∧
+      supportSurfaceReading.Equivalent
+        fullPacket outsideSupportMutationRepairPacket ∧
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket outsideSupportMutationRepairPacket ∧
+      SourceRefPacketHolonomyDefect
+        fullPacket outsideSupportMutationRepairPacket
+        (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.endpoint) ∧
+      SourceRefPacketHolonomyDefect
+        fullPacket outsideSupportMutationRepairPacket
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) ∧
+      HasSourceRefPacketHolonomyDefect
+        fullPacket outsideSupportMutationRepairPacket ∧
+      LossyPacketToTupleVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket outsideSupportMutationRepairPacket ∧
+      ¬ SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket outsideSupportMutationRepairPacket := by
+  exact ⟨outsideSupportMutation_fillsDeclaredSupport,
+    outsideSupportMutation_not_supportLocal,
+    outsideSupportMutation_endpointFrontier,
+    partialPacket_endpoint_not_frontier,
+    outsideSupportMutation_breaks_frontierRestriction,
+    outsideSupportMutation_visiblePacketSurface,
+    outsideSupportMutation_visibleTupleSurface,
+    outsideSupportMutation_endpointRepairFrontierComponentDefect,
+    outsideSupportMutation_endpointSourceRefTableComponentDefect,
+    outsideSupportMutation_hasPacketHolonomyDefect,
+    outsideSupportMutation_lossyPacketToTupleVisualization,
+    outsideSupportMutation_not_sourceRefExactVisualization⟩
+
+end OutsideSupportMutationObstruction
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-outside-support-mutation-obstruction.md
+++ b/research/ideas/g-aat-quality-surface-01-outside-support-mutation-obstruction.md
@@ -1,0 +1,140 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: orientation
+capability_category: obstruction / repair-potential / traceability / invariance
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle32
+tags: [quality-surface, repair, support, source-ref, obstruction]
+created: 2026-06-20
+cycle: 32
+lean: Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean
+---
+
+# Outside-support mutation obstruction for support-local frontier restriction
+
+## 主張
+
+Cycle 31 の `SupportLocalSourceRefRepair` から `preservesOutsideSupport` を落とすと、
+declared support 上の token supply が成功しても frontier restriction は壊れる。
+
+具体的には、`partialPacket` に対し declared repair support を storage に置き、storage には
+`storageRef` を供給する一方、support 外の endpoint source-ref table を `none` に変える repair action を作る。
+この action は declared support 上の fill law を満たすが support-local ではない。repair 後 packet では
+endpoint が post frontier に新規発生し、
+
+```text
+post frontier = pre frontier ∧ ¬ repairSupport
+```
+
+が失敗する。さらに full packet との source-ref exact visualization と packet holonomy annihilation も失敗する。
+この失敗は可視面の不一致ではなく、full packet と mutation repair packet が visible packet / tuple surface では
+一致したまま、endpoint の repair-frontier / source-ref table defect によって source-ref exactness が破れる
+lossy packet-to-tuple visualization として証明する。
+
+## 候補種別
+
+`orientation`
+
+## 依拠
+
+- Cycle 23: `Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean`
+- Cycle 24: `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
+- Cycle 25: `Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean`
+- Cycle 31: `Formal/AG/Research/QualitySurface/SupportLocalRepairFrontier.lean`
+
+## 非自明性
+
+Cycle 31 は support-local action の十分条件から post frontier formula を導いた。
+この候補はその仮定のうち `preservesOutsideSupport` が removable ではないことを、declared support 上の fill は成功している有限 witness で示す。
+単なる contrapositive ではなく、post frontier 新規発生、packet holonomy defect、source-ref exact visualization failure を同じ witness に束ねる。
+
+## 数学的興味
+
+support-locality は「support 内を直す」だけでは足りず、「外側を動かさない」ことを含む exactness 条件である。
+この候補は repair support の境界を、support 補集合上の obstruction carrier として読む。
+
+## GOAL への前進
+
+outside-support mutation obstruction を finite witness として固定し、support-local repair calculus の sharpness と
+repair-potential / traceability の protected boundary を進める。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 31 の positive theorem に対する sharp obstruction として base 60。frontier failure 自体は定義計算に近いため抑えめに評価し、declared support fill success、visible packet / tuple flatness、frontier / holonomy / exact visualization の三破綻を同一 witness に束ねることで dullness を避ける。
+- `dullness_risk`: medium。単なる仮定除去の反例に落とさず、declared support fill success、post frontier creation、exactness obstruction、component localization を同時に証明する。
+- `proof_or_evidence_plan`: weak support fill law、outside-support mutation action、post frontier creation、frontier formula failure、visible packet / tuple equivalence、component packet holonomy defect、lossy packet-to-tuple visualization、source-ref exact visualization failure、package theorem を Lean で証明する。
+
+## CS / SWE への帰結
+
+repair action が declared support 上では成功して見えても、support 外 source-ref table を壊すと、
+残 frontier と exact visualization が破綻する。support-aware repair dashboard は outside-support preservation law を
+見なければ false success を表示しうる。
+
+## 証明・根拠の見込み
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean`
+
+Declarations:
+
+- `WeakSupportFillSourceRefRepair`
+- `outsideSupportMutationRepairAction`
+- `outsideSupportMutationRepairPacket`
+- `outsideSupportMutation_fillsDeclaredSupport`
+- `outsideSupportMutation_not_supportLocal`
+- `outsideSupportMutation_endpointFrontier`
+- `outsideSupportMutation_breaks_frontierRestriction`
+- `outsideSupportMutation_endpointRepairFrontierDefect`
+- `outsideSupportMutation_endpointSourceRefTableDefect`
+- `outsideSupportMutation_hasPacketHolonomyDefect`
+- `outsideSupportMutation_visiblePacketSurface`
+- `outsideSupportMutation_visibleTupleSurface`
+- `outsideSupportMutation_lossyPacketToTupleVisualization`
+- `outsideSupportMutation_not_sourceRefExactVisualization`
+- `outsideSupportMutationObstruction_package`
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/outside_support_mutation_axioms.lean`: pass; all reported declarations depend on no axioms
+- independent axiom audit: pass; no `sorryAx`, nonstandard axioms, `propext`, `Classical.choice`, or `Quot.sound`
+- independent formalization-quality audit: pass; exactness failure is not weakened to visible mismatch because the same witness has visible packet / tuple equivalence and lossy visualization
+
+## 審判メモ
+
+- 厳密性: initial `revise`、recheck `accept`。`¬ SourceRefExactVisualization` だけでは可視面の不一致による失敗に弱まるため、visible packet / tuple equivalence と `LossyPacketToTupleVisualization` を同じ witness で証明すること。base は 60 に下げる。
+- 研究価値: `accept`、base 75。declared support fill success と外側 mutation、frontier 新規発生、holonomy/exactness failure を同時に固定できれば、Cycle 31 の support-locality を鋭くする。
+- repo 全体価値: `accept`、base 70。Tooling / paper では false repair success の境界として使えるが、単なる仮定除去反例に縮めないこと。
+
+## G4 SCORE 監査
+
+- `score_verdict`: `confirm`
+- `base_score`: 60
+- `evidence_multiplier`: 2.0
+- `penalty`: 0
+- `final_score`: 120
+- `category`: obstruction / repair-potential / traceability / invariance
+- `reason`: 同一 finite witness が weak fill success、outside-support mutation、frontier restriction failure、visible packet / tuple agreement、packet holonomy defect、lossy visualization、non-exactness を束ねており、Cycle 31 の `preservesOutsideSupport` の必要性を示す obstruction として base 60 が妥当。
+- `checked`: Lean claim と card/report の claim boundary は一致。Cycle 31 の 3820 に +120 して 3940/5000、proved-in-research は 32。
+- `unchecked`: なし。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-support-local-repair-frontier-restriction.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-table-law-sharp-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-visible-repair-transport-commutator-counterexample.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 32 G1 で作成。
+- 2026-06-20: G2 initial review。A は `revise`、B/C は `accept`。visible packet / tuple flatness と lossy visualization を証明対象に追加し、base 60 / final 120 に下げた。
+- 2026-06-20: G2-A recheck `accept`。base 60 / final 120 で picked。
+- 2026-06-20: G3 Lean verification pass。対象 Lean、`FormalAGResearch`、axiom harness が pass。
+- 2026-06-20: G3 independent axiom audit / formalization-quality audit pass。
+- 2026-06-20: G4 SCORE audit `confirm`。base 60 / multiplier 2.0 / final 120、累積 3940/5000。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 3820
+- total SCORE: 3940
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -37,8 +37,9 @@
   - traceability / certificate-transport / obstruction / invariance / quality-surface: 120
   - certificate-transport / repair-potential / traceability / invariance / obstruction: 130
   - repair-potential / traceability / atom-supported-quality-geometry / invariance: 130
+  - obstruction / repair-potential / traceability / invariance: 120
 - evidence portfolio:
-  - proved-in-research: 31
+  - proved-in-research: 32
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1371,10 +1372,53 @@ Lean 証拠は次を固定する。
 bounded semantics になった。主張は supplied finite source-ref packets と declared repair actions に相対化され、
 canonical repair planning、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 32: Outside-support mutation obstruction
+
+```text
+candidate: Outside-support mutation obstruction for support-local frontier restriction
+candidate_type: orientation
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: obstruction/repair-potential/traceability/invariance
+goal_delta: declared support 上の fill が成功しても support 外 source-ref table mutation が post frontier、packet holonomy、source-ref exact visualization を同時に壊す有限 witness を固定した。
+project_value_delta: Cycle 31 の support-local frontier restriction の `preservesOutsideSupport` が removable ではないことを、visible-flat かつ source-ref lossy な packet-to-tuple visualization として示した。
+formalization_quality: pass。`WeakSupportFillSourceRefRepair` は declared support fill のみを要求し、同一 witness で visible packet / tuple equivalence、frontier restriction failure、endpoint component defects、lossy visualization、non-exactness を証明する。全 declaration は axiom-free / sorry-free。
+open_questions: support-local repair/transport commutator criterion、supported-token mismatch obstruction、selected support-defect localization。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean` は、
+declared support 上の token supply だけでは support-local repair にならないことを示す有限 witness を定義する。
+`outsideSupportMutationRepairAction` は storage support を fill するが、support 外 endpoint の source-ref table を
+`none` に変える。
+
+Lean 証拠は次を固定する。
+
+- `WeakSupportFillSourceRefRepair`: declared support 上の token supply だけを読む弱い fill law。
+- `outsideSupportMutation_fillsDeclaredSupport`: mutation action は weak fill law を満たす。
+- `outsideSupportMutation_not_supportLocal`: mutation action は `preservesOutsideSupport` を破るため support-local ではない。
+- `outsideSupportMutation_endpointFrontier`: support 外 endpoint が post frontier に新規発生する。
+- `outsideSupportMutation_breaks_frontierRestriction`: Cycle 31 の frontier restriction formula は endpoint で失敗する。
+- `outsideSupportMutation_visiblePacketSurface` / `outsideSupportMutation_visibleTupleSurface`: full packet と mutation-repaired packet は visible packet / tuple surface で一致する。
+- `outsideSupportMutation_endpointRepairFrontierDefect` / `outsideSupportMutation_endpointSourceRefTableDefect`: endpoint に protected component defects がある。
+- `outsideSupportMutation_hasPacketHolonomyDefect`: mutation repair packet は full packet に対して nonzero packet holonomy を持つ。
+- `outsideSupportMutation_lossyPacketToTupleVisualization`: visible tuple flatness と protected packet holonomy defect が同じ witness に共存する。
+- `outsideSupportMutation_not_sourceRefExactVisualization`: protected endpoint table defect が source-ref exact visualization を阻害する。
+- `outsideSupportMutationObstruction_package`: weak fill success、non-support-locality、frontier failure、visible flatness、component defects、lossy visualization、non-exactness を束ねる。
+
+この結果により、support-locality は「support 内を直す」だけではなく、support 外 source-ref table を保存する
+exactness law を含むことが明確になった。主張は supplied finite source-ref packets と declared repair actions に
+相対化され、canonical repair planning、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 31 後の total SCORE は 3820 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 32 後の total SCORE は 3940 である。
 次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
 support-local repair/transport commutator criterion、
-または outside-support mutation obstruction を狙う。
+supported-token mismatch obstruction、
+または selected support-defect localization を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 32 として、support-local frontier restriction に対する outside-support mutation obstruction を追加する。declared support 上の fill が成功しても、support 外 source-ref table mutation により post frontier、packet holonomy、source-ref exact visualization が同時に破綻する finite witness を Lean で固定した。

SCORE は G4 監査で `confirm`、`+120`（base 60、multiplier 2.0、category: obstruction / repair-potential / traceability / invariance）。累積は `3940 / 5000`、`proved-in-research: 32`。

## 証明した定理

- `WeakSupportFillSourceRefRepair`
- `outsideSupportMutation_fillsDeclaredSupport`
- `outsideSupportMutation_not_supportLocal`
- `outsideSupportMutation_endpointFrontier`
- `outsideSupportMutation_breaks_frontierRestriction`
- `outsideSupportMutation_visiblePacketSurface`
- `outsideSupportMutation_visibleTupleSurface`
- `outsideSupportMutation_endpointRepairFrontierDefect`
- `outsideSupportMutation_endpointSourceRefTableDefect`
- `outsideSupportMutation_hasPacketHolonomyDefect`
- `outsideSupportMutation_lossyPacketToTupleVisualization`
- `outsideSupportMutation_not_sourceRefExactVisualization`
- `outsideSupportMutationObstruction_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-outside-support-mutation-obstruction.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（対象外）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（対象外）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local absolute path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（report/card の `sorry-free` 記述のみ）
- [x] axiom harness: all reported declarations depend on no axioms
- [x] independent formalization-quality audit: pass
- [x] independent G4 SCORE audit: confirm

`lake build` は成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ。

## チェックリスト

- [x] tracking Issue を `Refs #2348` 形式で本文に記載した（research-loop tracking Issue のため自動 close しない）
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
