### PR TITLE
研究ループ Cycle 36 frontier-local transport

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -34,3 +34,4 @@ import Formal.AG.Research.QualitySurface.OutsideSupportMutationObstruction
 import Formal.AG.Research.QualitySurface.SupportedTokenMismatchObstruction
 import Formal.AG.Research.QualitySurface.SupportLocalRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.FrontierLocalFormulaMinimality
+import Formal.AG.Research.QualitySurface.FrontierLocalRepairTransportCommutator

--- a/Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean
+++ b/Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean
@@ -1,0 +1,388 @@
+import Formal.AG.Research.QualitySurface.SupportLocalRepairTransportCommutator
+import Formal.AG.Research.QualitySurface.FrontierLocalFormulaMinimality
+
+/-!
+Cycle 36 evidence for `G-aat-quality-surface-01`.
+
+This file lowers the support-local hypothesis in the repair/transport
+frontier commutator from Cycle 34 to the missing-locus level isolated in
+Cycle 35.  In a lawful repair/transport square, frontier-locality transports
+from the source repair action to the transported action.  Therefore both route
+endpoints satisfy the same transported frontier formula, while source-ref exact
+visualization remains a separate lawful-square conclusion.
+
+The final witness places the Cycle 35 token-renaming action inside an identity
+lawful square.  It is frontier-local and satisfies the route frontier formula,
+but it is not table-level support-local.  Thus the Cycle 36 criterion strictly
+weakens the Cycle 34 support-local hypothesis for frontier-route correctness.
+The claim is relative to supplied finite source-ref packets, declared repair
+actions, exact pre-frontiers, and explicit packet transport laws; it does not
+assert canonical transport, canonical repair planning, source extraction
+completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace FrontierLocalRepairTransportCommutator
+
+open CodebaseTracePacket
+open CodebaseTraceRepairTrajectory
+open SourceRefPacketTransport
+open SourceRefExactVisualizationCriterion
+open LawfulRepairTransportCommutator
+open SupportLocalRepairFrontier
+open SupportLocalRepairTransportCommutator
+open FrontierLocalFormulaMinimality
+
+/-! ## Transporting frontier-locality -/
+
+/--
+In a lawful repair/transport square, frontier-locality of the source action
+transports to frontier-locality of the transported action.
+-/
+theorem transportedAction_frontierLocal_of_lawful
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hfrontier : FrontierLocalSourceRefRepair action packet) :
+    FrontierLocalSourceRefRepair transportedAction (τ.map packet) where
+  clearsSupportedMissing := by
+    intro atom hsupportTarget hrepairTransported hmissingTargetPost
+    have hsupportSource :
+        packet.codeSupport atom :=
+      hlawful.transport_laws.reflectsSupport packet atom hsupportTarget
+    have hrepairSource :
+        action.repairSupport atom :=
+      (hlawful.action_naturality.support_iff atom).mp hrepairTransported
+    have hsourceNone :
+        action.repairedSourceRefTable atom = none := by
+      rcases hmissingTargetPost with ⟨_hsupportPost, hnoneTarget⟩
+      change transportedAction.repairedSourceRefTable atom = none at hnoneTarget
+      rw [hlawful.action_naturality.table_eq atom] at hnoneTarget
+      exact hnoneTarget
+    exact hfrontier.clearsSupportedMissing atom
+      hsupportSource hrepairSource ⟨hsupportSource, hsourceNone⟩
+  preservesOutsideMissing := by
+    intro atom hnotTransported
+    have hnotSource :
+        ¬ action.repairSupport atom := by
+      intro hsourceSupport
+      exact hnotTransported
+        ((hlawful.action_naturality.support_iff atom).mpr hsourceSupport)
+    constructor
+    · intro hmissingTargetPost
+      rcases hmissingTargetPost with ⟨hsupportTarget, hnoneTarget⟩
+      have hsupportSource :
+          packet.codeSupport atom :=
+        hlawful.transport_laws.reflectsSupport packet atom hsupportTarget
+      have hsourceNone :
+          action.repairedSourceRefTable atom = none := by
+        change transportedAction.repairedSourceRefTable atom = none at hnoneTarget
+        rw [hlawful.action_naturality.table_eq atom] at hnoneTarget
+        exact hnoneTarget
+      have hmissingSourcePost :
+          SourceRefMissingLocus (repairPacket action packet) atom :=
+        ⟨hsupportSource, hsourceNone⟩
+      have hmissingSource :
+          SourceRefMissingLocus packet atom :=
+        (hfrontier.preservesOutsideMissing atom hnotSource).mp
+          hmissingSourcePost
+      exact hlawful.transport_laws.preservesMissing
+        packet atom hmissingSource
+    · intro hmissingTarget
+      have hmissingSource :
+          SourceRefMissingLocus packet atom :=
+        hlawful.transport_laws.reflectsMissing packet atom hmissingTarget
+      have hmissingSourcePost :
+          SourceRefMissingLocus (repairPacket action packet) atom :=
+        (hfrontier.preservesOutsideMissing atom hnotSource).mpr
+          hmissingSource
+      rcases hmissingSourcePost with ⟨_hsupportSource, hnoneSource⟩
+      refine ⟨hmissingTarget.1, ?_⟩
+      change transportedAction.repairedSourceRefTable atom = none
+      rw [hlawful.action_naturality.table_eq atom]
+      exact hnoneSource
+
+/-! ## Route frontier formulas -/
+
+/--
+For repair-then-transport, frontier-locality is enough to identify the
+endpoint frontier with the transported pre-frontier minus transported support.
+-/
+theorem frontierLocalRepairTransport_leftFrontierRestriction
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hfrontier : FrontierLocalSourceRefRepair action packet)
+    (hexact : RepairFrontierExact packet)
+    (atom : CodeAtom) :
+    (repairThenTransportPacket τ action packet).repairFrontier atom ↔
+      (τ.map packet).repairFrontier atom ∧
+        ¬ transportedAction.repairSupport atom := by
+  constructor
+  · intro hleft
+    have hrepairSourceEndpoint :
+        (repairPacket action packet).repairFrontier atom :=
+      hlawful.transport_laws.reflectsRepair
+        (repairPacket action packet) atom hleft
+    have hsourceFormula :
+        packet.repairFrontier atom ∧ ¬ action.repairSupport atom :=
+      (frontierLocal_frontierRestriction hfrontier hexact atom).mp
+        hrepairSourceEndpoint
+    constructor
+    · exact hlawful.transport_laws.preservesRepair
+        packet atom hsourceFormula.1
+    · intro htransportedSupport
+      exact hsourceFormula.2
+        ((hlawful.action_naturality.support_iff atom).mp
+          htransportedSupport)
+  · intro hright
+    rcases hright with ⟨hfrontierTarget, hnotTransported⟩
+    have hfrontierSource :
+        packet.repairFrontier atom :=
+      hlawful.transport_laws.reflectsRepair packet atom hfrontierTarget
+    have hnotSource :
+        ¬ action.repairSupport atom := by
+      intro hsourceSupport
+      exact hnotTransported
+        ((hlawful.action_naturality.support_iff atom).mpr
+          hsourceSupport)
+    have hrepairSourceEndpoint :
+        (repairPacket action packet).repairFrontier atom :=
+      (frontierLocal_frontierRestriction hfrontier hexact atom).mpr
+        ⟨hfrontierSource, hnotSource⟩
+    exact hlawful.transport_laws.preservesRepair
+      (repairPacket action packet) atom hrepairSourceEndpoint
+
+/--
+For transport-then-repair, the transported action satisfies the same
+frontier-local formula.
+-/
+theorem frontierLocalRepairTransport_rightFrontierRestriction
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hfrontier : FrontierLocalSourceRefRepair action packet)
+    (hexact : RepairFrontierExact packet)
+    (atom : CodeAtom) :
+    (transportThenRepairPacket τ transportedAction packet).repairFrontier atom ↔
+      (τ.map packet).repairFrontier atom ∧
+        ¬ transportedAction.repairSupport atom :=
+  frontierLocal_frontierRestriction
+    (transportedAction_frontierLocal_of_lawful hlawful hfrontier)
+    (packetTransport_repairFrontierExact
+      hlawful.transport_laws hexact)
+    atom
+
+/-- The two route endpoints have the same repair frontier. -/
+theorem frontierLocalRepairTransport_routeFrontiers_agree
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hfrontier : FrontierLocalSourceRefRepair action packet)
+    (hexact : RepairFrontierExact packet)
+    (atom : CodeAtom) :
+    (repairThenTransportPacket τ action packet).repairFrontier atom ↔
+      (transportThenRepairPacket τ transportedAction packet).repairFrontier atom :=
+  Iff.trans
+    (frontierLocalRepairTransport_leftFrontierRestriction
+      hlawful hfrontier hexact atom)
+    (frontierLocalRepairTransport_rightFrontierRestriction
+      hlawful hfrontier hexact atom).symm
+
+/-! ## Exact visualization remains a lawful-square conclusion -/
+
+/-- The lawful square still yields source-ref exact visualization of the routes. -/
+theorem frontierLocalRepairTransport_sourceRefExactVisualization
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (packet : SourceRefPacket) :
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (repairThenTransportPacket τ action packet)
+      (transportThenRepairPacket τ transportedAction packet) :=
+  repairTransport_sourceRefExactVisualization_of_lawful hlawful packet
+
+/-! ## Identity lawful square for the strict weakening witness -/
+
+/-- Identity packet update used to place the Cycle 35 witness in a lawful square. -/
+def identitySourceRefPacketUpdate : PacketUpdate where
+  map := fun packet => packet
+
+/-- Identity packet update satisfies all bidirectional source-ref transport laws. -/
+theorem identitySourceRefPacketTransport_lawful :
+    BidirectionalSourceRefPacketTransport identitySourceRefPacketUpdate where
+  preservesSupport := by
+    intro packet atom hsupport
+    exact hsupport
+  reflectsSupport := by
+    intro packet atom hsupport
+    exact hsupport
+  preservesMissing := by
+    intro packet atom hmissing
+    exact hmissing
+  reflectsMissing := by
+    intro packet atom hmissing
+    exact hmissing
+  preservesRepair := by
+    intro packet atom hrepair
+    exact hrepair
+  reflectsRepair := by
+    intro packet atom hrepair
+    exact hrepair
+  preservesSourceRefTable := by
+    intro packet atom
+    rfl
+
+/-- Any repair action is naturally transported to itself. -/
+theorem self_repairActionTransportNaturality
+    (action : SourceRefRepairAction) :
+    RepairActionTransportNaturality action action where
+  support_iff := by
+    intro atom
+    rfl
+  table_eq := by
+    intro atom
+    rfl
+  obligation_eq := rfl
+
+/--
+The Cycle 35 token-renaming action forms a lawful square with identity packet
+transport, even though it is not table-level support-local for `partialPacket`.
+-/
+theorem tokenRenaming_identity_lawfulSquare :
+    LawfulRepairTransportSquare
+      identitySourceRefPacketUpdate
+      tokenRenamingOutsideStorageRepairAction
+      tokenRenamingOutsideStorageRepairAction where
+  transport_laws := identitySourceRefPacketTransport_lawful
+  visible_preserves := by
+    intro packet
+    exact ⟨rfl, rfl⟩
+  obligation_preserves := by
+    intro packet
+    rfl
+  action_naturality :=
+    self_repairActionTransportNaturality
+      tokenRenamingOutsideStorageRepairAction
+
+/--
+The frontier-local commutator criterion strictly weakens the Cycle 34
+support-local hypothesis: the token-renaming witness is frontier-local inside
+a lawful identity square, satisfies both route frontier formulas, but is not
+table-level support-local.
+-/
+theorem frontierLocalRepairTransport_strictlyWeakens_supportLocalHypothesis :
+    LawfulRepairTransportSquare
+        identitySourceRefPacketUpdate
+        tokenRenamingOutsideStorageRepairAction
+        tokenRenamingOutsideStorageRepairAction ∧
+      FrontierLocalSourceRefRepair
+        tokenRenamingOutsideStorageRepairAction partialPacket ∧
+      ¬ SupportLocalSourceRefRepair
+        tokenRenamingOutsideStorageRepairAction partialPacket ∧
+      (∀ atom,
+        (repairThenTransportPacket identitySourceRefPacketUpdate
+            tokenRenamingOutsideStorageRepairAction partialPacket).repairFrontier atom ↔
+          (identitySourceRefPacketUpdate.map partialPacket).repairFrontier atom ∧
+            ¬ tokenRenamingOutsideStorageRepairAction.repairSupport atom) ∧
+      (∀ atom,
+        (transportThenRepairPacket identitySourceRefPacketUpdate
+            tokenRenamingOutsideStorageRepairAction partialPacket).repairFrontier atom ↔
+          (identitySourceRefPacketUpdate.map partialPacket).repairFrontier atom ∧
+            ¬ tokenRenamingOutsideStorageRepairAction.repairSupport atom) ∧
+      (∀ atom,
+        (repairThenTransportPacket identitySourceRefPacketUpdate
+            tokenRenamingOutsideStorageRepairAction partialPacket).repairFrontier atom ↔
+          (transportThenRepairPacket identitySourceRefPacketUpdate
+            tokenRenamingOutsideStorageRepairAction partialPacket).repairFrontier atom) ∧
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (repairThenTransportPacket identitySourceRefPacketUpdate
+          tokenRenamingOutsideStorageRepairAction partialPacket)
+        (transportThenRepairPacket identitySourceRefPacketUpdate
+          tokenRenamingOutsideStorageRepairAction partialPacket) := by
+  exact ⟨tokenRenaming_identity_lawfulSquare,
+    tokenRenaming_frontierLocal,
+    tokenRenaming_not_supportLocal,
+    frontierLocalRepairTransport_leftFrontierRestriction
+      tokenRenaming_identity_lawfulSquare
+      tokenRenaming_frontierLocal
+      partialTrace_repairFrontierExact,
+    frontierLocalRepairTransport_rightFrontierRestriction
+      tokenRenaming_identity_lawfulSquare
+      tokenRenaming_frontierLocal
+      partialTrace_repairFrontierExact,
+    frontierLocalRepairTransport_routeFrontiers_agree
+      tokenRenaming_identity_lawfulSquare
+      tokenRenaming_frontierLocal
+      partialTrace_repairFrontierExact,
+    frontierLocalRepairTransport_sourceRefExactVisualization
+      tokenRenaming_identity_lawfulSquare partialPacket⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-36 theorem package: lawful transport carries frontier-local repair
+calculus across a repair/transport square.  Both route endpoints satisfy the
+same transported frontier restriction formula, route frontiers agree, exact
+visualization remains a separate lawful-square conclusion, and the hypothesis
+strictly weakens table-level support-locality for frontier-route correctness.
+-/
+theorem frontierLocalRepairTransportCommutator_package
+    {τ : PacketUpdate}
+    {action transportedAction : SourceRefRepairAction}
+    {packet : SourceRefPacket}
+    (hlawful : LawfulRepairTransportSquare τ action transportedAction)
+    (hfrontier : FrontierLocalSourceRefRepair action packet)
+    (hexact : RepairFrontierExact packet) :
+    RepairFrontierExact (τ.map packet) ∧
+      FrontierLocalSourceRefRepair transportedAction (τ.map packet) ∧
+      (∀ atom,
+        (repairThenTransportPacket τ action packet).repairFrontier atom ↔
+          (τ.map packet).repairFrontier atom ∧
+            ¬ transportedAction.repairSupport atom) ∧
+      (∀ atom,
+        (transportThenRepairPacket τ transportedAction packet).repairFrontier atom ↔
+          (τ.map packet).repairFrontier atom ∧
+            ¬ transportedAction.repairSupport atom) ∧
+      (∀ atom,
+        (repairThenTransportPacket τ action packet).repairFrontier atom ↔
+          (transportThenRepairPacket τ transportedAction packet).repairFrontier atom) ∧
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (repairThenTransportPacket τ action packet)
+        (transportThenRepairPacket τ transportedAction packet) ∧
+      (LawfulRepairTransportSquare
+          identitySourceRefPacketUpdate
+          tokenRenamingOutsideStorageRepairAction
+          tokenRenamingOutsideStorageRepairAction ∧
+        FrontierLocalSourceRefRepair
+          tokenRenamingOutsideStorageRepairAction partialPacket ∧
+        ¬ SupportLocalSourceRefRepair
+          tokenRenamingOutsideStorageRepairAction partialPacket) := by
+  exact ⟨packetTransport_repairFrontierExact
+      hlawful.transport_laws hexact,
+    transportedAction_frontierLocal_of_lawful hlawful hfrontier,
+    frontierLocalRepairTransport_leftFrontierRestriction
+      hlawful hfrontier hexact,
+    frontierLocalRepairTransport_rightFrontierRestriction
+      hlawful hfrontier hexact,
+    frontierLocalRepairTransport_routeFrontiers_agree
+      hlawful hfrontier hexact,
+    frontierLocalRepairTransport_sourceRefExactVisualization hlawful packet,
+    tokenRenaming_identity_lawfulSquare,
+    tokenRenaming_frontierLocal,
+    tokenRenaming_not_supportLocal⟩
+
+end FrontierLocalRepairTransportCommutator
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-frontier-local-repair-transport-commutator.md
+++ b/research/ideas/g-aat-quality-surface-01-frontier-local-repair-transport-commutator.md
@@ -1,0 +1,146 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: repair-potential / certificate-transport / traceability / invariance / obstruction
+expected_base_score: 65
+expected_evidence_multiplier: 2.0
+expected_final_score: 130
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle36
+tags: [quality-surface, repair, support, frontier, transport, commutator, source-ref]
+created: 2026-06-20
+cycle: 36
+lean: Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean
+---
+
+# Frontier-local repair/transport commutator criterion
+
+## 主張
+
+Cycle 34 の lawful repair/transport commutator は、source action が table-level
+`SupportLocalSourceRefRepair` を満たすとき、repair-then-transport と
+transport-then-repair の両 endpoint frontier が同じ transported frontier formula を満たすことを示した。
+
+Cycle 36 では、この仮定を Cycle 35 の missing-locus law
+`FrontierLocalSourceRefRepair` へ下げる。すなわち、`τ` が lawful repair/transport square であり、
+source action が packet に対して frontier-local なら、transported action も `τ.map packet` に対して
+frontier-local であり、両 route endpoint は次の同じ formula を満たす。
+
+```text
+endpoint.repairFrontier atom
+  ↔ (τ.map packet).repairFrontier atom ∧ ¬ transportedAction.repairSupport atom
+```
+
+さらに lawful square から source-ref exact visualization はそのまま得られる。したがって route frontier の
+可換性に必要なのは table-level support-locality ではなく、missing-locus level の frontier-localityである。
+Cycle 35 の token-renaming witness により、この仮定は `SupportLocalSourceRefRepair` より真に弱い。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- Cycle 30: `Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean`
+- Cycle 31: `Formal/AG/Research/QualitySurface/SupportLocalRepairFrontier.lean`
+- Cycle 34: `Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean`
+- Cycle 35: `Formal/AG/Research/QualitySurface/FrontierLocalFormulaMinimality.lean`
+
+## 非自明性
+
+Cycle 34 は support-locality を transport して route formula を証明したが、その仮定は source-ref table identity
+まで要求する。Cycle 35 は frontier formula に必要十分な law が missing-locus level まで落ちることを示した。
+この候補は、transport square の中でも同じ弱化が有効であることを示し、repair/transport commutator の
+frontier calculus と source-ref exact visualization を分離する。
+
+単なる既存定理の即時系ではない理由は、`FrontierLocalSourceRefRepair` を action naturality と packet transport laws
+で target 側へ運ぶ必要があるためである。support predicate、missing locus、post repair packet の table equality が
+別々の経路で使われる。
+
+## 数学的興味
+
+repair/transport commutator は exact visualization には protected source-ref table law を使うが、
+frontier calculus は missing-locus law だけで可換になる。この結果は、route exactness と frontier formula correctness
+の必要構造を分離し、Quality Surface の repair-potential geometry をより細かい law 階層として読む素材になる。
+
+## GOAL への前進
+
+support-local repair theorem frontier を lawful transport の中で frontier-local criterion へ下げ、
+repair-potential / certificate-transport / traceability / invariance の境界を鋭くする。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 34 の commutator theorem と Cycle 35 の frontier-local minimalityを合成し、table-level support-locality が route frontier formula には不要であることを Lean で固定する。source-ref exact visualization は lawful square 側の別成分として残るため、frontier correctness と trace exactness の law 階層が明確になる。G2 厳密性審判は、主張が Cycle 34/35 の自然な合成に近いことから base 65 へ下げたため、picked score も base 65 / final 130 とする。
+- `dullness_risk`: medium。Cycle 34 の theorem を `FrontierLocalSourceRefRepair` に置換するだけに見える危険がある。strict weakening witness と route exact visualization の分離を package に含め、support-local 仮定を本当に落としたことを示す。
+- `proof_or_evidence`: `transportedAction_frontierLocal_of_lawful`、left/right route frontier restriction、route frontier agreement、lawful square からの source-ref exact visualization、identity lawful square 上の Cycle 35 token-renaming witness による strict weakening package を Lean で証明した。
+
+## CS / SWE への帰結
+
+repair/transport dashboard が frontier formula だけを主張する場合、support 外の source-ref token identity 保存までは
+必要条件ではない。一方、exact visualization は lawful square の protected table / obligation law に依存する。
+これにより、UI や report が「frontier correctness」と「source-ref exact visualization」を別ラベルで表示すべき理由を
+Lean-backed に説明できる。
+
+## 証明・根拠の見込み
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean`
+
+Proved declarations:
+
+- `transportedAction_frontierLocal_of_lawful`
+- `frontierLocalRepairTransport_leftFrontierRestriction`
+- `frontierLocalRepairTransport_rightFrontierRestriction`
+- `frontierLocalRepairTransport_routeFrontiers_agree`
+- `frontierLocalRepairTransport_sourceRefExactVisualization`
+- `identitySourceRefPacketUpdate`
+- `identitySourceRefPacketTransport_lawful`
+- `self_repairActionTransportNaturality`
+- `tokenRenaming_identity_lawfulSquare`
+- `frontierLocalRepairTransport_strictlyWeakens_supportLocalHypothesis`
+- `frontierLocalRepairTransportCommutator_package`
+
+Expected claim boundary:
+
+- finite `SourceRefPacket`
+- declared `SourceRefRepairAction`
+- explicit `PacketUpdate`
+- `LawfulRepairTransportSquare`
+- exact pre-frontier assumption for the source packet
+
+The result does not assert canonical transport, canonical repair planning, ArchMap correctness, source extraction completeness,
+or whole-codebase quality.
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/frontier_local_repair_transport_commutator_axioms.lean`: pass; reported declarations depend on no axioms
+- `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean`: pass; no hits in the Lean evidence file
+
+G3 audit summary:
+
+- 公理検査: `pass`。reported declarations と主要 dependency checks は `sorryAx`、`propext`、`Classical.choice`、`Quot.sound` を含む axiom dependency を持たない。Research evidence module と `Formal/AG/Research.lean` import aggregator 以外の `Formal/AG` は編集していない。
+- 形式化品質: `pass`。`LawfulRepairTransportSquare`、`FrontierLocalSourceRefRepair action packet`、`RepairFrontierExact packet` から route frontier formula、route agreement、source-ref exact visualization を導き、`SupportLocalSourceRefRepair` は主仮定に隠れていない。strict weakening は identity lawful square 上の commutator-contextual witness として実装されている。
+
+## 審判メモ
+
+- 厳密性: `accept`、base 65。`FrontierLocalSourceRefRepair` を lawful square の missing/support transport と action naturality で target 側へ運ぶ補題が必要なので単なる rename ではない。ただし Cycle 34/35 の自然な合成に近く、期待 80 は高い。strict weakening は identity lawful square 上の witness として実装することが要求された。
+- 研究価値: `accept`、base 70。新しい不変量ではないが、frontier correctness と source-ref exact visualization の二層分離を圧縮できる。strict weakening を commutator 文脈で示すことが要求された。
+- repo 全体価値: `accept`、base 70。Research / Lean / paper seed に加え、tooling/report で「frontier formula」と「exact visualization」を別ラベルで扱う根拠になる。既存 Cycle の置換補題に見えないよう、二つの結論ラベルの分離を report に明示することが要求された。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-lawful-repair-transport-commutator.md`
+- `research/ideas/g-aat-quality-surface-01-support-local-repair-transport-frontier-commutator.md`
+- `research/ideas/g-aat-quality-surface-01-frontier-local-formula-minimality.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 36 G1 で作成。G1 候補生成で、Cycle 34 の support-local commutator を Cycle 35 の frontier-local law へ下げる候補として採択候補にした。
+- 2026-06-20: G2 三審判すべて `accept`。A は base 65、B/C は base 70。picked は保守的に base 65 / final 130 とした。
+- 2026-06-20: G3 Lean 実装を追加。対象 file 単体の `lake env lean` が pass。
+- 2026-06-20: G3 公理検査と形式化品質監査がともに `pass`。G3.5 初回は report 未同期と監査要約不足で `revise`。
+- 2026-06-20: report と候補カードを同期。G3.5 再審査で残った hygiene 指摘に従い、Lean evidence file に限定した no-sorry scan と resolved revise を記録。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 4350
+- total SCORE: 4480
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -39,10 +39,10 @@
   - repair-potential / traceability / atom-supported-quality-geometry / invariance: 130
   - obstruction / repair-potential / traceability / invariance: 120
   - obstruction / repair-potential / traceability / invariance / quality-surface: 130
-  - repair-potential / certificate-transport / traceability / invariance / obstruction: 130
+  - repair-potential / certificate-transport / traceability / invariance / obstruction: 260
   - repair-potential / obstruction / traceability / invariance: 150
 - evidence portfolio:
-  - proved-in-research: 35
+  - proved-in-research: 36
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1543,9 +1543,53 @@ repair dashboard が frontier だけを保証する場合、source-ref token ide
 主張は supplied finite source-ref packets と declared repair actions に相対化され、canonical repair planning、
 source extraction completeness、ArchMap correctness、source-ref exact visualization、実コード全体の品質判定は結論しない。
 
+## Cycle 36: Frontier-local repair/transport commutator criterion
+
+```text
+candidate: Frontier-local repair/transport commutator criterion
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 65
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 130
+category: repair-potential/certificate-transport/traceability/invariance/obstruction
+goal_delta: lawful repair/transport square の route frontier correctness に必要な仮定を table-level support-locality から missing-locus level の frontier-localityへ下げた。
+project_value_delta: Cycle 34 の support-local commutator と Cycle 35 の frontier-local minimalityを統合し、frontier formula correctness と source-ref exact visualization を別ラベルの law 層として分離した。
+formalization_quality: pass。`transportedAction_frontierLocal_of_lawful` は `SupportLocalSourceRefRepair` を仮定せず、`LawfulRepairTransportSquare` と source frontier-locality から target frontier-locality を導く。identity lawful square 上の token-renaming witness により旧 support-local 仮定より真に弱いことを commutator 文脈で証明する。全 reported declarations は axiom-free / sorry-free。
+open_questions: lawful criterion minimality matrix、support/action/obligation/table law の独立必要性、selected commutator defect localization。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean` は、
+Cycle 34 の repair/transport frontier commutator を Cycle 35 の `FrontierLocalSourceRefRepair` へ弱化する。
+仮定は supplied packet、declared source action / transported action、explicit packet update `τ`、
+`LawfulRepairTransportSquare τ action transportedAction`、source 側の
+`FrontierLocalSourceRefRepair action packet`、および source packet の exact pre-frontier に相対化される。
+
+Lean 証拠は次を固定する。
+
+- `transportedAction_frontierLocal_of_lawful`: lawful square と source frontier-locality から transported action の frontier-locality が出る。
+- `frontierLocalRepairTransport_leftFrontierRestriction`: repair-then-transport route の frontier は transported pre-frontier minus transported support である。
+- `frontierLocalRepairTransport_rightFrontierRestriction`: transport-then-repair route の frontier も同じ transported formula である。
+- `frontierLocalRepairTransport_routeFrontiers_agree`: 両 route endpoint の repair frontier は一致する。
+- `frontierLocalRepairTransport_sourceRefExactVisualization`: source-ref exact visualization は frontier-locality ではなく lawful square 側の protected laws から得られる。
+- `identitySourceRefPacketUpdate` / `identitySourceRefPacketTransport_lawful` / `self_repairActionTransportNaturality`: strict weakening witness を lawful square 内へ置くための identity square。
+- `tokenRenaming_identity_lawfulSquare`: Cycle 35 の token-renaming action は identity packet transport と lawful square を作る。
+- `frontierLocalRepairTransport_strictlyWeakens_supportLocalHypothesis`: 同じ witness は frontier-local route formula、route agreement、source-ref exact visualization を満たすが、`SupportLocalSourceRefRepair` は満たさない。
+- `frontierLocalRepairTransportCommutator_package`: transported exact frontier、transported frontier-locality、left/right frontier formula、route frontier agreement、source-ref exact visualization、strict weakening witness を束ねる。
+
+この結果により、repair/transport route の frontier correctness は source-ref table identity preservation まで要求しない
+missing-locus law として読める。一方で source-ref exact visualization は lawful square の table / obligation /
+visible laws に残る。したがって report や tooling surface では、frontier formula correctness と source-ref exact visualization
+を別の保証として表示する必要がある。主張は supplied finite source-ref packets、declared repair actions、explicit
+packet transport laws に相対化され、canonical transport、canonical repair planning、source extraction completeness、
+ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 35 後の total SCORE は 4350 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 36 後の total SCORE は 4480 である。
 次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
 lawful repair/transport criterion minimality matrix、


### PR DESCRIPTION
## 概要

Refs #2348

研究ループ `G-aat-quality-surface-01` Cycle 36 として、Cycle 34 の support-local repair/transport frontier commutator を Cycle 35 の `FrontierLocalSourceRefRepair` まで弱化しました。

frontier correctness は missing-locus level の law で成立し、source-ref exact visualization は lawful square 側の protected laws から得られる、という二層分離を Lean-backed に固定します。

SCORE 監査結果:

- base score: 65
- evidence multiplier: 2.0
- penalty: 0
- final score: 130
- total SCORE: 4480 / 5000
- evidence stage: proved-in-research

## 証明した定理

- `transportedAction_frontierLocal_of_lawful`
- `frontierLocalRepairTransport_leftFrontierRestriction`
- `frontierLocalRepairTransport_rightFrontierRestriction`
- `frontierLocalRepairTransport_routeFrontiers_agree`
- `frontierLocalRepairTransport_sourceRefExactVisualization`
- `identitySourceRefPacketTransport_lawful`
- `self_repairActionTransportNaturality`
- `tokenRenaming_identity_lawfulSquare`
- `frontierLocalRepairTransport_strictlyWeakens_supportLocalHypothesis`
- `frontierLocalRepairTransportCommutator_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-frontier-local-repair-transport-commutator.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `lake env lean .tmp/frontier_local_repair_transport_commutator_axioms.lean`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan for the Lean evidence file

`lake build` は成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean:201,207` の linter warning は再現していますが、今回差分外です。

## チェックリスト

- [x] tracking Issue は `Refs #2348` として記載し、自動 close しない
- [x] Lean status は `proved-in-research`
- [x] research report と候補カードを SCORE 監査後の値へ同期した
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature / ArchSig / FieldSig の責務境界には触れていない
