### PR TITLE
研究ループ Cycle 37: table-law route localization

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -35,3 +35,4 @@ import Formal.AG.Research.QualitySurface.SupportedTokenMismatchObstruction
 import Formal.AG.Research.QualitySurface.SupportLocalRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.FrontierLocalFormulaMinimality
 import Formal.AG.Research.QualitySurface.FrontierLocalRepairTransportCommutator
+import Formal.AG.Research.QualitySurface.TransportTableLawRouteLocalization

--- a/Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean
+++ b/Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean
@@ -1,0 +1,261 @@
+import Formal.AG.Research.QualitySurface.SourceRefTableLawObstruction
+import Formal.AG.Research.QualitySurface.LawfulRepairTransportCommutator
+
+/-!
+Cycle 37 evidence for `G-aat-quality-surface-01`.
+
+This file lifts the Cycle 29 token-swap table-law obstruction into a selected
+repair/transport route square.  The square uses the token-swap packet update
+and a selected table re-supply repair action.  All non-table transport laws,
+visible surface, obligation, repair frontier, and action self-naturality are
+flat in the selected witness, but the route endpoints still differ at the
+endpoint source-ref table component.  Thus deleting the transport table law
+localizes the route defect to a selected source-ref table coordinate and
+obstructs source-ref exact visualization.
+
+The claim is a selected finite witness, not a global minimality theorem for the
+whole lawful criterion matrix.  It is relative to supplied finite source-ref
+packets, the supplied token-swap update, a declared repair action, and selected
+route endpoint comparison; it does not assert canonical transport, canonical
+repair planning, source extraction completeness, ArchMap correctness, or
+whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace TransportTableLawRouteLocalization
+
+open CodebaseTracePacket
+open CodebaseTraceRepairTrajectory
+open CodebaseTraceHolonomyPacket
+open SourceRefPacketTransport
+open SourceRefExactVisualizationCriterion
+open SourceRefTableLawObstruction
+open LawfulRepairTransportCommutator
+
+/-! ## Selected table-law-minus route square -/
+
+/--
+A selected repair action that re-supplies the full source-ref table and leaves
+the visible route frontier empty on the full/token-swapped witness.
+-/
+def fullTableResupplyRepairAction : SourceRefRepairAction where
+  repairSupport := fun _ => False
+  repairedSourceRefTable := fullSourceRefTable
+  repairedObligation := StateSeparation.ObligationKind.none
+
+/-- Repair then token-swap transport, evaluated at the selected full packet. -/
+def tokenSwapRoute_repairThenTransportPacket : SourceRefPacket :=
+  repairThenTransportPacket
+    sourceRefTokenSwapTransport
+    fullTableResupplyRepairAction
+    fullPacket
+
+/-- Token-swap transport then table re-supply repair, evaluated at the selected full packet. -/
+def tokenSwapRoute_transportThenRepairPacket : SourceRefPacket :=
+  transportThenRepairPacket
+    sourceRefTokenSwapTransport
+    fullTableResupplyRepairAction
+    fullPacket
+
+/-! ## Table-law-minus assumptions -/
+
+/--
+The selected token-swap update satisfies the non-table transport laws needed
+for the witness: support, missing-locus, and repair-frontier preservation and
+reflection.
+-/
+theorem tokenSwapRoute_nonTableTransportLaws :
+    PreservesCodeSupport sourceRefTokenSwapTransport ∧
+      ReflectsCodeSupport sourceRefTokenSwapTransport ∧
+      PreservesSourceRefMissingLocus sourceRefTokenSwapTransport ∧
+      ReflectsSourceRefMissingLocus sourceRefTokenSwapTransport ∧
+      PreservesSourceRefRepairFrontier sourceRefTokenSwapTransport ∧
+      ReflectsSourceRefRepairFrontier sourceRefTokenSwapTransport := by
+  exact ⟨tokenSwapTransport_preservesCodeSupport,
+    tokenSwapTransport_reflectsCodeSupport,
+    tokenSwapTransport_preservesMissingLocus,
+    tokenSwapTransport_reflectsMissingLocus,
+    tokenSwapTransport_preservesRepairFrontier,
+    tokenSwapTransport_reflectsRepairFrontier⟩
+
+/-- The table re-supply action is naturally transported to itself. -/
+theorem tokenSwapRoute_selfActionNaturality :
+    RepairActionTransportNaturality
+      fullTableResupplyRepairAction
+      fullTableResupplyRepairAction where
+  support_iff := by
+    intro atom
+    rfl
+  table_eq := by
+    intro atom
+    rfl
+  obligation_eq := rfl
+
+/-- The selected token-swap route square is not lawful, exactly because the table law is missing. -/
+theorem tokenSwapRoute_not_lawfulSquare :
+    ¬ LawfulRepairTransportSquare
+      sourceRefTokenSwapTransport
+      fullTableResupplyRepairAction
+      fullTableResupplyRepairAction := by
+  intro hlawful
+  exact tokenSwap_not_preservesSourceRefTable
+    hlawful.transport_laws.preservesSourceRefTable
+
+/-! ## Visible, obligation, and frontier flatness of the selected routes -/
+
+/-- The route endpoints agree at the visible packet surface. -/
+theorem tokenSwapRoute_visiblePacketSurface :
+    supportSurfaceReading.Equivalent
+      tokenSwapRoute_repairThenTransportPacket
+      tokenSwapRoute_transportThenRepairPacket := by
+  constructor
+  · exact ⟨rfl, rfl⟩
+  · intro atom
+    constructor <;> intro hsupport <;> exact hsupport
+
+/-- The selected route endpoints agree at the visible tuple surface. -/
+theorem tokenSwapRoute_visibleTupleSurface :
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      tokenSwapRoute_repairThenTransportPacket
+      tokenSwapRoute_transportThenRepairPacket :=
+  SourceRefTupleBridge.packet_supportSurface_projects_to_tuple_visible
+    tokenSwapRoute_visiblePacketSurface
+
+/-- The selected route endpoints agree in the obligation component. -/
+theorem tokenSwapRoute_obligation_flat :
+    tokenSwapRoute_repairThenTransportPacket.obligation =
+      tokenSwapRoute_transportThenRepairPacket.obligation := by
+  rfl
+
+/-- The selected route endpoints agree in the repair-frontier component. -/
+theorem tokenSwapRoute_repairFrontier_flat :
+    SameCodebaseRepairFrontier
+      tokenSwapRoute_repairThenTransportPacket
+      tokenSwapRoute_transportThenRepairPacket := by
+  intro atom
+  rfl
+
+/-! ## Selected source-ref table defect and exactness failure -/
+
+/-- The selected route defect is localized at the endpoint source-ref table component. -/
+theorem tokenSwapRoute_selectedSourceRefTableDefect :
+    SourceRefTableDefectAt
+      tokenSwapRoute_repairThenTransportPacket
+      tokenSwapRoute_transportThenRepairPacket
+      CodeAtom.endpoint := by
+  intro hsame
+  change some SourceRefToken.workerRef =
+    some SourceRefToken.endpointRef at hsame
+  cases hsame
+
+/-- The selected route table defect as a component-indexed packet defect. -/
+theorem tokenSwapRoute_selectedSourceRefTableComponentDefect :
+    SourceRefPacketHolonomyDefect
+      tokenSwapRoute_repairThenTransportPacket
+      tokenSwapRoute_transportThenRepairPacket
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) :=
+  tokenSwapRoute_selectedSourceRefTableDefect
+
+/-- The selected route square has nonzero packet holonomy. -/
+theorem tokenSwapRoute_hasPacketHolonomyDefect :
+    HasSourceRefPacketHolonomyDefect
+      tokenSwapRoute_repairThenTransportPacket
+      tokenSwapRoute_transportThenRepairPacket :=
+  sourceRefTableDefect_obstructs_noPacketHolonomy
+    tokenSwapRoute_selectedSourceRefTableDefect
+
+/-- The visible route square is lossy under packet-to-tuple visualization. -/
+theorem tokenSwapRoute_lossyPacketToTupleVisualization :
+    LossyPacketToTupleVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      tokenSwapRoute_repairThenTransportPacket
+      tokenSwapRoute_transportThenRepairPacket :=
+  ⟨tokenSwapRoute_visibleTupleSurface,
+    tokenSwapRoute_hasPacketHolonomyDefect⟩
+
+/-- The selected table defect obstructs source-ref exact visualization. -/
+theorem tokenSwapRoute_not_sourceRefExactVisualization :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      tokenSwapRoute_repairThenTransportPacket
+      tokenSwapRoute_transportThenRepairPacket :=
+  packetHolonomyDefect_obstructs_sourceRefExactVisualization
+    tokenSwapRoute_selectedSourceRefTableComponentDefect
+
+/-! ## Theorem package -/
+
+/--
+Cycle-37 theorem package: deleting the transport table law from the selected
+route square leaves visible, obligation, frontier, non-table transport, and
+action-naturality evidence flat, but localizes the route defect at the endpoint
+source-ref table component and obstructs source-ref exact visualization.
+-/
+theorem transportTableLawSelectedLocalization_package :
+    PreservesCodeSupport sourceRefTokenSwapTransport ∧
+      ReflectsCodeSupport sourceRefTokenSwapTransport ∧
+      PreservesSourceRefMissingLocus sourceRefTokenSwapTransport ∧
+      ReflectsSourceRefMissingLocus sourceRefTokenSwapTransport ∧
+      PreservesSourceRefRepairFrontier sourceRefTokenSwapTransport ∧
+      ReflectsSourceRefRepairFrontier sourceRefTokenSwapTransport ∧
+      RepairActionTransportNaturality
+        fullTableResupplyRepairAction
+        fullTableResupplyRepairAction ∧
+      ¬ LawfulRepairTransportSquare
+        sourceRefTokenSwapTransport
+        fullTableResupplyRepairAction
+        fullTableResupplyRepairAction ∧
+      supportSurfaceReading.Equivalent
+        tokenSwapRoute_repairThenTransportPacket
+        tokenSwapRoute_transportThenRepairPacket ∧
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        tokenSwapRoute_repairThenTransportPacket
+        tokenSwapRoute_transportThenRepairPacket ∧
+      tokenSwapRoute_repairThenTransportPacket.obligation =
+        tokenSwapRoute_transportThenRepairPacket.obligation ∧
+      SameCodebaseRepairFrontier
+        tokenSwapRoute_repairThenTransportPacket
+        tokenSwapRoute_transportThenRepairPacket ∧
+      SourceRefPacketHolonomyDefect
+        tokenSwapRoute_repairThenTransportPacket
+        tokenSwapRoute_transportThenRepairPacket
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) ∧
+      HasSourceRefPacketHolonomyDefect
+        tokenSwapRoute_repairThenTransportPacket
+        tokenSwapRoute_transportThenRepairPacket ∧
+      LossyPacketToTupleVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        tokenSwapRoute_repairThenTransportPacket
+        tokenSwapRoute_transportThenRepairPacket ∧
+      ¬ SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        tokenSwapRoute_repairThenTransportPacket
+        tokenSwapRoute_transportThenRepairPacket := by
+  exact ⟨tokenSwapTransport_preservesCodeSupport,
+    tokenSwapTransport_reflectsCodeSupport,
+    tokenSwapTransport_preservesMissingLocus,
+    tokenSwapTransport_reflectsMissingLocus,
+    tokenSwapTransport_preservesRepairFrontier,
+    tokenSwapTransport_reflectsRepairFrontier,
+    tokenSwapRoute_selfActionNaturality,
+    tokenSwapRoute_not_lawfulSquare,
+    tokenSwapRoute_visiblePacketSurface,
+    tokenSwapRoute_visibleTupleSurface,
+    tokenSwapRoute_obligation_flat,
+    tokenSwapRoute_repairFrontier_flat,
+    tokenSwapRoute_selectedSourceRefTableComponentDefect,
+    tokenSwapRoute_hasPacketHolonomyDefect,
+    tokenSwapRoute_lossyPacketToTupleVisualization,
+    tokenSwapRoute_not_sourceRefExactVisualization⟩
+
+end TransportTableLawRouteLocalization
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-transport-table-law-route-localization.md
+++ b/research/ideas/g-aat-quality-surface-01-transport-table-law-route-localization.md
@@ -1,0 +1,145 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: obstruction / certificate-transport / traceability / invariance / quality-surface
+expected_base_score: 50
+expected_evidence_multiplier: 2.0
+expected_final_score: 100
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle37
+tags: [quality-surface, repair, transport, table-law, commutator, obstruction, source-ref]
+created: 2026-06-20
+cycle: 37
+lean: Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean
+---
+
+# Transport table-law deletion localizes the selected route defect
+
+## 主張
+
+Cycle 29 の `sourceRefTokenSwapTransport` は、support、missing locus、repair frontier、visible surface、
+obligation を保存・反映するが、source-ref table identity だけを壊す。Cycle 37 では、この token-swap transport を
+repair/transport route square に持ち上げる。
+
+具体的には、selected full/token-swapped packets 上で full source-ref table を再供給する table re-supply action を選ぶと、
+repair-then-transport route は token-swapped full packet へ行き、transport-then-repair route は full table を
+再供給するため full packet へ戻る。両 route は visible surface、obligation、repair frontier では一致するが、
+selected endpoint の source-ref table component だけが異なる。したがって source-ref exact visualization は失敗する。
+
+この有限 witness は、`preservesSourceRefTable` を削った route-square 仮定群では、visible/obligation/frontier/action
+naturality が保たれても selected route source-ref table defect が残ることを示す。これは global な minimality theorem
+ではなく、table-law deletion が route source-ref exactness を壊す一つの selected localization cell である。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- Cycle 29: `Formal/AG/Research/QualitySurface/SourceRefTableLawObstruction.lean`
+- Cycle 30: `Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean`
+- Cycle 34: `Formal/AG/Research/QualitySurface/SupportLocalRepairTransportCommutator.lean`
+- Cycle 36: `Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean`
+
+## 非自明性
+
+Cycle 29 は token-swap transport 単体で source-ref table law の独立性を示した。今回の候補は、それを
+repair/transport route endpoint の比較へ持ち上げ、`preservesSourceRefTable` を削った selected route-square
+仮定群として明示する。route frontier や visible surface が flat な状況でも、selected source-ref table component に
+route defect が局在し、source-ref exact visualization が失敗することを示す点が新しい。
+
+## 数学的興味
+
+lawful repair/transport criterion は一つの bundle に見えるが、source-ref exactness を支える component law は
+coordinate ごとに異なる。この候補は、transport table law row を selected component defect として切り出し、
+lawful criterion minimality matrix の一セルを Lean-backed に埋める。
+
+## GOAL への前進
+
+selected commutator defect localization と lawful criterion minimality matrix を同時に前進させる。特に、
+visible/support/frontier/obligation readings では source-ref token identity defect を復元できないことを、
+route square 文脈で固定する。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 29 の token-swap obstruction と Cycle 30/36 の route commutator vocabulary を結び、transport table law deletion が selected route source-ref table defect と source-ref exact visualization failure を生むことを示す。G2 厳密性審判は即時系に近いリスクを指摘したため、picked 前の期待値は base 50 / final 100 に下げる。
+- `dullness_risk`: high。Cycle 29 の再掲に落ちる危険があるため、`preservesSourceRefTable` を削った route-square 仮定群、route endpoint equalities、non-table transport laws、action naturality、route visible/frontier/obligation flatness、selected route table defect、source-ref exact visualization failure を同じ package に入れる。
+- `proof_or_evidence_plan`: `sourceRefTokenSwapTransport` を使い、selected full/token-swapped packets 上で full table を再供給する action と selected full packet 上の route endpoints を定義する。support/missing/frontier/visible/obligation の non-table flatness、self action naturality、`¬ LawfulRepairTransportSquare` または同等の table-law deletion statement、selected endpoint table defect、packet holonomy defect、source-ref exact visualization failure、package theorem を Lean で証明する。
+
+## CS / SWE への帰結
+
+repair/transport dashboard が visible、support、frontier、obligation だけを確認しても、source-ref token identity の
+route defect は残りうる。ただしこの候補が示すのは selected finite witness であり、全 law matrix の完全分類ではない。
+report/tooling surface では、transport table law failure を selected source-ref component defect として独立表示する
+根拠の一セルになる。
+
+## 証明・根拠の見込み
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean`
+
+Planned declarations:
+
+- `fullTableResupplyRepairAction`
+- `tokenSwapRoute_repairThenTransportPacket`
+- `tokenSwapRoute_transportThenRepairPacket`
+- `tokenSwapRoute_nonTableTransportLaws`
+- `tokenSwapRoute_selfActionNaturality`
+- `tokenSwapRoute_not_lawfulSquare`
+- `tokenSwapRoute_visiblePacketSurface`
+- `tokenSwapRoute_visibleTupleSurface`
+- `tokenSwapRoute_obligation_flat`
+- `tokenSwapRoute_repairFrontier_flat`
+- `tokenSwapRoute_selectedSourceRefTableDefect`
+- `tokenSwapRoute_selectedSourceRefTableComponentDefect`
+- `tokenSwapRoute_hasPacketHolonomyDefect`
+- `tokenSwapRoute_lossyPacketToTupleVisualization`
+- `tokenSwapRoute_not_sourceRefExactVisualization`
+- `transportTableLawSelectedLocalization_package`
+
+Expected claim boundary:
+
+- finite `SourceRefPacket`
+- supplied token-swap `PacketUpdate`
+- declared selected table re-supply repair action
+- selected full packet witness
+- route endpoint comparison in `Formal/AG/Research`
+
+The result does not assert canonical transport, canonical repair planning, source extraction completeness, ArchMap correctness,
+or whole-codebase quality.
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/transport_table_law_route_localization_axioms.lean`: pass; reported declarations depend on no axioms
+- `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean`: pass; no hits in the Lean evidence file
+
+G3 audit summary:
+
+- 公理検査: `pass`。reported declarations と route packet definitions は `sorryAx`、`propext`、`Classical.choice`、`Quot.sound` を含む axiom dependency を持たない。Research evidence module と `Formal/AG/Research.lean` import aggregator 以外の `Formal/AG` は編集していない。
+- 形式化品質: `pass`。Lean は finite `SourceRefPacket`、supplied token-swap update、selected full-table re-supply action、selected full packet route endpoint 比較に限定され、non-table transport laws、action naturality、`¬ LawfulRepairTransportSquare`、visible/obligation/frontier flatness、selected source-ref table defect、packet holonomy defect、lossy visualization、`¬ SourceRefExactVisualization` を同じ package に入れる。global minimality や全 law matrix の一意分類には踏み込んでいない。
+
+## 審判メモ
+
+- 厳密性: 初回 G2 は `revise`、base 50。Cycle 29 の即時系に近いため、global minimality ではなく table-law-minus route-square 仮定群の selected localization theorem に絞ること、selected full/token-swapped packets 上の table re-supply action として明記すること、`¬ LawfulRepairTransportSquare` か同等の table-law deletion statement を package に入れることが要求された。
+- 研究価値: `accept`、base 65。Cycle 29 の route-level lift として意味はあるが、新しい不変量や主定理級の surprise ではない。route square、non-table flatness、action naturality context を同じ package に入れることが要求された。
+- repo 全体価値: `accept`、base 60。lawful criterion minimality matrix の一セルを埋め、将来の tooling/report で visible/frontier/obligation flatness と source-ref exactness failure を別表示する根拠になる。ただし既存 token-swap witness の再利用が中心なので score は抑える。
+- SCORE 監査: `confirm`。base 50、evidence multiplier 2.0、penalty 0、final SCORE 100。selected finite witness としては有効だが、Cycle 29 の再利用が中心で phase-boundary-level ではない。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-source-ref-table-law-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-lawful-repair-transport-commutator.md`
+- `research/ideas/g-aat-quality-surface-01-frontier-local-repair-transport-commutator.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 37 G1 で作成。三方向の G1 候補生成のうち、lawful criterion minimality matrix の一セルとして実装範囲と SCORE のバランスが最もよい候補として選んだ。
+- 2026-06-20: G2 A 初回は `revise`。過大主張を避け、candidate を selected route-square table-law deletion localization に狭め、期待 score を base 50 / final 100 へ下げた。
+- 2026-06-20: G2 A 再審査は `accept`、base 50。G2 B/C も `accept` だが、picked score は保守的に base 50 / final 100 とした。
+- 2026-06-20: G3 Lean 実装を追加。対象 file、`FormalAGResearch`、axiom harness が pass。
+- 2026-06-20: G3 公理検査と形式化品質監査がともに `pass`。
+- 2026-06-20: G4 SCORE 監査が `confirm`。base 50 / final 100 で確定。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 4480
+- total SCORE: 4580
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -41,8 +41,9 @@
   - obstruction / repair-potential / traceability / invariance / quality-surface: 130
   - repair-potential / certificate-transport / traceability / invariance / obstruction: 260
   - repair-potential / obstruction / traceability / invariance: 150
+  - obstruction / certificate-transport / traceability / invariance / quality-surface: 100
 - evidence portfolio:
-  - proved-in-research: 36
+  - proved-in-research: 37
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1587,9 +1588,53 @@ visible laws に残る。したがって report や tooling surface では、fro
 packet transport laws に相対化され、canonical transport、canonical repair planning、source extraction completeness、
 ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 37: Transport table-law deletion localizes the selected route defect
+
+```text
+candidate: Transport table-law deletion localizes the selected route defect
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 50
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 100
+category: obstruction/certificate-transport/traceability/invariance/quality-surface
+goal_delta: selected repair/transport route square 上で、visible / obligation / frontier / action naturality が flat でも source-ref table law deletion による endpoint table defect と exact visualization failure が残ることを固定した。
+project_value_delta: lawful criterion minimality matrix の table-law cell を補強し、frontier correctness と source-ref exactness failure を別表示する根拠を追加した。
+formalization_quality: pass。主張は selected finite witness に限定され、global minimality や whole-codebase quality へ越境していない。reported declarations は axiom-free / sorry-free。
+open_questions: support/action/obligation/visible law の独立必要性、全 matrix ではなく selected cell 群としての整理、route defect support calculus。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean` は、Cycle 29 の
+`sourceRefTokenSwapTransport` を selected repair/transport route square に持ち上げる。
+対象は supplied full packet、token-swap packet update、full table を再供給する selected repair action に相対化される。
+
+Lean 証拠は次を固定する。
+
+- `fullTableResupplyRepairAction`: selected full/token-swapped packets 上で full source-ref table を再供給する repair action。
+- `tokenSwapRoute_repairThenTransportPacket` / `tokenSwapRoute_transportThenRepairPacket`: token-swap update と re-supply action から作る二つの route endpoints。
+- `tokenSwapRoute_nonTableTransportLaws`: token-swap transport は support、missing locus、repair frontier を preserve / reflect する。
+- `tokenSwapRoute_selfActionNaturality`: selected repair action は self action naturality を満たす。
+- `tokenSwapRoute_not_lawfulSquare`: ただし transport table law がないため `LawfulRepairTransportSquare` にはならない。
+- `tokenSwapRoute_visiblePacketSurface` / `tokenSwapRoute_visibleTupleSurface`: route endpoints は visible packet / tuple surface で flat。
+- `tokenSwapRoute_obligation_flat` / `tokenSwapRoute_repairFrontier_flat`: route endpoints は obligation と repair frontier でも flat。
+- `tokenSwapRoute_selectedSourceRefTableDefect`: selected endpoint source-ref table component に route defect が局在する。
+- `tokenSwapRoute_hasPacketHolonomyDefect`: selected table defect は nonzero packet holonomy を与える。
+- `tokenSwapRoute_lossyPacketToTupleVisualization`: visible tuple flatness と packet holonomy defect が同じ route square に共存する。
+- `tokenSwapRoute_not_sourceRefExactVisualization`: selected table defect は source-ref exact visualization を阻害する。
+- `transportTableLawSelectedLocalization_package`: table-law-minus assumptions、flat components、selected table defect、lossy visualization、non-exactness を束ねる。
+
+この結果により、visible/support/frontier/obligation/action-naturality が flat でも、transport table law を削ると
+selected source-ref token identity の route defect が残ることが分かる。これは global な lawful criterion minimality
+matrix の完全分類ではなく、table-law deletion による selected localization cell である。主張は supplied finite
+source-ref packets、token-swap update、declared repair action、selected route endpoint comparison に相対化され、
+canonical transport、canonical repair planning、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 36 後の total SCORE は 4480 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 37 後の total SCORE は 4580 である。
 次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
 lawful repair/transport criterion minimality matrix、


### PR DESCRIPTION
## 概要

Refs #2348

`G-aat-quality-surface-01` の research-loop Cycle 37 として、Cycle 29 の source-ref table-law obstruction を selected repair/transport route square に持ち上げました。

transport table law を削った selected route-square では、visible surface、obligation、repair frontier、non-table transport laws、action naturality が flat でも、endpoint source-ref table component の route defect と source-ref exact visualization failure が残ることを Lean で固定しています。

## 証明した定理

- `fullTableResupplyRepairAction`
- `tokenSwapRoute_repairThenTransportPacket`
- `tokenSwapRoute_transportThenRepairPacket`
- `tokenSwapRoute_nonTableTransportLaws`
- `tokenSwapRoute_selfActionNaturality`
- `tokenSwapRoute_not_lawfulSquare`
- `tokenSwapRoute_visiblePacketSurface`
- `tokenSwapRoute_visibleTupleSurface`
- `tokenSwapRoute_obligation_flat`
- `tokenSwapRoute_repairFrontier_flat`
- `tokenSwapRoute_selectedSourceRefTableDefect`
- `tokenSwapRoute_selectedSourceRefTableComponentDefect`
- `tokenSwapRoute_hasPacketHolonomyDefect`
- `tokenSwapRoute_lossyPacketToTupleVisualization`
- `tokenSwapRoute_not_sourceRefExactVisualization`
- `transportTableLawSelectedLocalization_package`

Lean status: `proved-in-research`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-transport-table-law-route-localization.md`
- `research/reports/G-aat-quality-surface-01.md`

## SCORE

- base SCORE: 50
- evidence multiplier: 2.0
- penalty: 0
- final SCORE: 100
- total SCORE: 4580 / 5000
- category: obstruction / certificate-transport / traceability / invariance / quality-surface

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/transport_table_law_route_localization_axioms.lean`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] tracking Issue は research-loop 規律により `Refs #2348` として記載した。`Closes` は使っていない
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
