### PR TITLE
Cycle 35 frontier-local formula minimalityを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -33,3 +33,4 @@ import Formal.AG.Research.QualitySurface.SupportLocalRepairFrontier
 import Formal.AG.Research.QualitySurface.OutsideSupportMutationObstruction
 import Formal.AG.Research.QualitySurface.SupportedTokenMismatchObstruction
 import Formal.AG.Research.QualitySurface.SupportLocalRepairTransportCommutator
+import Formal.AG.Research.QualitySurface.FrontierLocalFormulaMinimality

--- a/Formal/AG/Research/QualitySurface/FrontierLocalFormulaMinimality.lean
+++ b/Formal/AG/Research/QualitySurface/FrontierLocalFormulaMinimality.lean
@@ -1,0 +1,327 @@
+import Formal.AG.Research.QualitySurface.SupportLocalRepairFrontier
+
+/-!
+Cycle 35 evidence for `G-aat-quality-surface-01`.
+
+This file extracts the frontier-local law behind the support-local repair
+frontier formula.  The law is stated at the missing-locus level: supported
+repair atoms are cleared from the post missing locus, and outside the declared
+repair support the missing locus is preserved and reflected.  This criterion is
+equivalent to the post-frontier formula under exact pre-frontiers, follows from
+the table-level `SupportLocalSourceRefRepair` law, and is strictly weaker than
+that table-level law.  The result is relative to supplied finite source-ref
+packets and declared repair actions; it does not assert canonical repair
+planning, source extraction completeness, ArchMap correctness, source-ref exact
+visualization, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace FrontierLocalFormulaMinimality
+
+open CodebaseTracePacket
+open CodebaseTraceRepairTrajectory
+open SupportLocalRepairFrontier
+
+/-! ## Frontier-local repair law -/
+
+/--
+A repair action is frontier-local when it has exactly the missing-locus behavior
+needed for the support-local frontier formula: it clears supported repair atoms
+from the post missing locus and preserves/refects missingness outside its
+declared repair support.
+
+This is intentionally weaker than table-level source-ref preservation: outside
+support, token identity may change as long as missingness is unchanged.
+-/
+structure FrontierLocalSourceRefRepair
+    (action : SourceRefRepairAction) (packet : SourceRefPacket) : Prop where
+  clearsSupportedMissing :
+    ∀ atom, packet.codeSupport atom -> action.repairSupport atom ->
+      ¬ SourceRefMissingLocus (repairPacket action packet) atom
+  preservesOutsideMissing :
+    ∀ atom, ¬ action.repairSupport atom ->
+      (SourceRefMissingLocus (repairPacket action packet) atom ↔
+        SourceRefMissingLocus packet atom)
+
+/--
+The table-level support-local law of Cycle 31 implies the frontier-local law.
+-/
+theorem supportLocal_implies_frontierLocal
+    {action : SourceRefRepairAction} {packet : SourceRefPacket}
+    (hlocal : SupportLocalSourceRefRepair action packet) :
+    FrontierLocalSourceRefRepair action packet where
+  clearsSupportedMissing := by
+    intro atom hsupport hrepair
+    exact hlocal.supported_atoms_not_missing hsupport hrepair
+  preservesOutsideMissing := by
+    intro atom hout
+    exact hlocal.outside_preserves_missing_iff hout
+
+/-! ## Frontier-locality is the sharp formula criterion -/
+
+/--
+Under an exact pre-frontier, frontier-locality gives the post-frontier formula:
+post frontier is pre frontier with the declared support removed.
+-/
+theorem frontierLocal_frontierRestriction
+    {action : SourceRefRepairAction} {packet : SourceRefPacket}
+    (hfrontier : FrontierLocalSourceRefRepair action packet)
+    (hexact : RepairFrontierExact packet)
+    (atom : CodeAtom) :
+    (repairPacket action packet).repairFrontier atom ↔
+      packet.repairFrontier atom ∧ ¬ action.repairSupport atom := by
+  constructor
+  · intro hpost
+    have hout : ¬ action.repairSupport atom := by
+      intro hrepair
+      exact hfrontier.clearsSupportedMissing atom hpost.1 hrepair hpost
+    have hmissingPre :
+        SourceRefMissingLocus packet atom :=
+      (hfrontier.preservesOutsideMissing atom hout).mp hpost
+    exact ⟨(hexact atom).mpr hmissingPre, hout⟩
+  · intro hpre
+    rcases hpre with ⟨hfrontierPre, hout⟩
+    have hmissingPre :
+        SourceRefMissingLocus packet atom :=
+      (hexact atom).mp hfrontierPre
+    exact (hfrontier.preservesOutsideMissing atom hout).mpr hmissingPre
+
+/--
+Conversely, under an exact pre-frontier, the post-frontier formula implies the
+frontier-local missing-locus law.
+-/
+theorem frontierRestriction_implies_frontierLocal
+    {action : SourceRefRepairAction} {packet : SourceRefPacket}
+    (hexact : RepairFrontierExact packet)
+    (hformula :
+      ∀ atom,
+        (repairPacket action packet).repairFrontier atom ↔
+          packet.repairFrontier atom ∧ ¬ action.repairSupport atom) :
+    FrontierLocalSourceRefRepair action packet where
+  clearsSupportedMissing := by
+    intro atom _hsupport hrepair hmissingPost
+    have hout :
+        ¬ action.repairSupport atom :=
+      ((hformula atom).mp hmissingPost).2
+    exact hout hrepair
+  preservesOutsideMissing := by
+    intro atom hout
+    constructor
+    · intro hmissingPost
+      have hfrontierPre :
+          packet.repairFrontier atom :=
+        ((hformula atom).mp hmissingPost).1
+      exact (hexact atom).mp hfrontierPre
+    · intro hmissingPre
+      have hfrontierPre :
+          packet.repairFrontier atom :=
+        (hexact atom).mpr hmissingPre
+      exact (hformula atom).mpr ⟨hfrontierPre, hout⟩
+
+/--
+For exact pre-frontiers, frontier-locality is equivalent to the support-deleting
+post-frontier formula.
+-/
+theorem frontierLocal_iff_frontierRestriction
+    {action : SourceRefRepairAction} {packet : SourceRefPacket}
+    (hexact : RepairFrontierExact packet) :
+    FrontierLocalSourceRefRepair action packet ↔
+      ∀ atom,
+        (repairPacket action packet).repairFrontier atom ↔
+          packet.repairFrontier atom ∧ ¬ action.repairSupport atom := by
+  constructor
+  · intro hfrontier atom
+    exact frontierLocal_frontierRestriction hfrontier hexact atom
+  · intro hformula
+    exact frontierRestriction_implies_frontierLocal hexact hformula
+
+/-! ## Strictness witness: frontier-local is weaker than table-local -/
+
+/--
+A repair action that fills the storage frontier but renames the endpoint token
+outside the declared repair support.  Missingness is preserved outside support,
+but table identity is not.
+-/
+def tokenRenamingOutsideStorageRepairAction : SourceRefRepairAction where
+  repairSupport := storageRepairFrontier
+  repairedSourceRefTable
+    | CodeAtom.endpoint => some SourceRefToken.workerRef
+    | CodeAtom.storage => some SourceRefToken.storageRef
+    | CodeAtom.worker => some SourceRefToken.workerRef
+  repairedObligation := StateSeparation.ObligationKind.none
+
+/-- The finite packet obtained from the token-renaming action. -/
+def tokenRenamingOutsideStorageRepairPacket : SourceRefPacket :=
+  repairPacket tokenRenamingOutsideStorageRepairAction partialPacket
+
+/-- The token-renaming action is frontier-local. -/
+theorem tokenRenaming_frontierLocal :
+    FrontierLocalSourceRefRepair
+      tokenRenamingOutsideStorageRepairAction partialPacket where
+  clearsSupportedMissing := by
+    intro atom _hsupport hrepair hmissing
+    change atom = CodeAtom.storage at hrepair
+    cases hrepair
+    rcases hmissing with ⟨_hsupportPost, hnone⟩
+    change some SourceRefToken.storageRef = none at hnone
+    cases hnone
+  preservesOutsideMissing := by
+    intro atom hout
+    constructor
+    · intro hmissing
+      rcases hmissing with ⟨_hsupport, hnone⟩
+      cases atom with
+      | endpoint =>
+          change some SourceRefToken.workerRef = none at hnone
+          cases hnone
+      | storage =>
+          exact False.elim (hout rfl)
+      | worker =>
+          change some SourceRefToken.workerRef = none at hnone
+          cases hnone
+    · intro hmissing
+      rcases hmissing with ⟨_hsupport, hnone⟩
+      cases atom with
+      | endpoint =>
+          change some SourceRefToken.endpointRef = none at hnone
+          cases hnone
+      | storage =>
+          exact False.elim (hout rfl)
+      | worker =>
+          change some SourceRefToken.workerRef = none at hnone
+          cases hnone
+
+/-- The token-renaming action still satisfies the frontier restriction formula. -/
+theorem tokenRenaming_frontierRestriction
+    (atom : CodeAtom) :
+    tokenRenamingOutsideStorageRepairPacket.repairFrontier atom ↔
+      partialPacket.repairFrontier atom ∧
+        ¬ tokenRenamingOutsideStorageRepairAction.repairSupport atom :=
+  frontierLocal_frontierRestriction
+    tokenRenaming_frontierLocal partialTrace_repairFrontierExact atom
+
+/--
+The token-renaming action is not table-level support-local: it changes the
+endpoint source-ref token outside its declared storage support.
+-/
+theorem tokenRenaming_not_supportLocal :
+    ¬ SupportLocalSourceRefRepair
+      tokenRenamingOutsideStorageRepairAction partialPacket := by
+  intro hlocal
+  have hout :
+      ¬ tokenRenamingOutsideStorageRepairAction.repairSupport
+        CodeAtom.endpoint := by
+    intro h
+    cases h
+  have hpreserve := hlocal.preservesOutsideSupport CodeAtom.endpoint hout
+  change some SourceRefToken.workerRef =
+    some SourceRefToken.endpointRef at hpreserve
+  cases hpreserve
+
+/-! ## The two frontier-formula conjuncts are both necessary -/
+
+/--
+The `¬ repairSupport` conjunct is necessary: storage is in the pre-frontier and
+in the declared repair support, but it is not in the post frontier.
+-/
+theorem frontierFormula_outsideSupportConjunct_is_necessary :
+    ∃ atom,
+      partialPacket.repairFrontier atom ∧
+        storageRepairAction.repairSupport atom ∧
+        ¬ storageRepairPacket.repairFrontier atom := by
+  refine ⟨CodeAtom.storage, ?_⟩
+  constructor
+  · exact partialTrace_forces_storage_repair
+  constructor
+  · rfl
+  · intro hpost
+    exact repairTrajectory_repairFrontier_collapses
+      ⟨CodeAtom.storage, hpost⟩
+
+/--
+The pre-frontier conjunct is necessary: endpoint is outside the declared repair
+support, but it was not in the pre-frontier and is not in the post frontier.
+-/
+theorem frontierFormula_preFrontierConjunct_is_necessary :
+    ∃ atom,
+      ¬ storageRepairAction.repairSupport atom ∧
+        ¬ partialPacket.repairFrontier atom ∧
+        ¬ storageRepairPacket.repairFrontier atom := by
+  refine ⟨CodeAtom.endpoint, ?_⟩
+  constructor
+  · intro h
+    change CodeAtom.endpoint = CodeAtom.storage at h
+    cases h
+  constructor
+  · intro h
+    change CodeAtom.endpoint = CodeAtom.storage at h
+    cases h
+  · intro hpost
+    exact repairTrajectory_repairFrontier_collapses
+      ⟨CodeAtom.endpoint, hpost⟩
+
+/-- The two conjuncts of the support-deleting frontier formula are independent. -/
+theorem frontierFormula_conjuncts_are_independent :
+    (∃ atom,
+      partialPacket.repairFrontier atom ∧
+        storageRepairAction.repairSupport atom ∧
+        ¬ storageRepairPacket.repairFrontier atom) ∧
+      (∃ atom,
+        ¬ storageRepairAction.repairSupport atom ∧
+          ¬ partialPacket.repairFrontier atom ∧
+          ¬ storageRepairPacket.repairFrontier atom) := by
+  exact ⟨frontierFormula_outsideSupportConjunct_is_necessary,
+    frontierFormula_preFrontierConjunct_is_necessary⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-35 theorem package: frontier-locality is the sharp missing-locus law for
+the support-deleting frontier formula.  It follows from table-level
+support-locality, is equivalent to the frontier formula under exact
+pre-frontiers, is strictly weaker than table-level support-locality, and both
+formula conjuncts are necessary.
+-/
+theorem frontierLocalFormulaMinimality_package :
+    (∀ {action : SourceRefRepairAction} {packet : SourceRefPacket},
+      SupportLocalSourceRefRepair action packet ->
+        FrontierLocalSourceRefRepair action packet) ∧
+      (∀ {action : SourceRefRepairAction} {packet : SourceRefPacket},
+        RepairFrontierExact packet ->
+          (FrontierLocalSourceRefRepair action packet ↔
+            ∀ atom,
+              (repairPacket action packet).repairFrontier atom ↔
+                packet.repairFrontier atom ∧
+                  ¬ action.repairSupport atom)) ∧
+      FrontierLocalSourceRefRepair
+        tokenRenamingOutsideStorageRepairAction partialPacket ∧
+      (∀ atom,
+        tokenRenamingOutsideStorageRepairPacket.repairFrontier atom ↔
+          partialPacket.repairFrontier atom ∧
+            ¬ tokenRenamingOutsideStorageRepairAction.repairSupport atom) ∧
+      ¬ SupportLocalSourceRefRepair
+        tokenRenamingOutsideStorageRepairAction partialPacket ∧
+      (∃ atom,
+        partialPacket.repairFrontier atom ∧
+          storageRepairAction.repairSupport atom ∧
+          ¬ storageRepairPacket.repairFrontier atom) ∧
+      (∃ atom,
+        ¬ storageRepairAction.repairSupport atom ∧
+          ¬ partialPacket.repairFrontier atom ∧
+          ¬ storageRepairPacket.repairFrontier atom) := by
+  exact ⟨by
+      intro action packet hlocal
+      exact supportLocal_implies_frontierLocal hlocal,
+    by
+      intro action packet hexact
+      exact frontierLocal_iff_frontierRestriction hexact,
+    tokenRenaming_frontierLocal,
+    tokenRenaming_frontierRestriction,
+    tokenRenaming_not_supportLocal,
+    frontierFormula_outsideSupportConjunct_is_necessary,
+    frontierFormula_preFrontierConjunct_is_necessary⟩
+
+end FrontierLocalFormulaMinimality
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-frontier-local-formula-minimality.md
+++ b/research/ideas/g-aat-quality-surface-01-frontier-local-formula-minimality.md
@@ -1,0 +1,131 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: repair-potential / obstruction / traceability / invariance
+expected_base_score: 75
+expected_evidence_multiplier: 2.0
+expected_final_score: 150
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle35
+tags: [quality-surface, repair, support, frontier, minimality, source-ref]
+created: 2026-06-20
+cycle: 35
+lean: Formal/AG/Research/QualitySurface/FrontierLocalFormulaMinimality.lean
+---
+
+# Frontier-local formula minimality criterion
+
+## 主張
+
+Cycle 31 の `SupportLocalSourceRefRepair` は、source-ref table を support 外で保存する table-level law として
+post-frontier formula を導いた。
+
+Cycle 35 では、exact pre-frontier の下で
+
+```text
+(repairPacket action packet).repairFrontier atom
+  ↔ packet.repairFrontier atom ∧ ¬ action.repairSupport atom
+```
+
+が成立するための frontier-level law を切り出す。必要な構造は次の二つである。
+
+- support 上では post missing locus を消すこと。
+- support 外では missing locus を保存・反映すること。
+
+この `FrontierLocalSourceRefRepair` は `SupportLocalSourceRefRepair` から従うが、source-ref table の
+token identity を support 外で保存することまでは要求しない。したがって table-level support-locality より弱く、
+frontier formula に対して sharp な criterion である。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- Cycle 21: `Formal/AG/Research/QualitySurface/CodebaseTraceRepairTrajectory.lean`
+- Cycle 31: `Formal/AG/Research/QualitySurface/SupportLocalRepairFrontier.lean`
+- Cycle 32: `Formal/AG/Research/QualitySurface/OutsideSupportMutationObstruction.lean`
+- Cycle 34: `Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean`
+
+## 非自明性
+
+Cycle 31 は十分条件を与えたが、その仮定が frontier formula に対して最小かどうかは示していない。
+Cycle 32 は outside-support mutation が frontier formula を壊すことを示したが、frontier formula そのものに必要十分な
+law は切り出していない。
+
+この候補は、table equality を要求する `SupportLocalSourceRefRepair` と、frontier formula に本当に必要な
+missing-locus law を分離する。さらに、support 外の token identity を変えても missing locus を保存する有限 witness により、
+frontier-local law が table-local law より真に弱いことを固定する。
+
+## 数学的興味
+
+repair frontier は source-ref table 全体ではなく、missing locus と repair support の相互作用だけを読む。
+この結果は、frontier geometry の最小構造を table-level traceability law から切り離し、repair support を
+frontier-deleting operation として sharp に定式化する。
+
+## GOAL への前進
+
+support-local repair theorem を十分条件から frontier-local な必要十分 criterion へ進め、
+repair-potential / obstruction / traceability / invariance の境界を鋭くする。
+
+## SCORE 根拠
+
+- `score_reason`: Cycle 31 の positive theorem と Cycle 32 の obstruction を、frontier formula の sharp criterion として再定式化する。`SupportLocalSourceRefRepair -> FrontierLocalSourceRefRepair`、frontier formula との iff、table-locality より弱い有限 witness をすべて Lean で固定する。ただし `frontierLocal_iff_frontierRestriction` 自体は `RepairFrontierExact` と `repairPacket` の定義から直接的でもあるため、G2 厳密性審判に合わせて base 75 / final 150 とする。
+- `dullness_risk`: medium。既存 formula の再掲に落ちる危険があるため、必要十分性、strictness witness、conjunct minimality を theorem package に入れる。
+- `proof_or_evidence`: `FrontierLocalSourceRefRepair` を formula の直定義ではなく missing-locus law として定義し、support-locality からの導出、frontier formula との同値、token-renaming witness による `FrontierLocalSourceRefRepair ∧ ¬ SupportLocalSourceRefRepair`、pre-frontier conjunct / outside-support conjunct の独立 witness、package theorem を Lean で証明した。
+
+## CS / SWE への帰結
+
+repair dashboard が frontier だけを扱う場合、source-ref token identity の完全保存までは必要条件ではない。
+一方で exact visualization や traceability surface では token identity が必要になる。frontier-local correctness と
+table-local trace correctness を分けることで、repair UI / analysis packet がどの保証を表示しているかを明確にできる。
+
+## 証明・根拠
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/FrontierLocalFormulaMinimality.lean`
+
+Proved declarations:
+
+- `FrontierLocalSourceRefRepair`
+- `supportLocal_implies_frontierLocal`
+- `frontierLocal_frontierRestriction`
+- `frontierLocal_iff_frontierRestriction`
+- `frontierRestriction_implies_frontierLocal`
+- `tokenRenamingOutsideStorageRepairAction`
+- `tokenRenamingOutsideStorageRepairPacket`
+- `tokenRenaming_frontierLocal`
+- `tokenRenaming_frontierRestriction`
+- `tokenRenaming_not_supportLocal`
+- `frontierFormula_preFrontierConjunct_is_necessary`
+- `frontierFormula_outsideSupportConjunct_is_necessary`
+- `frontierFormula_conjuncts_are_independent`
+- `frontierLocalFormulaMinimality_package`
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/FrontierLocalFormulaMinimality.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/frontier_local_formula_minimality_axioms.lean`: pass; all reported declarations depend on no axioms
+- `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal/AG/Research/QualitySurface/FrontierLocalFormulaMinimality.lean`: pass; no hits
+
+## 審判メモ
+
+- 厳密性: `accept`、base 75。claim boundary は有限 `SourceRefPacket` / declared repair action / missing locus / repair frontier に収まる。`FrontierLocalSourceRefRepair` は formula の直定義ではなく、support 上 clearing と support 外 missing-locus preserve/reflect の law として定義することが採択条件。
+- 研究価値: `accept`、base 80。Cycle 31/32/33/34 を frontier-local law に圧縮する価値がある。base 80 を保つには strictness witness と conjunct minimality が必要。
+- repo 全体価値: `accept`、base 80。Research / Lean / paper seed として価値があり、repair UI / analysis packet で frontier-local correctness と table-local trace correctness を分ける将来 surface に接続する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-support-local-repair-frontier-restriction.md`
+- `research/ideas/g-aat-quality-surface-01-outside-support-mutation-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-supported-token-mismatch-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-support-local-repair-transport-frontier-commutator.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 35 G1 で作成。二つの G1 候補生成が最上位候補として挙げ、scratch Lean feasibility check が pass。
+- 2026-06-20: G2 三審判すべて `accept`。A は直接性リスクから base 75、B/C は base 80。picked は保守的に base 75 / final 150 とした。
+- 2026-06-20: G3 Lean verification pass。対象 Lean、`FormalAGResearch`、axiom harness が pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 4200
+- total SCORE: 4350
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -40,8 +40,9 @@
   - obstruction / repair-potential / traceability / invariance: 120
   - obstruction / repair-potential / traceability / invariance / quality-surface: 130
   - repair-potential / certificate-transport / traceability / invariance / obstruction: 130
+  - repair-potential / obstruction / traceability / invariance: 150
 - evidence portfolio:
-  - proved-in-research: 34
+  - proved-in-research: 35
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1497,10 +1498,55 @@ Cycle 32 の outside-support mutation と Cycle 33 の supported-token mismatch 
 主張は supplied finite source-ref packets、declared repair actions、explicit packet transport laws に相対化され、
 canonical transport、canonical repair planning、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 35: Frontier-local formula minimality criterion
+
+```text
+candidate: Frontier-local formula minimality criterion
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 75
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 150
+category: repair-potential/obstruction/traceability/invariance
+goal_delta: support-local repair frontier formula に必要な missing-locus law を切り出し、table-level support-locality より弱い frontier-local criterion として固定した。
+project_value_delta: Cycle 31 の table-level sufficient condition、Cycle 32 の outside-support obstruction、Cycle 34 の transport-compatible frontier formula を、frontier-local correctness と table-local trace correctness の境界として整理した。
+formalization_quality: pass。`FrontierLocalSourceRefRepair` は formula の直定義ではなく support 上 clearing と support 外 missing-locus preserve/reflect として定義され、strictness witness と二 conjunct necessity を含む。全 declaration は axiom-free / sorry-free。
+open_questions: lawful repair/transport criterion minimality matrix、selected support-defect localization、selected commutator defect localization。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/FrontierLocalFormulaMinimality.lean` は、
+frontier formula に本当に必要な repair law を missing-locus level で抽出する。
+`FrontierLocalSourceRefRepair` は、declared repair support 上で post missing locus を消し、
+support 外で missing locus を保存・反映する law である。これは table-level の token identity preservation を要求しない。
+
+Lean 証拠は次を固定する。
+
+- `FrontierLocalSourceRefRepair`: formula そのものではなく、support 上 clearing と support 外 missing-locus preserve/reflect を持つ frontier-local law。
+- `supportLocal_implies_frontierLocal`: Cycle 31 の `SupportLocalSourceRefRepair` は frontier-local law を含意する。
+- `frontierLocal_frontierRestriction`: exact pre-frontier の下で frontier-local law は post frontier = pre frontier minus declared support を導く。
+- `frontierRestriction_implies_frontierLocal`: 同じ exactness 仮定の下で、frontier formula は frontier-local law を反映する。
+- `frontierLocal_iff_frontierRestriction`: exact pre-frontier に相対化した必要十分 criterion。
+- `tokenRenamingOutsideStorageRepairAction` / `tokenRenamingOutsideStorageRepairPacket`: support 外 endpoint token を rename する有限 witness。
+- `tokenRenaming_frontierLocal` / `tokenRenaming_frontierRestriction`: token-renaming witness は missingness と frontier formula を保つ。
+- `tokenRenaming_not_supportLocal`: 同じ witness は support 外 table identity を破るため table-level support-locality を満たさない。
+- `frontierFormula_outsideSupportConjunct_is_necessary`: declared support に属する pre-frontier atom は post frontier から消えるため、`¬ repairSupport` conjunct が必要である。
+- `frontierFormula_preFrontierConjunct_is_necessary`: repair support 外であっても pre-frontier でない atom は post frontier に入らないため、pre-frontier conjunct が必要である。
+- `frontierFormula_conjuncts_are_independent`: 二つの conjunct の独立 witness を束ねる。
+- `frontierLocalFormulaMinimality_package`: frontier-local criterion、strictness witness、conjunct necessity を束ねる。
+
+この結果により、frontier-local correctness と table-local trace correctness は分離された。
+repair dashboard が frontier だけを保証する場合、source-ref token identity の完全保存までは要求しない。
+一方で source-ref exact visualization や traceability surface では token identity が別途必要である。
+主張は supplied finite source-ref packets と declared repair actions に相対化され、canonical repair planning、
+source extraction completeness、ArchMap correctness、source-ref exact visualization、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 34 後の total SCORE は 4200 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 35 後の total SCORE は 4350 である。
 次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
-frontier formula minimality theorem、
+lawful repair/transport criterion minimality matrix、
 または selected support-defect localization を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 35 として、support-local repair frontier formula の frontier-local minimality criterion を追加しました。

- `FrontierLocalSourceRefRepair` を formula 直定義ではなく missing-locus law として定義
- `SupportLocalSourceRefRepair -> FrontierLocalSourceRefRepair` を証明
- exact pre-frontier の下で frontier-local law と post-frontier formula が同値であることを証明
- token-renaming witness により frontier-local law が table-level support-locality より真に弱いことを証明
- pre-frontier conjunct / outside-support conjunct の必要性 witness を追加
- 候補カードと research report を SCORE +150 / total 4350 / proved-in-research 35 に同期

tracking Issue は研究状態の正本なので閉じず、`Refs #2348` のみを使っています。

## 証明した定理

- `FrontierLocalSourceRefRepair`
- `supportLocal_implies_frontierLocal`
- `frontierLocal_frontierRestriction`
- `frontierRestriction_implies_frontierLocal`
- `frontierLocal_iff_frontierRestriction`
- `tokenRenamingOutsideStorageRepairAction`
- `tokenRenamingOutsideStorageRepairPacket`
- `tokenRenaming_frontierLocal`
- `tokenRenaming_frontierRestriction`
- `tokenRenaming_not_supportLocal`
- `frontierFormula_outsideSupportConjunct_is_necessary`
- `frontierFormula_preFrontierConjunct_is_necessary`
- `frontierFormula_conjuncts_are_independent`
- `frontierLocalFormulaMinimality_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-frontier-local-formula-minimality.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/FrontierLocalFormulaMinimality.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/frontier_local_formula_minimality_axioms.lean`
- [x] `lake build`（成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning 2件のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local path scan on changed public files
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
