### PR TITLE
Cycle 34 support-local repair transport frontier commutatorを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -32,3 +32,4 @@ import Formal.AG.Research.QualitySurface.LawfulRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.SupportLocalRepairFrontier
 import Formal.AG.Research.QualitySurface.OutsideSupportMutationObstruction
 import Formal.AG.Research.QualitySurface.SupportedTokenMismatchObstruction
+import Formal.AG.Research.QualitySurface.SupportLocalRepairTransportCommutator

--- a/Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean
+++ b/Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean
@@ -1,0 +1,246 @@
+import Formal.AG.Research.QualitySurface.LawfulRepairTransportCommutator
+import Formal.AG.Research.QualitySurface.SupportLocalRepairFrontier
+
+/-!
+Cycle 34 evidence for `G-aat-quality-surface-01`.
+
+This file combines the lawful repair/transport commutator criterion with the
+support-local repair frontier calculus.  A lawful packet transport carries
+repair-frontier exactness, and action naturality carries support-locality from
+a source action to the transported action.  Under these hypotheses, both
+repair-then-transport and transport-then-repair endpoints satisfy the same
+transported frontier restriction formula, and the existing lawful commutator
+gives source-ref exact visualization.  The claim is relative to supplied finite
+source-ref packets, declared repair actions, and explicit packet transport
+laws; it does not assert canonical transport, canonical repair planning, source
+extraction completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SupportLocalRepairTransportCommutator
+
+open CodebaseTracePacket
+open CodebaseTraceRepairTrajectory
+open SourceRefPacketTransport
+open SourceRefExactVisualizationCriterion
+open LawfulRepairTransportCommutator
+open SupportLocalRepairFrontier
+
+/-! ## Transporting exact frontiers and support-locality -/
+
+/-- Lawful packet transport carries repair-frontier exactness. -/
+theorem packetTransport_repairFrontierExact
+    {τ : PacketUpdate}
+    (hlaws : BidirectionalSourceRefPacketTransport τ)
+    {packet : SourceRefPacket}
+    (hexact : RepairFrontierExact packet) :
+    RepairFrontierExact (τ.map packet) := by
+  intro atom
+  constructor
+  · intro hrepairTarget
+    have hrepairSource :
+        packet.repairFrontier atom :=
+      hlaws.reflectsRepair packet atom hrepairTarget
+    have hmissingSource :
+        SourceRefMissingLocus packet atom :=
+      (hexact atom).mp hrepairSource
+    exact hlaws.preservesMissing packet atom hmissingSource
+  · intro hmissingTarget
+    have hmissingSource :
+        SourceRefMissingLocus packet atom :=
+      hlaws.reflectsMissing packet atom hmissingTarget
+    have hrepairSource :
+        packet.repairFrontier atom :=
+      (hexact atom).mpr hmissingSource
+    exact hlaws.preservesRepair packet atom hrepairSource
+
+/--
+In a lawful repair/transport square, support-locality of the source action
+transports to support-locality of the transported action.
+-/
+theorem transportedAction_supportLocal_of_lawful
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hlocal : SupportLocalSourceRefRepair action packet) :
+    SupportLocalSourceRefRepair transportedAction (τ.map packet) where
+  fillsSupportedAtoms := by
+    intro atom hsupportTarget hrepairTransported
+    have hsupportSource :
+        packet.codeSupport atom :=
+      hlawful.transport_laws.reflectsSupport packet atom hsupportTarget
+    have hrepairSource :
+        action.repairSupport atom :=
+      (hlawful.action_naturality.support_iff atom).mp hrepairTransported
+    rcases hlocal.fillsSupportedAtoms atom hsupportSource hrepairSource with
+      ⟨token, hsome⟩
+    refine ⟨token, ?_⟩
+    rw [hlawful.action_naturality.table_eq atom]
+    exact hsome
+  preservesOutsideSupport := by
+    intro atom hnotTransported
+    have hnotSource :
+        ¬ action.repairSupport atom := by
+      intro hrepairSource
+      exact hnotTransported
+        ((hlawful.action_naturality.support_iff atom).mpr hrepairSource)
+    calc
+      transportedAction.repairedSourceRefTable atom =
+          action.repairedSourceRefTable atom :=
+        hlawful.action_naturality.table_eq atom
+      _ = packet.sourceRefTable atom :=
+        hlocal.preservesOutsideSupport atom hnotSource
+      _ = (τ.map packet).sourceRefTable atom :=
+        (hlawful.transport_laws.preservesSourceRefTable packet atom).symm
+
+/-! ## Route frontier formulas -/
+
+/--
+For repair-then-transport, the endpoint frontier is the transported pre-frontier
+with the transported support removed.
+-/
+theorem supportLocalRepairTransport_leftFrontierRestriction
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hlocal : SupportLocalSourceRefRepair action packet)
+    (hexact : RepairFrontierExact packet)
+    (atom : CodeAtom) :
+    (repairThenTransportPacket τ action packet).repairFrontier atom ↔
+      (τ.map packet).repairFrontier atom ∧
+        ¬ transportedAction.repairSupport atom := by
+  constructor
+  · intro hleft
+    have hrepairSourceEndpoint :
+        (repairPacket action packet).repairFrontier atom :=
+      hlawful.transport_laws.reflectsRepair
+        (repairPacket action packet) atom hleft
+    have hsourceFormula :
+        packet.repairFrontier atom ∧ ¬ action.repairSupport atom :=
+      (supportLocalRepair_frontier_eq_preFrontier_diff_support
+        hlocal hexact atom).mp hrepairSourceEndpoint
+    constructor
+    · exact hlawful.transport_laws.preservesRepair
+        packet atom hsourceFormula.1
+    · intro htransportedSupport
+      exact hsourceFormula.2
+        ((hlawful.action_naturality.support_iff atom).mp
+          htransportedSupport)
+  · intro hright
+    rcases hright with ⟨hfrontierTarget, hnotTransported⟩
+    have hfrontierSource :
+        packet.repairFrontier atom :=
+      hlawful.transport_laws.reflectsRepair packet atom hfrontierTarget
+    have hnotSource :
+        ¬ action.repairSupport atom := by
+      intro hsourceSupport
+      exact hnotTransported
+        ((hlawful.action_naturality.support_iff atom).mpr
+          hsourceSupport)
+    have hrepairSourceEndpoint :
+        (repairPacket action packet).repairFrontier atom :=
+      (supportLocalRepair_frontier_eq_preFrontier_diff_support
+        hlocal hexact atom).mpr ⟨hfrontierSource, hnotSource⟩
+    exact hlawful.transport_laws.preservesRepair
+      (repairPacket action packet) atom hrepairSourceEndpoint
+
+/--
+For transport-then-repair, the endpoint frontier is the same transported
+pre-frontier with the transported support removed.
+-/
+theorem supportLocalRepairTransport_rightFrontierRestriction
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hlocal : SupportLocalSourceRefRepair action packet)
+    (hexact : RepairFrontierExact packet)
+    (atom : CodeAtom) :
+    (transportThenRepairPacket τ transportedAction packet).repairFrontier atom ↔
+      (τ.map packet).repairFrontier atom ∧
+        ¬ transportedAction.repairSupport atom :=
+  supportLocalRepair_frontier_eq_preFrontier_diff_support
+    (transportedAction_supportLocal_of_lawful hlawful hlocal)
+    (packetTransport_repairFrontierExact
+      hlawful.transport_laws hexact)
+    atom
+
+/-- The two lawful route endpoints have the same repair frontier. -/
+theorem supportLocalRepairTransport_routeFrontiers_agree
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hlocal : SupportLocalSourceRefRepair action packet)
+    (hexact : RepairFrontierExact packet)
+    (atom : CodeAtom) :
+    (repairThenTransportPacket τ action packet).repairFrontier atom ↔
+      (transportThenRepairPacket τ transportedAction packet).repairFrontier atom :=
+  Iff.trans
+    (supportLocalRepairTransport_leftFrontierRestriction
+      hlawful hlocal hexact atom)
+    (supportLocalRepairTransport_rightFrontierRestriction
+      hlawful hlocal hexact atom).symm
+
+/-! ## Exact visualization -/
+
+/-- The lawful square still yields source-ref exact visualization of the routes. -/
+theorem supportLocalRepairTransport_sourceRefExactVisualization
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (packet : SourceRefPacket) :
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (repairThenTransportPacket τ action packet)
+      (transportThenRepairPacket τ transportedAction packet) :=
+  repairTransport_sourceRefExactVisualization_of_lawful hlawful packet
+
+/-! ## Theorem package -/
+
+/--
+Cycle-34 theorem package: lawful transport carries support-local frontier
+calculus across a repair/transport square.  Both route endpoints satisfy the
+same transported frontier restriction formula, the route frontiers agree, and
+the route visualization is source-ref exact.
+-/
+theorem supportLocalRepairTransportCommutator_package
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hlocal : SupportLocalSourceRefRepair action packet)
+    (hexact : RepairFrontierExact packet) :
+    RepairFrontierExact (τ.map packet) ∧
+      SupportLocalSourceRefRepair transportedAction (τ.map packet) ∧
+      (∀ atom,
+        (repairThenTransportPacket τ action packet).repairFrontier atom ↔
+          (τ.map packet).repairFrontier atom ∧
+            ¬ transportedAction.repairSupport atom) ∧
+      (∀ atom,
+        (transportThenRepairPacket τ transportedAction packet).repairFrontier atom ↔
+          (τ.map packet).repairFrontier atom ∧
+            ¬ transportedAction.repairSupport atom) ∧
+      (∀ atom,
+        (repairThenTransportPacket τ action packet).repairFrontier atom ↔
+          (transportThenRepairPacket τ transportedAction packet).repairFrontier atom) ∧
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (repairThenTransportPacket τ action packet)
+        (transportThenRepairPacket τ transportedAction packet) := by
+  exact ⟨packetTransport_repairFrontierExact
+      hlawful.transport_laws hexact,
+    transportedAction_supportLocal_of_lawful hlawful hlocal,
+    supportLocalRepairTransport_leftFrontierRestriction hlawful hlocal hexact,
+    supportLocalRepairTransport_rightFrontierRestriction hlawful hlocal hexact,
+    supportLocalRepairTransport_routeFrontiers_agree hlawful hlocal hexact,
+    supportLocalRepairTransport_sourceRefExactVisualization hlawful packet⟩
+
+end SupportLocalRepairTransportCommutator
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-support-local-repair-transport-frontier-commutator.md
+++ b/research/ideas/g-aat-quality-surface-01-support-local-repair-transport-frontier-commutator.md
@@ -1,0 +1,117 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: repair-potential / certificate-transport / traceability / invariance / obstruction
+expected_base_score: 65
+expected_evidence_multiplier: 2.0
+expected_final_score: 130
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle34
+tags: [quality-surface, repair, support, transport, source-ref, frontier]
+created: 2026-06-20
+cycle: 34
+lean: Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean
+---
+
+# Support-local repair/transport frontier commutator criterion
+
+## 主張
+
+Cycle 30 の `LawfulRepairTransportSquare` と Cycle 31 の `SupportLocalSourceRefRepair` を統合する。
+`τ` が lawful packet transport で、source action が packet に対して support-local なら、transported action は
+transported packet に対して support-local になる。さらに exact pre-frontier の下で、
+
+```text
+repairThenTransportPacket τ action packet
+transportThenRepairPacket τ transportedAction packet
+```
+
+の両 route endpoint は、transported pre-frontier から transported support を除いた同じ frontier formula を満たす。
+同時に Cycle 30 の source-ref exact visualization も得られる。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- Cycle 30: `Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean`
+- Cycle 31: `Formal/AG/Research/QualitySurface/SupportLocalRepairFrontier.lean`
+- Cycle 32: `Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean`
+- Cycle 33: `Formal/AG/Research/QualitySurface/SupportedTokenMismatchObstruction.lean`
+
+## 非自明性
+
+Cycle 30 は protected commutator exactness を示したが、repair support が frontier calculus として
+transport square 上でどう振る舞うかは示していない。Cycle 31 は単一 repair action の frontier restriction を
+示したが、transported action や二経路 endpoint への移送は扱っていない。
+
+この候補は、transport law と repair action naturality から support-locality 自体を移送し、両 route endpoint の
+frontier restriction を同じ transported formula として固定する。
+
+## 数学的興味
+
+repair support は単なる metadata ではなく、lawful transport 下で functorial に移送される frontier-deleting operation として振る舞う。
+Cycle 32/33 の obstruction はこの criterion の外側に位置づけられる。
+
+## GOAL への前進
+
+repair / transport / frontier / exact visualization を一つの sufficient criterion に統合し、
+support-local repair theorem を certificate transport geometry へ接続する。
+
+## SCORE 根拠
+
+- `score_reason`: G6 next frontier に直接対応する closure。Cycle 30 の exact commutator と Cycle 31 の frontier calculus を、transported support-localityと両 route frontier formulaを含む theorem に圧縮する。G2 では既存 theorem 合成に近いリスクを踏まえ、期待 base を 70 から 65 に下げた。
+- `dullness_risk`: medium。既存の `repairTransport_sourceRefExactVisualization_of_lawful` と `supportLocalRepair_frontier_eq_preFrontier_diff_support` を並べるだけなら低価値。transported support-locality、transported exact pre-frontier、両 route の同一 frontier formulaを結論に入れる。
+- `proof_or_evidence`: transported exact pre-frontier、transported support-locality、left route frontier formula、right route frontier formula、route frontier agreement、source-ref exact visualization、package theorem を Lean で証明した。
+
+## CS / SWE への帰結
+
+repair action が lawful transport と support-locality の条件を満たすとき、profile / packet view を変えても
+repair frontier の削れ方が一致する。これは repair dashboard が transport 後の frontier を再解釈するときの
+bounded correctness criterion になる。ただし canonical repair planning、source extraction completeness、実コード全体品質は主張しない。
+
+## 証明・根拠
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean`
+
+Proved declarations:
+
+- `packetTransport_repairFrontierExact`
+- `transportedAction_supportLocal_of_lawful`
+- `supportLocalRepairTransport_leftFrontierRestriction`
+- `supportLocalRepairTransport_rightFrontierRestriction`
+- `supportLocalRepairTransport_routeFrontiers_agree`
+- `supportLocalRepairTransport_sourceRefExactVisualization`
+- `supportLocalRepairTransportCommutator_package`
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/support_local_repair_transport_axioms.lean`: pass; all reported declarations depend on no axioms
+- independent axiom audit: pass; no `sorryAx`, nonstandard axioms, `propext`, `Classical.choice`, or `Quot.sound`
+- independent formalization-quality audit: pass; transported exact pre-frontier, transported support-locality, left/right route frontier formula, route frontier agreement, and source-ref exact visualization are all in the theorem package
+
+## 審判メモ
+
+- 厳密性: `accept`、base 65。`transportedAction_supportLocal_of_lawful`、`packetTransport_repairFrontierExact`、left/right route frontier formula、route frontier agreement が実 theorem として入るなら Cycle 30/31 の単なる名前替えではない。
+- 研究価値: `accept`、base 70。repair support を certificate transport 下の functorial frontier-deleting operation として読めるため、Cycle 30/31/32/33 を圧縮する。ただし existing theorem の併記なら減点。
+- repo 全体価値: `accept`、base 70。AAT の certificate transport と repair basin、Tooling の view-change frontier correctness、SFT の repair operation invariance に接続できる。transported support-locality と route frontier agreement を package に含めることが採択条件。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-support-local-repair-frontier-restriction.md`
+- `research/ideas/g-aat-quality-surface-01-outside-support-mutation-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-supported-token-mismatch-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-lawful-repair-transport-commutator.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 34 G1 で作成。二つの G1 候補生成が第一候補として挙げた。
+- 2026-06-20: G2 三審判すべて `accept`。A は既存 theorem 合成に近いリスクから base 65、B/C は base 70。picked は保守的に base 65 / final 130 とした。
+- 2026-06-20: G3 Lean verification pass。対象 Lean、`FormalAGResearch`、axiom harness が pass。
+- 2026-06-20: G3 independent axiom audit / formalization-quality audit pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 4070
+- total SCORE: 4200
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -39,8 +39,9 @@
   - repair-potential / traceability / atom-supported-quality-geometry / invariance: 130
   - obstruction / repair-potential / traceability / invariance: 120
   - obstruction / repair-potential / traceability / invariance / quality-surface: 130
+  - repair-potential / certificate-transport / traceability / invariance / obstruction: 130
 - evidence portfolio:
-  - proved-in-research: 33
+  - proved-in-research: 34
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1457,10 +1458,49 @@ Lean 証拠は次を固定する。
 分離された。主張は supplied finite source-ref packets と declared repair actions に相対化され、canonical repair planning、
 source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 34: Support-local repair/transport frontier commutator criterion
+
+```text
+candidate: Support-local repair/transport frontier commutator criterion
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 65
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 130
+category: repair-potential/certificate-transport/traceability/invariance/obstruction
+goal_delta: lawful repair/transport square と source action の support-locality から、transported support-locality、両 route の同一 frontier formula、route frontier agreement、source-ref exact visualization を導いた。
+project_value_delta: Cycle 30 の protected commutator criterion と Cycle 31 の support-local frontier calculus を、transport compatible frontier repair theorem として統合した。
+formalization_quality: pass。`transportedAction_supportLocal_of_lawful` は transported support-locality を仮定せず導出し、left/right route frontier restriction は同じ transported formula を結論する。全 declaration は axiom-free / sorry-free。
+open_questions: frontier formula minimality theorem、selected support-defect localization、lawful criterion の necessity / minimality。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean` は、
+lawful transport 下で support-local repair frontier calculus が二経路 commutator と整合することを証明する。
+仮定は supplied packet、declared source action / transported action、explicit packet update `τ`、および
+`LawfulRepairTransportSquare τ action transportedAction` と source 側の `SupportLocalSourceRefRepair action packet` に相対化される。
+
+Lean 証拠は次を固定する。
+
+- `packetTransport_repairFrontierExact`: packet transport law は `RepairFrontierExact` を transported packet へ運ぶ。
+- `transportedAction_supportLocal_of_lawful`: lawful square と source support-locality から transported action の support-locality が出る。
+- `supportLocalRepairTransport_leftFrontierRestriction`: repair-then-transport route の frontier は transported pre-frontier minus transported support である。
+- `supportLocalRepairTransport_rightFrontierRestriction`: transport-then-repair route の frontier も同じ transported formula である。
+- `supportLocalRepairTransport_routeFrontiers_agree`: 両 route endpoint の repair frontier は一致する。
+- `supportLocalRepairTransport_sourceRefExactVisualization`: lawful square は両 route の source-ref exact visualization を与える。
+- `supportLocalRepairTransportCommutator_package`: transported exact frontier、transported support-locality、left/right frontier formula、route frontier agreement、source-ref exact visualization を束ねる。
+
+この結果により、repair support は lawful transport 下で functorial に移送される frontier-deleting operation として読める。
+Cycle 32 の outside-support mutation と Cycle 33 の supported-token mismatch は、この criterion の外側に位置づけられる。
+主張は supplied finite source-ref packets、declared repair actions、explicit packet transport laws に相対化され、
+canonical transport、canonical repair planning、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 33 後の total SCORE は 4070 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 34 後の total SCORE は 4200 である。
 次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
-support-local repair/transport commutator criterion、
+frontier formula minimality theorem、
 または selected support-defect localization を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 34 として、support-local repair と lawful packet transport の commutator criterion を追加しました。

- lawful packet transport が `RepairFrontierExact` を transported packet に運ぶことを証明
- lawful square と source 側 support-locality から transported action の support-locality を導出
- repair-then-transport / transport-then-repair の両 route frontier が、同じ transported pre-frontier minus transported support formula を満たすことを証明
- route frontier agreement と source-ref exact visualization を theorem package に集約
- 候補カードと research report を SCORE +130 / total 4200 / proved-in-research 34 に同期

tracking Issue は研究状態の正本なので閉じず、`Refs #2348` のみを使っています。

## 証明した定理

- `packetTransport_repairFrontierExact`
- `transportedAction_supportLocal_of_lawful`
- `supportLocalRepairTransport_leftFrontierRestriction`
- `supportLocalRepairTransport_rightFrontierRestriction`
- `supportLocalRepairTransport_routeFrontiers_agree`
- `supportLocalRepairTransport_sourceRefExactVisualization`
- `supportLocalRepairTransportCommutator_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-support-local-repair-transport-frontier-commutator.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning 2件のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local path scan on changed public files
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
