### PR TITLE
研究ループ Cycle 38: route defect support calculus

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -36,3 +36,4 @@ import Formal.AG.Research.QualitySurface.SupportLocalRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.FrontierLocalFormulaMinimality
 import Formal.AG.Research.QualitySurface.FrontierLocalRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.TransportTableLawRouteLocalization
+import Formal.AG.Research.QualitySurface.RouteDefectSupport

--- a/Formal/AG/Research/QualitySurface/RouteDefectSupport.lean
+++ b/Formal/AG/Research/QualitySurface/RouteDefectSupport.lean
@@ -1,0 +1,401 @@
+import Formal.AG.Research.QualitySurface.ComponentDefectPropagation
+import Formal.AG.Research.QualitySurface.TransportTableLawRouteLocalization
+import Formal.AG.Research.QualitySurface.VisibleRepairTransportCommutator
+
+/-!
+Cycle 38 evidence for `G-aat-quality-surface-01`.
+
+This file reads repair/transport endpoint defects as a component-indexed route
+defect support.  The support is not merely used as a new name for an existing
+defect predicate: the selected witnesses also compute exact support shapes with
+off-coordinate nonmembership.
+
+The claim is relative to supplied finite source-ref packets, selected
+repair/transport route endpoints, and the explicit packet-to-tuple bridge.  It
+does not assert a global lawful-criterion minimality matrix, source extraction
+completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace RouteDefectSupportTheory
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+
+/-! ## Route defect support calculus -/
+
+/-- Component agreement for a source-ref route endpoint pair. -/
+def RouteComponentAgreement
+    (left right : SourceRefPacket) :
+    SourceRefPacketProtectedComponent -> Prop
+  | .obligation => left.obligation = right.obligation
+  | .repairFrontier atom => left.repairFrontier atom ↔ right.repairFrontier atom
+  | .sourceRefTable atom => left.sourceRefTable atom = right.sourceRefTable atom
+
+/-- Component-indexed support of a route endpoint defect. -/
+def RouteDefectSupport
+    (left right : SourceRefPacket)
+    (component : SourceRefPacketProtectedComponent) : Prop :=
+  ¬ RouteComponentAgreement left right component
+
+/-- Empty route defect support, stated positively to avoid double-negation loss. -/
+def RouteDefectSupportEmpty
+    (left right : SourceRefPacket) : Prop :=
+  ∀ component, RouteComponentAgreement left right component
+
+/-- Route defect support is the component-indexed packet holonomy defect. -/
+theorem routeDefectSupport_iff_packetHolonomyDefect
+    (left right : SourceRefPacket)
+    (component : SourceRefPacketProtectedComponent) :
+    RouteDefectSupport left right component ↔
+      SourceRefPacketHolonomyDefect left right component := by
+  cases component <;> rfl
+
+/-- Empty route defect support is exactly packet zero holonomy. -/
+theorem routeDefectSupport_empty_iff_noPacketHolonomy
+    (left right : SourceRefPacket) :
+    RouteDefectSupportEmpty left right ↔
+      NoSourceRefPacketHolonomyDefect left right := by
+  constructor
+  · intro hempty
+    exact ⟨hempty SourceRefPacketProtectedComponent.obligation,
+      by
+        intro atom
+        exact hempty (SourceRefPacketProtectedComponent.repairFrontier atom),
+      by
+        intro atom
+        exact hempty (SourceRefPacketProtectedComponent.sourceRefTable atom)⟩
+  · intro hzero component
+    cases component with
+    | obligation => exact hzero.1
+    | repairFrontier atom => exact hzero.2.1 atom
+    | sourceRefTable atom => exact hzero.2.2 atom
+
+/-- Route defect support projects to tuple protected-component defects. -/
+theorem routeDefectSupport_projects_to_tupleDefects
+    {p : CodebaseTraceHolonomyPacket.TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket}
+    {component : SourceRefPacketProtectedComponent}
+    (hdefect : RouteDefectSupport left right component) :
+    TupleHolonomyDefectInvariant.TupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple gridLeft left)
+      (SourceRefTupleBridge.packetToTuple gridRight right)
+      (packetComponentToTupleComponent component) :=
+  sourceRefPacketHolonomy_projects_to_tupleHolonomy
+    gridLeft gridRight
+    ((routeDefectSupport_iff_packetHolonomyDefect
+      left right component).mp hdefect)
+
+/-- Route defect support propagates across a zero packet-holonomy leg on the left. -/
+theorem routeDefectSupport_propagates_left_of_zero
+    {left middle right : SourceRefPacket}
+    (hzero : NoSourceRefPacketHolonomyDefect left middle)
+    (component : SourceRefPacketProtectedComponent) :
+    RouteDefectSupport middle right component ↔
+      RouteDefectSupport left right component := by
+  constructor
+  · intro hsupport
+    have hpacket :
+        SourceRefPacketHolonomyDefect middle right component :=
+      (routeDefectSupport_iff_packetHolonomyDefect
+        middle right component).mp hsupport
+    have hpacket' :
+        SourceRefPacketHolonomyDefect left right component :=
+      (ComponentHolonomyDefectPropagation.packetComponentDefect_propagates_left_of_zero
+        hzero component).mp hpacket
+    exact (routeDefectSupport_iff_packetHolonomyDefect
+      left right component).mpr hpacket'
+  · intro hsupport
+    have hpacket :
+        SourceRefPacketHolonomyDefect left right component :=
+      (routeDefectSupport_iff_packetHolonomyDefect
+        left right component).mp hsupport
+    have hpacket' :
+        SourceRefPacketHolonomyDefect middle right component :=
+      (ComponentHolonomyDefectPropagation.packetComponentDefect_propagates_left_of_zero
+        hzero component).mpr hpacket
+    exact (routeDefectSupport_iff_packetHolonomyDefect
+      middle right component).mpr hpacket'
+
+/-- Route defect support propagates across a zero packet-holonomy leg on the right. -/
+theorem routeDefectSupport_propagates_right_of_zero
+    {left middle right : SourceRefPacket}
+    (hzero : NoSourceRefPacketHolonomyDefect middle right)
+    (component : SourceRefPacketProtectedComponent) :
+    RouteDefectSupport left middle component ↔
+      RouteDefectSupport left right component := by
+  constructor
+  · intro hsupport
+    have hpacket :
+        SourceRefPacketHolonomyDefect left middle component :=
+      (routeDefectSupport_iff_packetHolonomyDefect
+        left middle component).mp hsupport
+    have hpacket' :
+        SourceRefPacketHolonomyDefect left right component :=
+      (ComponentHolonomyDefectPropagation.packetComponentDefect_propagates_right_of_zero
+        hzero component).mp hpacket
+    exact (routeDefectSupport_iff_packetHolonomyDefect
+      left right component).mpr hpacket'
+  · intro hsupport
+    have hpacket :
+        SourceRefPacketHolonomyDefect left right component :=
+      (routeDefectSupport_iff_packetHolonomyDefect
+        left right component).mp hsupport
+    have hpacket' :
+        SourceRefPacketHolonomyDefect left middle component :=
+      (ComponentHolonomyDefectPropagation.packetComponentDefect_propagates_right_of_zero
+        hzero component).mpr hpacket
+    exact (routeDefectSupport_iff_packetHolonomyDefect
+      left middle component).mpr hpacket'
+
+/-! ## Cycle 37 table-law route exact support -/
+
+abbrev tableRouteLeft : SourceRefPacket :=
+  TransportTableLawRouteLocalization.tokenSwapRoute_repairThenTransportPacket
+
+abbrev tableRouteRight : SourceRefPacket :=
+  TransportTableLawRouteLocalization.tokenSwapRoute_transportThenRepairPacket
+
+/-- The Cycle 37 table-law route has endpoint table defect support. -/
+theorem tokenSwapRoute_defectSupport_endpointTable :
+    RouteDefectSupport
+      tableRouteLeft tableRouteRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) :=
+  (routeDefectSupport_iff_packetHolonomyDefect
+    tableRouteLeft tableRouteRight
+    (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint)).mpr
+    TransportTableLawRouteLocalization.tokenSwapRoute_selectedSourceRefTableComponentDefect
+
+/-- The Cycle 37 table-law route also has worker table defect support. -/
+theorem tokenSwapRoute_defectSupport_workerTable :
+    RouteDefectSupport
+      tableRouteLeft tableRouteRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.worker) := by
+  intro hagree
+  change some SourceRefToken.endpointRef =
+    some SourceRefToken.workerRef at hagree
+  cases hagree
+
+/-- The Cycle 37 table-law route has no obligation defect. -/
+theorem tokenSwapRoute_noObligationDefect :
+    ¬ RouteDefectSupport
+      tableRouteLeft tableRouteRight
+      SourceRefPacketProtectedComponent.obligation := by
+  intro hdefect
+  exact hdefect TransportTableLawRouteLocalization.tokenSwapRoute_obligation_flat
+
+/-- The Cycle 37 table-law route has no repair-frontier defect at any atom. -/
+theorem tokenSwapRoute_noRepairFrontierDefect
+    (atom : CodeAtom) :
+    ¬ RouteDefectSupport
+      tableRouteLeft tableRouteRight
+      (SourceRefPacketProtectedComponent.repairFrontier atom) := by
+  intro hdefect
+  exact hdefect (TransportTableLawRouteLocalization.tokenSwapRoute_repairFrontier_flat atom)
+
+/-- The Cycle 37 table-law route has no storage table defect. -/
+theorem tokenSwapRoute_noStorageTableDefect :
+    ¬ RouteDefectSupport
+      tableRouteLeft tableRouteRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) := by
+  intro hdefect
+  exact hdefect rfl
+
+/--
+Exact support computation for the Cycle 37 table-law route: the support is the
+endpoint/worker source-ref table pair, with obligation, frontier, and storage
+table coordinates flat.
+-/
+def TokenSwapRouteExactTablePairSupport : Prop :=
+    RouteDefectSupport
+        tableRouteLeft tableRouteRight
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) ∧
+      RouteDefectSupport
+        tableRouteLeft tableRouteRight
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.worker) ∧
+      ¬ RouteDefectSupport
+        tableRouteLeft tableRouteRight
+        SourceRefPacketProtectedComponent.obligation ∧
+      (∀ atom,
+        ¬ RouteDefectSupport
+          tableRouteLeft tableRouteRight
+          (SourceRefPacketProtectedComponent.repairFrontier atom)) ∧
+      ¬ RouteDefectSupport
+        tableRouteLeft tableRouteRight
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage)
+
+theorem tokenSwapRoute_defectSupport_exact_tablePair :
+    TokenSwapRouteExactTablePairSupport :=
+  ⟨tokenSwapRoute_defectSupport_endpointTable,
+    tokenSwapRoute_defectSupport_workerTable,
+    tokenSwapRoute_noObligationDefect,
+    tokenSwapRoute_noRepairFrontierDefect,
+    tokenSwapRoute_noStorageTableDefect⟩
+
+/-! ## Cycle 28 visible-only route exact support -/
+
+abbrev visibleRouteLeft : SourceRefPacket :=
+  VisibleRepairTransportCommutator.repairThenTransportPacket
+
+abbrev visibleRouteRight : SourceRefPacket :=
+  VisibleRepairTransportCommutator.transportThenRepairPacket
+
+/-- The visible-only route has obligation defect support. -/
+theorem visibleRepairTransport_defectSupport_obligation :
+    RouteDefectSupport
+      visibleRouteLeft visibleRouteRight
+      SourceRefPacketProtectedComponent.obligation :=
+  (routeDefectSupport_iff_packetHolonomyDefect
+    visibleRouteLeft visibleRouteRight
+    SourceRefPacketProtectedComponent.obligation).mpr
+    VisibleRepairTransportCommutator.repairTransport_obligation_componentDefect
+
+/-- The visible-only route has storage repair-frontier defect support. -/
+theorem visibleRepairTransport_defectSupport_storageRepair :
+    RouteDefectSupport
+      visibleRouteLeft visibleRouteRight
+      (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) :=
+  (routeDefectSupport_iff_packetHolonomyDefect
+    visibleRouteLeft visibleRouteRight
+    (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage)).mpr
+    VisibleRepairTransportCommutator.repairTransport_repairFrontier_componentDefect
+
+/-- The visible-only route has storage table defect support. -/
+theorem visibleRepairTransport_defectSupport_storageTable :
+    RouteDefectSupport
+      visibleRouteLeft visibleRouteRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) :=
+  (routeDefectSupport_iff_packetHolonomyDefect
+    visibleRouteLeft visibleRouteRight
+    (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage)).mpr
+    VisibleRepairTransportCommutator.repairTransport_sourceRefTable_componentDefect
+
+/-- The visible-only route has no repair-frontier defect away from storage. -/
+theorem visibleRepairTransport_noRepairFrontierDefect_offStorage
+    (atom : CodeAtom) (hoff : atom ≠ CodeAtom.storage) :
+    ¬ RouteDefectSupport
+      visibleRouteLeft visibleRouteRight
+      (SourceRefPacketProtectedComponent.repairFrontier atom) := by
+  intro hdefect
+  apply hdefect
+  dsimp [RouteComponentAgreement, visibleRouteLeft, visibleRouteRight]
+  rw [VisibleRepairTransportCommutator.repairThenTransportPacket_eq_partial,
+    VisibleRepairTransportCommutator.transportThenRepairPacket_eq_storageRepair]
+  cases atom with
+  | endpoint =>
+      constructor <;> intro hfrontier
+      · cases hfrontier
+      · rcases hfrontier with ⟨_hsupport, htable⟩
+        cases htable
+  | storage =>
+      exact False.elim (hoff rfl)
+  | worker =>
+      constructor <;> intro hfrontier
+      · cases hfrontier
+      · rcases hfrontier with ⟨_hsupport, htable⟩
+        cases htable
+
+/-- The visible-only route has no source-ref table defect away from storage. -/
+theorem visibleRepairTransport_noTableDefect_offStorage
+    (atom : CodeAtom) (hoff : atom ≠ CodeAtom.storage) :
+    ¬ RouteDefectSupport
+      visibleRouteLeft visibleRouteRight
+      (SourceRefPacketProtectedComponent.sourceRefTable atom) := by
+  intro hdefect
+  apply hdefect
+  dsimp [RouteComponentAgreement, visibleRouteLeft, visibleRouteRight]
+  rw [VisibleRepairTransportCommutator.repairThenTransportPacket_eq_partial,
+    VisibleRepairTransportCommutator.transportThenRepairPacket_eq_storageRepair]
+  cases atom with
+  | endpoint => rfl
+  | storage => exact False.elim (hoff rfl)
+  | worker => rfl
+
+/--
+Exact support computation for the Cycle 28 visible-only route: obligation,
+storage repair-frontier, and storage source-ref table are supported defects;
+repair-frontier and table coordinates away from storage are flat.
+-/
+def VisibleRepairTransportDefectSupportTriple : Prop :=
+    RouteDefectSupport
+        visibleRouteLeft visibleRouteRight
+        SourceRefPacketProtectedComponent.obligation ∧
+      RouteDefectSupport
+        visibleRouteLeft visibleRouteRight
+        (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) ∧
+      RouteDefectSupport
+        visibleRouteLeft visibleRouteRight
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) ∧
+      (∀ atom, atom ≠ CodeAtom.storage ->
+        ¬ RouteDefectSupport
+          visibleRouteLeft visibleRouteRight
+          (SourceRefPacketProtectedComponent.repairFrontier atom)) ∧
+      (∀ atom, atom ≠ CodeAtom.storage ->
+        ¬ RouteDefectSupport
+          visibleRouteLeft visibleRouteRight
+          (SourceRefPacketProtectedComponent.sourceRefTable atom))
+
+theorem visibleRepairTransport_defectSupport_triple :
+    VisibleRepairTransportDefectSupportTriple :=
+  ⟨visibleRepairTransport_defectSupport_obligation,
+    visibleRepairTransport_defectSupport_storageRepair,
+    visibleRepairTransport_defectSupport_storageTable,
+    visibleRepairTransport_noRepairFrontierDefect_offStorage,
+    visibleRepairTransport_noTableDefect_offStorage⟩
+
+/-! ## Package theorem -/
+
+/--
+Cycle-38 theorem package: route defect support has a zero-support criterion,
+tuple projection, zero-leg propagation, and exact selected support computations
+for the Cycle 37 table-law route and Cycle 28 visible-only route.
+-/
+theorem routeDefectSupportCalculus_package :
+    (∀ left right : SourceRefPacket,
+      RouteDefectSupportEmpty left right ↔
+        NoSourceRefPacketHolonomyDefect left right) ∧
+      (∀ {p : CodebaseTraceHolonomyPacket.TupleProfile}
+        (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+        {left right : SourceRefPacket}
+        {component : SourceRefPacketProtectedComponent},
+        RouteDefectSupport left right component ->
+          TupleHolonomyDefectInvariant.TupleHolonomyDefect
+            (SourceRefTupleBridge.packetToTuple gridLeft left)
+            (SourceRefTupleBridge.packetToTuple gridRight right)
+            (packetComponentToTupleComponent component)) ∧
+      (∀ {left middle right : SourceRefPacket}
+        (_hzero : NoSourceRefPacketHolonomyDefect left middle)
+        (component : SourceRefPacketProtectedComponent),
+        RouteDefectSupport middle right component ↔
+          RouteDefectSupport left right component) ∧
+      (∀ {left middle right : SourceRefPacket}
+        (_hzero : NoSourceRefPacketHolonomyDefect middle right)
+        (component : SourceRefPacketProtectedComponent),
+        RouteDefectSupport left middle component ↔
+          RouteDefectSupport left right component) ∧
+      supportSurfaceReading.Equivalent tableRouteLeft tableRouteRight ∧
+      TokenSwapRouteExactTablePairSupport ∧
+      supportSurfaceReading.Equivalent visibleRouteLeft visibleRouteRight ∧
+      VisibleRepairTransportDefectSupportTriple := by
+  exact ⟨routeDefectSupport_empty_iff_noPacketHolonomy,
+    by
+      intro p gridLeft gridRight left right component hdefect
+      exact routeDefectSupport_projects_to_tupleDefects
+        gridLeft gridRight hdefect,
+    by
+      intro left middle right hzero component
+      exact routeDefectSupport_propagates_left_of_zero hzero component,
+    by
+      intro left middle right hzero component
+      exact routeDefectSupport_propagates_right_of_zero hzero component,
+    TransportTableLawRouteLocalization.tokenSwapRoute_visiblePacketSurface,
+    tokenSwapRoute_defectSupport_exact_tablePair,
+    VisibleRepairTransportCommutator.repairTransport_visiblePacketSurface_commutes,
+    visibleRepairTransport_defectSupport_triple⟩
+
+end RouteDefectSupportTheory
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-route-defect-support-calculus.md
+++ b/research/ideas/g-aat-quality-surface-01-route-defect-support-calculus.md
@@ -1,0 +1,144 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: certificate-transport / traceability / obstruction / invariance / repair-potential / computability
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle38
+tags: [quality-surface, route-defect, holonomy, support, repair-transport, source-ref]
+created: 2026-06-20
+cycle: 38
+lean: Formal/AG/Research/QualitySurface/RouteDefectSupport.lean
+---
+
+# Route defect support calculus for selected repair/transport endpoints
+
+## 主張
+
+repair/transport endpoint pair に対し、component-indexed packet holonomy defect を `RouteDefectSupport`
+として読む。support が空であることは packet zero holonomy と同値であり、defect support は packet-to-tuple
+bridge を通じて tuple protected component defect へ射影される。また zero packet leg に沿って route defect support は
+preserve / reflect される。
+
+selected witnesses では、Cycle 37 の transport table-law deletion route は `sourceRefTable endpoint` と
+`sourceRefTable worker` の exact two-table support を持つ。ここで exact とは、この二つの table components で defect があり、
+obligation、全 repair frontier components、`sourceRefTable storage` では defect がない、という pointwise
+nonmembership を含む。Cycle 28 の visible-only repair/transport route は obligation、`repairFrontier storage`、
+`sourceRefTable storage` の exact triple support を持つ。こちらも triple 以外の source-ref table / repair-frontier
+coordinates では defect がないことを含む。したがって visible route flatness は route defect support に faithful ではなく、
+commutator defect は atom/component support を持つ traceable obstruction として計算できる。
+
+これは global な minimality matrix ではなく、route endpoint pair の defect support calculus と selected finite witness
+計算である。`RouteDefectSupport` の名前替えだけでは成果としない。exact two-table / triple support の membership と
+off-coordinate nonmembership を Lean statement に含める。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- Cycle 23: `Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean`
+- Cycle 26: `Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean`
+- Cycle 28: `Formal/AG/Research/QualitySurface/VisibleRepairTransportCommutator.lean`
+- Cycle 37: `Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean`
+
+## 非自明性
+
+既存成果は component defect の存在や source-ref exact visualization failure を個別に示している。この候補は、
+route endpoint pair の defect を support calculus として再読し、空性同値、tuple projection、zero-leg propagation、
+selected exact two-table/triple support 計算を同じ Lean package に入れる。特に exact support 計算では、defect がある
+coordinate だけでなく、他 coordinate に defect がないことを全 component case で固定する。これにより単なる defect
+predicate の名前替えを避け、route defect を traceable support として運ぶための再利用可能な証拠境界を作る。
+
+## 数学的興味
+
+repair/transport commutator defect を、命題の失敗ではなく atom/component support を持つ obstruction として扱える。
+これにより、source-ref exactness、loss-aware visualization、lawful criterion minimality matrix の各 cell を、
+「どの protected coordinate が defect を支えるか」という幾何的な言葉で比較できる。
+
+## GOAL への前進
+
+selected commutator localization と route defect support calculus の frontier を直接進める。特に、Cycle 37 の
+`open_questions` に残った route defect support calculus を Lean-backed な計算対象へ移す。
+
+## SCORE 見込み
+
+- `score_reason`: 直近 cycles の table-law / frontier-local / visible-only route obstruction を、traceable support calculus へ圧縮する。GOAL の certificate-transport、traceability、obstruction、repair-potential、computability を同時に増やすが、新現象そのものより再編成と support 化が主なので、G2 A の保守評価に合わせて base 70 / final 140 とする。
+- `dullness_risk`: medium。`RouteDefectSupport := SourceRefPacketHolonomyDefect` の単なる別名に留まると低価値。empty iff、tuple projection、zero-leg propagation、Cycle 37 exact two-table support、Cycle 28 exact triple support、off-coordinate nonmembership を入れることで研究差分を確保する。
+- `proof_or_evidence_plan`: `CodebaseTraceHolonomyPacket` の component defect と `ComponentDefectPropagation` の zero-leg propagation を使う。Cycle 37 route endpoint pair と Cycle 28 visible-only route endpoint pair に対し、support membership と non-membership を component cases で証明する。`propext` を避けるため、Set equality ではなく pointwise membership / non-membership theorem と package theorem を優先する。
+
+## CS / SWE への帰結
+
+repair/transport dashboard や report surface は、visible commutation の有無だけでなく、route defect support を
+component label と atom label の drill-down として表示できる。table-only loss と multi-component loss を同じ
+route surface に載せられる。ただしこの候補が示すのは supplied finite packets と selected route endpoint pair に相対化された
+Lean witness であり、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
+## 証明・根拠
+
+Lean file:
+
+- `Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`
+
+Lean declarations:
+
+- `RouteComponentAgreement`
+- `RouteDefectSupport`
+- `RouteDefectSupportEmpty`
+- `routeDefectSupport_iff_packetHolonomyDefect`
+- `routeDefectSupport_empty_iff_noPacketHolonomy`
+- `routeDefectSupport_projects_to_tupleDefects`
+- `routeDefectSupport_propagates_left_of_zero`
+- `routeDefectSupport_propagates_right_of_zero`
+- `tokenSwapRoute_defectSupport_endpointTable`
+- `tokenSwapRoute_defectSupport_workerTable`
+- `tokenSwapRoute_noObligationDefect`
+- `tokenSwapRoute_noRepairFrontierDefect`
+- `tokenSwapRoute_noStorageTableDefect`
+- `tokenSwapRoute_defectSupport_exact_tablePair`
+- `visibleRepairTransport_defectSupport_obligation`
+- `visibleRepairTransport_defectSupport_storageRepair`
+- `visibleRepairTransport_defectSupport_storageTable`
+- `visibleRepairTransport_noRepairFrontierDefect_offStorage`
+- `visibleRepairTransport_noTableDefect_offStorage`
+- `visibleRepairTransport_defectSupport_triple`
+- `routeDefectSupportCalculus_package`
+
+Claim boundary:
+
+- finite `SourceRefPacket`
+- component-indexed `SourceRefPacketProtectedComponent`
+- selected repair/transport endpoint pairs already supplied in `Formal/AG/Research`
+- explicit packet-to-tuple bridge
+- pointwise support membership / non-membership, not global codebase quality
+
+Local G3 checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake env lean .tmp/route_defect_support_axioms.lean`: pass; reported declarations depend on no axioms
+- `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`: pass; no hits in the Lean evidence file
+
+## 審判メモ
+
+- 厳密性: 初回 G2 A は `revise`、base 45。一般 calculus 部分は既存定理の pointwise lift に近いため、Cycle 37 exact support と Cycle 28 triple support を、存在だけでなく全 off-coordinate nonmembership まで含む theorem として明示することが要求された。実装前確認で Cycle 37 token-swap route は endpoint だけでなく worker も table defect を持つため、claim を exact two-table support に修正した。再審査は `accept`、base 70。
+- 研究価値: G2 B は `accept`、base 75。新現象そのものより再編成と support 化が主なので、初期期待 base 80 から 75 へ下げる。
+- repo 全体価値: G2 C は `accept`、base 75。Lean / paper / future loss-aware visualization surface に価値があるが、selected finite witness を tooling verdict や whole-codebase quality へ昇格しないことが要求された。
+- G3 audit summary: 公理 harness は reported declarations すべて axiom-free。Lean は `RouteDefectSupport` の空性同値、tuple projection、zero-leg propagation、Cycle 37 exact two-table support、Cycle 28 exact triple support を pointwise membership / nonmembership として表現している。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-transport-table-law-route-localization.md`
+- `research/ideas/g-aat-quality-surface-01-visible-repair-transport-commutator.md`
+- `research/ideas/g-aat-quality-surface-01-supported-token-mismatch-obstruction.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 38 G1 で三者の候補生成から採択候補として作成。複数 agent が route defect support calculus または exact support localization を推した。
+- 2026-06-20: G2 A の `revise` を受け、expected score を base 75 / final 150 に下げ、exact support と off-coordinate nonmembership を必須化した。実装前確認により Cycle 37 は singleton ではなく endpoint/worker の exact two-table support として修正した。
+- 2026-06-20: G2 A 再審査が `accept`、base 70。保守評価に合わせて expected score を base 70 / final 140 に更新した。
+- 2026-06-20: G3 Lean 実装を追加。対象 file、`FormalAGResearch`、axiom harness が pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 4580
+- total SCORE: 4720
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -42,8 +42,9 @@
   - repair-potential / certificate-transport / traceability / invariance / obstruction: 260
   - repair-potential / obstruction / traceability / invariance: 150
   - obstruction / certificate-transport / traceability / invariance / quality-surface: 100
+  - certificate-transport / traceability / obstruction / invariance / repair-potential / computability: 140
 - evidence portfolio:
-  - proved-in-research: 37
+  - proved-in-research: 38
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1632,9 +1633,50 @@ matrix の完全分類ではなく、table-law deletion による selected local
 source-ref packets、token-swap update、declared repair action、selected route endpoint comparison に相対化され、
 canonical transport、canonical repair planning、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 38: Route defect support calculus for selected repair/transport endpoints
+
+```text
+candidate: Route defect support calculus for selected repair/transport endpoints
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: certificate-transport/traceability/obstruction/invariance/repair-potential/computability
+goal_delta: repair/transport endpoint defect を component-indexed support calculus として読み、empty iff zero holonomy、tuple projection、zero-leg propagation、selected exact support 計算を固定した。
+project_value_delta: visible-flat route の table-only two-coordinate support と multi-component triple support を同じ route support calculus で比較できるようにした。
+formalization_quality: pass。主張は finite SourceRefPacket、selected endpoint pair、explicit packet-to-tuple bridge に限定され、global minimality matrix や whole-codebase quality へ越境していない。reported declarations は axiom-free / sorry-free。
+open_questions: support/action/obligation/visible law deletion cells、route defect support の minimal support family 化、loss-aware visualization surface への整理。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/RouteDefectSupport.lean` は、route endpoint pair の protected defect を
+`RouteDefectSupport` として読む。`RouteComponentAgreement` は obligation、atom-indexed repair frontier、
+atom-indexed source-ref table の component agreement を与え、`RouteDefectSupportEmpty` は全 component agreement を
+pointwise に要求する。
+
+Lean 証拠は次を固定する。
+
+- `routeDefectSupport_iff_packetHolonomyDefect`: route defect support は component-indexed packet holonomy defect と一致する。
+- `routeDefectSupport_empty_iff_noPacketHolonomy`: empty route defect support は packet zero holonomy と同値。
+- `routeDefectSupport_projects_to_tupleDefects`: route defect support は packet-to-tuple bridge で tuple protected component defect へ射影される。
+- `routeDefectSupport_propagates_left_of_zero` / `routeDefectSupport_propagates_right_of_zero`: zero packet-holonomy leg に沿って defect support は preserve / reflect される。
+- `tokenSwapRoute_defectSupport_exact_tablePair`: Cycle 37 table-law route は endpoint / worker source-ref table の exact two-table support を持ち、obligation、全 repair frontier、storage table coordinate は flat。
+- `visibleRepairTransport_defectSupport_triple`: Cycle 28 visible-only route は obligation、storage repair frontier、storage source-ref table の exact triple support を持ち、storage 以外の repair frontier / table coordinates は flat。
+- `routeDefectSupportCalculus_package`: empty criterion、tuple projection、zero-leg propagation、two selected exact support computations を束ねる。
+
+この結果により、visible route flatness は route defect support に faithful ではないことが、二つの異なる finite witness で
+明確になる。Cycle 37 の table-law deletion は table coordinate pair に defect support を局在させ、Cycle 28 の visible-only
+route は obligation / frontier / table の multi-component support を持つ。主張は supplied finite source-ref packets、
+selected route endpoint pair、explicit packet-to-tuple bridge に相対化され、lawful criterion minimality matrix の完全分類、
+canonical transport、canonical repair planning、source extraction completeness、ArchMap correctness、
+実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 37 後の total SCORE は 4580 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 38 後の total SCORE は 4720 である。
 次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
 lawful repair/transport criterion minimality matrix、


### PR DESCRIPTION
## 概要

Refs #2348

`G-aat-quality-surface-01` の research-loop Cycle 38 として、repair/transport endpoint pair の protected defect を component-indexed route defect support として読む Lean 証拠を追加しました。

Cycle 37 table-law route の endpoint / worker table two-coordinate support と、Cycle 28 visible-only route の obligation / storage repair-frontier / storage table triple support を exact membership / off-coordinate nonmembership まで固定しています。

## 証明した定理

- `RouteComponentAgreement`
- `RouteDefectSupport`
- `RouteDefectSupportEmpty`
- `routeDefectSupport_iff_packetHolonomyDefect`
- `routeDefectSupport_empty_iff_noPacketHolonomy`
- `routeDefectSupport_projects_to_tupleDefects`
- `routeDefectSupport_propagates_left_of_zero`
- `routeDefectSupport_propagates_right_of_zero`
- `tokenSwapRoute_defectSupport_endpointTable`
- `tokenSwapRoute_defectSupport_workerTable`
- `tokenSwapRoute_noObligationDefect`
- `tokenSwapRoute_noRepairFrontierDefect`
- `tokenSwapRoute_noStorageTableDefect`
- `tokenSwapRoute_defectSupport_exact_tablePair`
- `visibleRepairTransport_defectSupport_obligation`
- `visibleRepairTransport_defectSupport_storageRepair`
- `visibleRepairTransport_defectSupport_storageTable`
- `visibleRepairTransport_noRepairFrontierDefect_offStorage`
- `visibleRepairTransport_noTableDefect_offStorage`
- `visibleRepairTransport_defectSupport_triple`
- `routeDefectSupportCalculus_package`

Lean status: `proved-in-research`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-route-defect-support-calculus.md`
- `research/reports/G-aat-quality-surface-01.md`

## SCORE

- base SCORE: 70
- evidence multiplier: 2.0
- penalty: 0
- final SCORE: 140
- total SCORE: 4720 / 5000
- category: certificate-transport / traceability / obstruction / invariance / repair-potential / computability

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/route_defect_support_axioms.lean`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] tracking Issue は research-loop 規律により `Refs #2348` として記載した。`Closes` は使っていない
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
