### PR TITLE
Cycle 33 supported-token mismatch obstructionを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -31,3 +31,4 @@ import Formal.AG.Research.QualitySurface.SourceRefTableLawObstruction
 import Formal.AG.Research.QualitySurface.LawfulRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.SupportLocalRepairFrontier
 import Formal.AG.Research.QualitySurface.OutsideSupportMutationObstruction
+import Formal.AG.Research.QualitySurface.SupportedTokenMismatchObstruction

--- a/Formal/AG/Research/QualitySurface/SupportedTokenMismatchObstruction.lean
+++ b/Formal/AG/Research/QualitySurface/SupportedTokenMismatchObstruction.lean
@@ -1,0 +1,198 @@
+import Formal.AG.Research.QualitySurface.SupportLocalRepairFrontier
+import Formal.AG.Research.QualitySurface.SourceRefExactVisualization
+
+/-!
+Cycle 33 evidence for `G-aat-quality-surface-01`.
+
+This file gives a finite supported-token mismatch obstruction: a declared
+support-local repair action can satisfy the Cycle-31 frontier restriction and
+collapse the post-repair frontier while still writing the wrong source-ref token
+inside the repaired support.  The visible packet-to-tuple surface is flat, but
+source-ref exact visualization fails because protected token identity is wrong.
+The claim is relative to supplied finite source-ref packets and declared repair
+actions; it does not assert canonical repair planning, source extraction
+completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SupportedTokenMismatchObstruction
+
+open CodebaseTracePacket
+open CodebaseTraceRepairTrajectory
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+open SupportLocalRepairFrontier
+
+/-! ## Wrong-token repair action -/
+
+/--
+A storage repair action that fills the declared support but writes the worker
+source-ref token at storage.  This is enough to clear the missing frontier but
+not enough to restore source-ref exactness against the supplied full packet.
+-/
+def supportedTokenMismatchRepairAction : SourceRefRepairAction where
+  repairSupport := storageRepairFrontier
+  repairedSourceRefTable
+    | CodeAtom.endpoint => some SourceRefToken.endpointRef
+    | CodeAtom.storage => some SourceRefToken.workerRef
+    | CodeAtom.worker => some SourceRefToken.workerRef
+  repairedObligation := StateSeparation.ObligationKind.none
+
+/-- The finite packet obtained by applying the supported-token mismatch repair. -/
+def supportedTokenMismatchRepairPacket : SourceRefPacket :=
+  repairPacket supportedTokenMismatchRepairAction partialPacket
+
+/--
+The wrong-token action is still support-local in the Cycle-31 sense: it supplies
+some token on the declared support and preserves the source-ref table outside
+that support.
+-/
+theorem supportedTokenMismatch_supportLocal :
+    SupportLocalSourceRefRepair
+      supportedTokenMismatchRepairAction partialPacket where
+  fillsSupportedAtoms := by
+    intro atom _hsupport hrepair
+    change atom = CodeAtom.storage at hrepair
+    cases hrepair
+    exact ⟨SourceRefToken.workerRef, rfl⟩
+  preservesOutsideSupport := by
+    intro atom hout
+    change ¬ atom = CodeAtom.storage at hout
+    cases atom with
+    | endpoint => rfl
+    | storage => exact False.elim (hout rfl)
+    | worker => rfl
+
+/-! ## Frontier success -/
+
+/-- The Cycle-31 frontier restriction formula holds for the wrong-token action. -/
+theorem supportedTokenMismatch_frontierRestriction_holds
+    (atom : CodeAtom) :
+    supportedTokenMismatchRepairPacket.repairFrontier atom ↔
+      partialPacket.repairFrontier atom ∧
+        ¬ supportedTokenMismatchRepairAction.repairSupport atom :=
+  supportLocalRepair_frontier_eq_preFrontier_diff_support
+    supportedTokenMismatch_supportLocal partialTrace_repairFrontierExact atom
+
+/-- The wrong-token repair clears the post-repair frontier. -/
+theorem supportedTokenMismatch_postFrontier_empty :
+    ¬ ∃ atom, supportedTokenMismatchRepairPacket.repairFrontier atom := by
+  intro hfrontier
+  rcases hfrontier with ⟨atom, hpost⟩
+  have hformula := supportedTokenMismatch_frontierRestriction_holds atom
+  have hright := hformula.mp hpost
+  exact hright.2 hright.1
+
+/-! ## Visible flatness and protected token mismatch -/
+
+/-- The full packet and wrong-token repaired packet agree at the visible surface. -/
+theorem supportedTokenMismatch_visiblePacketSurface :
+    supportSurfaceReading.Equivalent
+      fullPacket supportedTokenMismatchRepairPacket := by
+  constructor
+  · exact ⟨rfl, rfl⟩
+  · intro atom
+    constructor <;> intro _hsupport <;> trivial
+
+/-- The visible packet agreement projects to visible tuple agreement. -/
+theorem supportedTokenMismatch_visibleTupleSurface :
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket supportedTokenMismatchRepairPacket :=
+  SourceRefTupleBridge.packet_supportSurface_projects_to_tuple_visible
+    supportedTokenMismatch_visiblePacketSurface
+
+/-- The wrong-token repair leaves a storage source-ref table component defect. -/
+theorem supportedTokenMismatch_storageSourceRefTableDefect :
+    SourceRefTableDefectAt
+      fullPacket supportedTokenMismatchRepairPacket CodeAtom.storage := by
+  intro hsame
+  change some SourceRefToken.storageRef =
+    some SourceRefToken.workerRef at hsame
+  cases hsame
+
+/-- The storage source-ref table mismatch is a component-indexed packet defect. -/
+theorem supportedTokenMismatch_storageSourceRefTableComponentDefect :
+    SourceRefPacketHolonomyDefect
+      fullPacket supportedTokenMismatchRepairPacket
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) :=
+  supportedTokenMismatch_storageSourceRefTableDefect
+
+/-- The wrong-token repair creates nonzero packet holonomy. -/
+theorem supportedTokenMismatch_hasPacketHolonomyDefect :
+    HasSourceRefPacketHolonomyDefect
+      fullPacket supportedTokenMismatchRepairPacket :=
+  sourceRefTableDefect_obstructs_noPacketHolonomy
+    supportedTokenMismatch_storageSourceRefTableDefect
+
+/--
+The wrong-token repair is visibly flat after packet-to-tuple projection, but
+protected packet holonomy is nonzero.
+-/
+theorem supportedTokenMismatch_lossyPacketToTupleVisualization :
+    LossyPacketToTupleVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket supportedTokenMismatchRepairPacket :=
+  ⟨supportedTokenMismatch_visibleTupleSurface,
+    supportedTokenMismatch_hasPacketHolonomyDefect⟩
+
+/-- The storage table defect obstructs source-ref exact visualization. -/
+theorem supportedTokenMismatch_not_sourceRefExactVisualization :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket supportedTokenMismatchRepairPacket :=
+  packetHolonomyDefect_obstructs_sourceRefExactVisualization
+    supportedTokenMismatch_storageSourceRefTableComponentDefect
+
+/-! ## Theorem package -/
+
+/--
+Cycle-33 theorem package: frontier success is not source-ref exactness.  The
+wrong-token action is support-local and clears the post frontier, but the
+repaired packet remains visibly flat and source-ref lossy relative to the full
+packet because storage carries the wrong source-ref token.
+-/
+theorem supportedTokenMismatchObstruction_package :
+    SupportLocalSourceRefRepair
+        supportedTokenMismatchRepairAction partialPacket ∧
+      (∀ atom,
+        supportedTokenMismatchRepairPacket.repairFrontier atom ↔
+          partialPacket.repairFrontier atom ∧
+            ¬ supportedTokenMismatchRepairAction.repairSupport atom) ∧
+      (¬ ∃ atom, supportedTokenMismatchRepairPacket.repairFrontier atom) ∧
+      supportSurfaceReading.Equivalent
+        fullPacket supportedTokenMismatchRepairPacket ∧
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket supportedTokenMismatchRepairPacket ∧
+      SourceRefPacketHolonomyDefect
+        fullPacket supportedTokenMismatchRepairPacket
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) ∧
+      HasSourceRefPacketHolonomyDefect
+        fullPacket supportedTokenMismatchRepairPacket ∧
+      LossyPacketToTupleVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket supportedTokenMismatchRepairPacket ∧
+      ¬ SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket supportedTokenMismatchRepairPacket := by
+  exact ⟨supportedTokenMismatch_supportLocal,
+    supportedTokenMismatch_frontierRestriction_holds,
+    supportedTokenMismatch_postFrontier_empty,
+    supportedTokenMismatch_visiblePacketSurface,
+    supportedTokenMismatch_visibleTupleSurface,
+    supportedTokenMismatch_storageSourceRefTableComponentDefect,
+    supportedTokenMismatch_hasPacketHolonomyDefect,
+    supportedTokenMismatch_lossyPacketToTupleVisualization,
+    supportedTokenMismatch_not_sourceRefExactVisualization⟩
+
+end SupportedTokenMismatchObstruction
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-supported-token-mismatch-obstruction.md
+++ b/research/ideas/g-aat-quality-surface-01-supported-token-mismatch-obstruction.md
@@ -1,0 +1,123 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: orientation
+capability_category: obstruction / repair-potential / traceability / invariance / quality-surface
+expected_base_score: 65
+expected_evidence_multiplier: 2.0
+expected_final_score: 130
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle33
+tags: [quality-surface, repair, support, source-ref, obstruction, exactness]
+created: 2026-06-20
+cycle: 33
+lean: Formal/AG/Research/QualitySurface/SupportedTokenMismatchObstruction.lean
+---
+
+# Supported-token mismatch obstruction: frontier exact but source-ref non-exact
+
+## 主張
+
+Cycle 31 の `SupportLocalSourceRefRepair` が保証する frontier restriction は、source-ref exact visualization を保証しない。
+declared storage support 上に `none` ではない token を供給し、support 外 source-ref table を保存する repair action を作る。
+この action は support-local であり、
+
+```text
+post frontier = pre frontier ∧ ¬ repairSupport
+```
+
+を満たす。したがって post frontier は空になる。
+
+しかし support 内 storage に supplied full packet と異なる source-ref token を入れるため、full packet との
+source-ref table component defect が残る。visible packet / tuple surface と frontier collapse は成功して見えるが、
+packet holonomy は nonzero であり、source-ref exact visualization は失敗する。
+
+## 候補種別
+
+`orientation`
+
+## 依拠
+
+- Cycle 23: `Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean`
+- Cycle 24: `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
+- Cycle 25: `Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean`
+- Cycle 29: `Formal/AG/Research/QualitySurface/SourceRefTableLawObstruction.lean`
+- Cycle 31: `Formal/AG/Research/QualitySurface/SupportLocalRepairFrontier.lean`
+- Cycle 32: `Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean`
+
+## 非自明性
+
+Cycle 32 は support 外 mutation により frontier formula 自体が壊れることを示した。
+この候補は逆に、frontier formula が成立しても protected token identity が間違えば source-ref exactness は壊れることを示す。
+単なる token swap ではなく、support-local repair、post frontier collapse、visible flatness、component table defect、
+lossy packet-to-tuple visualization、non-exactness を同一 finite witness に束ねる。
+
+## 数学的興味
+
+repair success は「missing が消える」ことと「正しい source-ref token に戻る」ことに分かれる。
+この候補は frontier calculus と source-ref exactness の独立性を、support 内 token identity obstruction として局所化する。
+
+## GOAL への前進
+
+support-local repair theorem の限界を exact visualization 側から鋭くし、repair-potential / traceability / obstruction の
+protected boundary を進める。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 31 の positive frontier theorem と Cycle 32 の outside-support obstruction に対し、frontier 成功と source-ref exactness failure を分離する sharp obstruction として base 65 を見込む。frontier collapse、visible flatness、protected table defect、lossy visualization を同一 witness に入れるため、単なる token mismatch にはしない。Cycle 29 の token identity obstruction と近いため、G2 で当初見込みの 70 から 65 に下げた。
+- `dullness_risk`: medium。Cycle 29 の token identity obstruction の焼き直しになる危険があるため、support-locality と frontier restriction success を明示的に証明対象へ入れる。
+- `proof_or_evidence_plan`: wrong-token repair action、support-locality、frontier restriction formula、post frontier collapse、visible packet / tuple equivalence、storage source-ref table component defect、packet holonomy defect、lossy visualization、source-ref exact visualization failure、package theorem を Lean で証明する。
+
+## CS / SWE への帰結
+
+repair dashboard が repair frontier の collapse だけを見ると、wrong source-ref token を入れた repair を成功と誤読する。
+loss-aware visualization には frontier state だけでなく source-ref token identity / packet holonomy を含める必要がある。
+
+## 証明・根拠の見込み
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/SupportedTokenMismatchObstruction.lean`
+
+Planned declarations:
+
+- `supportedTokenMismatchRepairAction`
+- `supportedTokenMismatchRepairPacket`
+- `supportedTokenMismatch_supportLocal`
+- `supportedTokenMismatch_frontierRestriction_holds`
+- `supportedTokenMismatch_postFrontier_empty`
+- `supportedTokenMismatch_visiblePacketSurface`
+- `supportedTokenMismatch_visibleTupleSurface`
+- `supportedTokenMismatch_storageSourceRefTableDefect`
+- `supportedTokenMismatch_storageSourceRefTableComponentDefect`
+- `supportedTokenMismatch_hasPacketHolonomyDefect`
+- `supportedTokenMismatch_lossyPacketToTupleVisualization`
+- `supportedTokenMismatch_not_sourceRefExactVisualization`
+- `supportedTokenMismatchObstruction_package`
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SupportedTokenMismatchObstruction.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/supported_token_mismatch_axioms.lean`: pass; all reported declarations depend on no axioms
+- independent axiom audit: pass; no `sorryAx`, nonstandard axioms, `propext`, `Classical.choice`, or `Quot.sound`
+- independent formalization-quality audit: pass; `supportedTokenMismatch_frontierRestriction_holds` is the full all-atom frontier formula, not only empty-frontier collapse, and the witness is a repair action obstruction rather than a transport token-swap restatement
+
+## 審判メモ
+
+- 厳密性: `accept`、base 65。Cycle 29 の token-swap transport の名前替えではなく、partial packet への declared repair action として `SupportLocalSourceRefRepair` と frontier restriction success を同一 witness に入れる点が差分。`frontierRestriction_holds` を空 frontier だけに弱めず、wrong token と full packet の storage table defect を明示すること。
+- 研究価値: `accept`、base 65。repair success を missing/frontier collapse と正しい source-ref token identity に分離し、Cycle 31/32/29 を repair law の二層性として圧縮する。
+- repo 全体価値: `accept`、base 65。AAT quality surface、loss-aware visualization、repair-potential、Research report の obstruction 節に自然に接続する。ただし wrong-token witness だけでは弱く、support-locality、frontier restriction 成功、exactness failure を同一 theorem package に入れること。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-outside-support-mutation-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-table-law-sharp-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-support-local-repair-frontier-restriction.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 33 G1 で作成。二つの G1 候補生成が同系統候補を上位に挙げた。
+- 2026-06-20: G2 三審判すべて `accept`。全員 base 65 と判定したため、期待 SCORE を 65 * 2.0 = 130 に下げて picked。
+- 2026-06-20: G3 Lean verification pass。対象 Lean、`FormalAGResearch`、axiom harness が pass。
+- 2026-06-20: G3 independent axiom audit / formalization-quality audit pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 3940
+- total SCORE: 4070
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -38,8 +38,9 @@
   - certificate-transport / repair-potential / traceability / invariance / obstruction: 130
   - repair-potential / traceability / atom-supported-quality-geometry / invariance: 130
   - obstruction / repair-potential / traceability / invariance: 120
+  - obstruction / repair-potential / traceability / invariance / quality-surface: 130
 - evidence portfolio:
-  - proved-in-research: 32
+  - proved-in-research: 33
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1414,11 +1415,52 @@ Lean 証拠は次を固定する。
 exactness law を含むことが明確になった。主張は supplied finite source-ref packets と declared repair actions に
 相対化され、canonical repair planning、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 33: Supported-token mismatch obstruction
+
+```text
+candidate: Supported-token mismatch obstruction: frontier exact but source-ref non-exact
+candidate_type: orientation
+evidence_stage: proved-in-research
+base_score: 65
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 130
+category: obstruction/repair-potential/traceability/invariance/quality-surface
+goal_delta: support-local repair action が frontier restriction と post frontier collapse を満たしても、support 内 wrong source-ref token により source-ref exact visualization が失敗する有限 witness を固定した。
+project_value_delta: Cycle 31 の positive frontier calculus、Cycle 32 の outside-support obstruction、Cycle 29 の token identity obstruction を、repair success と source-ref exactness の二層性として圧縮した。
+formalization_quality: pass。`supportedTokenMismatch_frontierRestriction_holds` は全 atom の frontier formula であり、空 frontier だけに弱めていない。同一 witness で support-locality、post frontier collapse、visible packet / tuple equivalence、storage table component defect、lossy visualization、non-exactness を証明する。全 declaration は axiom-free / sorry-free。
+open_questions: support-local repair/transport commutator criterion、frontier formula minimality theorem、selected support-defect localization。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SupportedTokenMismatchObstruction.lean` は、
+frontier success と source-ref exactness が一致しないことを示す有限 repair witness を定義する。
+`supportedTokenMismatchRepairAction` は storage support に token を供給し、support 外 source-ref table を保存するため
+`SupportLocalSourceRefRepair` を満たす。しかし storage には supplied full packet の `storageRef` ではなく
+`workerRef` を入れる。
+
+Lean 証拠は次を固定する。
+
+- `supportedTokenMismatch_supportLocal`: wrong-token action は Cycle 31 の support-local repair law を満たす。
+- `supportedTokenMismatch_frontierRestriction_holds`: post frontier は pre frontier minus declared support として計算される。
+- `supportedTokenMismatch_postFrontier_empty`: wrong-token repair は post frontier を空にする。
+- `supportedTokenMismatch_visiblePacketSurface` / `supportedTokenMismatch_visibleTupleSurface`: full packet と wrong-token repaired packet は visible packet / tuple surface で一致する。
+- `supportedTokenMismatch_storageSourceRefTableDefect`: storage source-ref table component は full packet と一致しない。
+- `supportedTokenMismatch_storageSourceRefTableComponentDefect`: storage source-ref table mismatch は component-indexed packet defect である。
+- `supportedTokenMismatch_hasPacketHolonomyDefect`: wrong-token repaired packet は full packet に対して nonzero packet holonomy を持つ。
+- `supportedTokenMismatch_lossyPacketToTupleVisualization`: visible tuple flatness と protected packet holonomy defect が同じ witness に共存する。
+- `supportedTokenMismatch_not_sourceRefExactVisualization`: protected storage token defect が source-ref exact visualization を阻害する。
+- `supportedTokenMismatchObstruction_package`: support-locality、frontier formula、frontier collapse、visible flatness、component defect、lossy visualization、non-exactness を束ねる。
+
+この結果により、repair success は「missing / frontier が消える」ことと「正しい source-ref token identity へ戻る」ことに
+分離された。主張は supplied finite source-ref packets と declared repair actions に相対化され、canonical repair planning、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 32 後の total SCORE は 3940 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 33 後の total SCORE は 4070 である。
 次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
 support-local repair/transport commutator criterion、
-supported-token mismatch obstruction、
 または selected support-defect localization を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 33 として、support-local repair の frontier success と source-ref exactness を分離する supported-token mismatch obstruction を追加する。wrong-token repair action は `SupportLocalSourceRefRepair` を満たし、Cycle 31 の frontier restriction formula と post frontier collapse も成立するが、storage に wrong source-ref token を入れるため source-ref exact visualization は失敗する。

SCORE は G4 監査で `confirm`、`+130`（base 65、multiplier 2.0、category: obstruction / repair-potential / traceability / invariance / quality-surface）。累積は `4070 / 5000`、`proved-in-research: 33`。

## 証明した定理

- `supportedTokenMismatch_supportLocal`
- `supportedTokenMismatch_frontierRestriction_holds`
- `supportedTokenMismatch_postFrontier_empty`
- `supportedTokenMismatch_visiblePacketSurface`
- `supportedTokenMismatch_visibleTupleSurface`
- `supportedTokenMismatch_storageSourceRefTableDefect`
- `supportedTokenMismatch_storageSourceRefTableComponentDefect`
- `supportedTokenMismatch_hasPacketHolonomyDefect`
- `supportedTokenMismatch_lossyPacketToTupleVisualization`
- `supportedTokenMismatch_not_sourceRefExactVisualization`
- `supportedTokenMismatchObstruction_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-supported-token-mismatch-obstruction.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SupportedTokenMismatchObstruction.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/supported_token_mismatch_axioms.lean`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（対象外）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（対象外）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local absolute path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（report/card の `sorry-free` 記述のみ）
- [x] independent axiom audit: pass
- [x] independent formalization-quality audit: pass
- [x] G3.5 sync audit: synced
- [x] independent G4 SCORE audit: confirm

`lake build` は成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ。

## チェックリスト

- [x] tracking Issue を `Refs #2348` 形式で本文に記載した（research-loop tracking Issue のため自動 close しない）
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
