### PR TITLE
研究: route defect excursion support を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -38,3 +38,4 @@ import Formal.AG.Research.QualitySurface.FrontierLocalRepairTransportCommutator
 import Formal.AG.Research.QualitySurface.TransportTableLawRouteLocalization
 import Formal.AG.Research.QualitySurface.RouteDefectSupport
 import Formal.AG.Research.QualitySurface.VisibleLawDeletionProtectedZero
+import Formal.AG.Research.QualitySurface.RouteDefectExcursionSupport

--- a/Formal/AG/Research/QualitySurface/RouteDefectExcursionSupport.lean
+++ b/Formal/AG/Research/QualitySurface/RouteDefectExcursionSupport.lean
@@ -1,0 +1,375 @@
+import Formal.AG.Research.QualitySurface.RouteDefectSupport
+import Formal.AG.Research.QualitySurface.SourceRefTableLawObstruction
+
+/-!
+Cycle 40 evidence for `G-aat-quality-surface-01`.
+
+This file promotes route-defect support from an endpoint-pair predicate to a
+path-internal excursion certificate.  A route chain can have empty endpoint
+defect support while carrying nonempty internal defect support along its legs.
+The selected token-swap/un-swap chain is the finite witness: it starts and ends
+at the same full packet, so endpoint support is empty, but both internal legs
+carry exact endpoint/worker source-ref table support.
+
+The claim is relative to supplied finite source-ref packets, selected route
+chains, and the explicit packet-to-tuple bridge.  It does not assert a global
+additive defect group, canonical transport, canonical repair planning, source
+extraction completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace RouteDefectExcursionSupport
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+open RouteDefectSupportTheory
+open SourceRefTableLawObstruction
+
+/-! ## Internal route-chain support -/
+
+/-- Internal route defect support carried by either leg of a length-two chain. -/
+def InternalRouteDefectSupport
+    (left middle right : SourceRefPacket)
+    (component : SourceRefPacketProtectedComponent) : Prop :=
+  RouteDefectSupport left middle component ∨
+    RouteDefectSupport middle right component
+
+/-- Endpoint route defect support of a length-two chain. -/
+def EndpointRouteDefectSupport
+    (left _middle right : SourceRefPacket)
+    (component : SourceRefPacketProtectedComponent) : Prop :=
+  RouteDefectSupport left right component
+
+/-- A component is an internal excursion when it appears internally but not at the endpoint. -/
+def RouteDefectExcursion
+    (left middle right : SourceRefPacket)
+    (component : SourceRefPacketProtectedComponent) : Prop :=
+  InternalRouteDefectSupport left middle right component ∧
+    ¬ EndpointRouteDefectSupport left middle right component
+
+/-- Same endpoint support for two selected chains. -/
+def SameEndpointRouteDefectSupport
+    (left₁ middle₁ right₁ left₂ middle₂ right₂ : SourceRefPacket) : Prop :=
+  ∀ component,
+    EndpointRouteDefectSupport left₁ middle₁ right₁ component ↔
+      EndpointRouteDefectSupport left₂ middle₂ right₂ component
+
+/-- Same internal support for two selected chains. -/
+def SameInternalRouteDefectSupport
+    (left₁ middle₁ right₁ left₂ middle₂ right₂ : SourceRefPacket) : Prop :=
+  ∀ component,
+    InternalRouteDefectSupport left₁ middle₁ right₁ component ↔
+      InternalRouteDefectSupport left₂ middle₂ right₂ component
+
+/-- If the left boundary leg is zero, internal support equals endpoint support. -/
+theorem internalRouteDefectSupport_eq_endpoint_leftZero
+    {left middle right : SourceRefPacket}
+    (hzero : NoSourceRefPacketHolonomyDefect left middle)
+    (component : SourceRefPacketProtectedComponent) :
+    InternalRouteDefectSupport left middle right component ↔
+      EndpointRouteDefectSupport left middle right component := by
+  constructor
+  · intro hinternal
+    cases hinternal with
+    | inl hleft =>
+        exact (False.elim
+          (sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy
+            ((routeDefectSupport_iff_packetHolonomyDefect
+              left middle component).mp hleft) hzero))
+    | inr hright =>
+        exact (routeDefectSupport_propagates_left_of_zero
+          hzero component).mp hright
+  · intro hendpoint
+    exact Or.inr ((routeDefectSupport_propagates_left_of_zero
+      hzero component).mpr hendpoint)
+
+/-- If the right boundary leg is zero, internal support equals endpoint support. -/
+theorem internalRouteDefectSupport_eq_endpoint_rightZero
+    {left middle right : SourceRefPacket}
+    (hzero : NoSourceRefPacketHolonomyDefect middle right)
+    (component : SourceRefPacketProtectedComponent) :
+    InternalRouteDefectSupport left middle right component ↔
+      EndpointRouteDefectSupport left middle right component := by
+  constructor
+  · intro hinternal
+    cases hinternal with
+    | inl hleft =>
+        exact (routeDefectSupport_propagates_right_of_zero
+          hzero component).mp hleft
+    | inr hright =>
+        exact (False.elim
+          (sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy
+            ((routeDefectSupport_iff_packetHolonomyDefect
+              middle right component).mp hright) hzero))
+  · intro hendpoint
+    exact Or.inl ((routeDefectSupport_propagates_right_of_zero
+      hzero component).mpr hendpoint)
+
+/-- Visible tuple equivalence plus empty endpoint support gives source-ref exact visualization. -/
+theorem sourceRefExact_of_visible_and_emptyRouteSupport
+    {p : CodebaseTraceHolonomyPacket.TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket}
+    (hvisible :
+      TupleVisibleVisualizationEquivalent gridLeft gridRight left right)
+    (hempty : RouteDefectSupportEmpty left right) :
+    SourceRefExactVisualization gridLeft gridRight left right := by
+  have hzero :
+      NoSourceRefPacketHolonomyDefect left right :=
+    (routeDefectSupport_empty_iff_noPacketHolonomy left right).mp
+      hempty
+  exact (sourceRefExactVisualization_iff_visible_packetZeroHolonomy
+    gridLeft gridRight left right).mpr ⟨hvisible, hzero⟩
+
+/-! ## Flat chain and token-swap/un-swap chain -/
+
+abbrev flatChainLeft : SourceRefPacket := fullPacket
+abbrev flatChainMiddle : SourceRefPacket := fullPacket
+abbrev flatChainRight : SourceRefPacket := fullPacket
+
+abbrev tokenSwapChainLeft : SourceRefPacket := fullPacket
+abbrev tokenSwapChainMiddle : SourceRefPacket := tokenSwappedFullPacket
+abbrev tokenSwapChainRight : SourceRefPacket := fullPacket
+
+/-- The flat chain has empty endpoint support. -/
+theorem flatChain_endpointSupport_empty
+    (component : SourceRefPacketProtectedComponent) :
+    ¬ EndpointRouteDefectSupport
+      flatChainLeft flatChainMiddle flatChainRight component := by
+  intro hsupport
+  have hzero :
+      NoSourceRefPacketHolonomyDefect flatChainLeft flatChainRight :=
+    ComponentHolonomyDefectPropagation.noSourceRefPacketHolonomyDefect_refl
+      flatChainLeft
+  exact sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy
+    ((routeDefectSupport_iff_packetHolonomyDefect
+      flatChainLeft flatChainRight component).mp hsupport) hzero
+
+/-- The flat chain has empty internal support. -/
+theorem flatChain_internalSupport_empty
+    (component : SourceRefPacketProtectedComponent) :
+    ¬ InternalRouteDefectSupport
+      flatChainLeft flatChainMiddle flatChainRight component := by
+  intro hinternal
+  cases hinternal with
+  | inl hleft =>
+      have hzero :
+          NoSourceRefPacketHolonomyDefect flatChainLeft flatChainMiddle :=
+        ComponentHolonomyDefectPropagation.noSourceRefPacketHolonomyDefect_refl
+          flatChainLeft
+      exact sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy
+        ((routeDefectSupport_iff_packetHolonomyDefect
+          flatChainLeft flatChainMiddle component).mp hleft) hzero
+  | inr hright =>
+      have hzero :
+          NoSourceRefPacketHolonomyDefect flatChainMiddle flatChainRight :=
+        ComponentHolonomyDefectPropagation.noSourceRefPacketHolonomyDefect_refl
+          flatChainMiddle
+      exact sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy
+        ((routeDefectSupport_iff_packetHolonomyDefect
+          flatChainMiddle flatChainRight component).mp hright) hzero
+
+/-- The token-swap/un-swap chain has empty endpoint support. -/
+theorem tokenSwapUnswap_endpointSupport_empty
+    (component : SourceRefPacketProtectedComponent) :
+    ¬ EndpointRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight component := by
+  intro hsupport
+  have hzero :
+      NoSourceRefPacketHolonomyDefect tokenSwapChainLeft tokenSwapChainRight :=
+    ComponentHolonomyDefectPropagation.noSourceRefPacketHolonomyDefect_refl
+      tokenSwapChainLeft
+  exact sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy
+    ((routeDefectSupport_iff_packetHolonomyDefect
+      tokenSwapChainLeft tokenSwapChainRight component).mp hsupport) hzero
+
+/-- The first token-swap leg has endpoint table internal support. -/
+theorem tokenSwapUnswap_internalSupport_endpointTable :
+    InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) :=
+  Or.inl ((routeDefectSupport_iff_packetHolonomyDefect
+    tokenSwapChainLeft tokenSwapChainMiddle
+    (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint)).mpr
+    tokenSwap_sourceRefTable_componentDefect)
+
+/-- The first token-swap leg also has worker table internal support. -/
+theorem tokenSwapUnswap_internalSupport_workerTable :
+    InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.worker) := by
+  apply Or.inl
+  intro hagree
+  change some SourceRefToken.workerRef = some SourceRefToken.endpointRef at hagree
+  cases hagree
+
+/-- The token-swap/un-swap chain has no internal obligation support. -/
+theorem tokenSwapUnswap_noInternalObligationSupport :
+    ¬ InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      SourceRefPacketProtectedComponent.obligation := by
+  intro hinternal
+  cases hinternal with
+  | inl hleft =>
+      exact hleft rfl
+  | inr hright =>
+      exact hright rfl
+
+/-- The token-swap/un-swap chain has no internal repair-frontier support. -/
+theorem tokenSwapUnswap_noInternalRepairFrontierSupport
+    (atom : CodeAtom) :
+    ¬ InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.repairFrontier atom) := by
+  intro hinternal
+  cases hinternal with
+  | inl hleft =>
+      exact hleft (tokenSwap_repairFrontier_flat atom)
+  | inr hright =>
+      exact hright (by
+        exact (tokenSwap_repairFrontier_flat atom).symm)
+
+/-- The token-swap/un-swap chain has no internal storage-table support. -/
+theorem tokenSwapUnswap_noInternalStorageTableSupport :
+    ¬ InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) := by
+  intro hinternal
+  cases hinternal with
+  | inl hleft =>
+      exact hleft rfl
+  | inr hright =>
+      exact hright rfl
+
+/--
+Exact internal support computation for the token-swap/un-swap chain: endpoint
+and worker source-ref table coordinates carry the internal excursion, while
+obligation, all repair-frontier coordinates, and storage table are flat.
+-/
+def TokenSwapUnswapExactInternalTablePairSupport : Prop :=
+    InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) ∧
+    InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.worker) ∧
+    ¬ InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      SourceRefPacketProtectedComponent.obligation ∧
+    (∀ atom,
+      ¬ InternalRouteDefectSupport
+        tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+        (SourceRefPacketProtectedComponent.repairFrontier atom)) ∧
+    ¬ InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage)
+
+/-- The token-swap/un-swap chain has exact endpoint/worker table internal support. -/
+theorem tokenSwapUnswap_internalSupport_exact_tablePair :
+    TokenSwapUnswapExactInternalTablePairSupport :=
+  ⟨tokenSwapUnswap_internalSupport_endpointTable,
+    tokenSwapUnswap_internalSupport_workerTable,
+    tokenSwapUnswap_noInternalObligationSupport,
+    tokenSwapUnswap_noInternalRepairFrontierSupport,
+    tokenSwapUnswap_noInternalStorageTableSupport⟩
+
+/-- The token-swap/un-swap chain carries an internal endpoint-table excursion. -/
+theorem tokenSwapUnswap_endpointTable_excursion :
+    RouteDefectExcursion
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) :=
+  ⟨tokenSwapUnswap_internalSupport_endpointTable,
+    tokenSwapUnswap_endpointSupport_empty
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint)⟩
+
+/-- Flat and token-swap/un-swap chains agree at endpoint support. -/
+theorem flat_tokenSwapUnswap_sameEndpointSupport :
+    SameEndpointRouteDefectSupport
+      flatChainLeft flatChainMiddle flatChainRight
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight := by
+  intro component
+  constructor
+  · intro hflat
+    exact False.elim (flatChain_endpointSupport_empty component hflat)
+  · intro hswap
+    exact False.elim (tokenSwapUnswap_endpointSupport_empty component hswap)
+
+/-- Endpoint support is not faithful to internal route-defect support. -/
+theorem endpointSupport_not_faithful_to_internalSupport :
+    SameEndpointRouteDefectSupport
+        flatChainLeft flatChainMiddle flatChainRight
+        tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight ∧
+      ¬ SameInternalRouteDefectSupport
+        flatChainLeft flatChainMiddle flatChainRight
+        tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight := by
+  refine ⟨flat_tokenSwapUnswap_sameEndpointSupport, ?_⟩
+  intro hsame
+  have hflatInternal :
+      InternalRouteDefectSupport
+        flatChainLeft flatChainMiddle flatChainRight
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) :=
+    (hsame
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint)).mpr
+      tokenSwapUnswap_internalSupport_endpointTable
+  exact flatChain_internalSupport_empty
+    (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint)
+    hflatInternal
+
+/-! ## Theorem package -/
+
+/--
+Cycle-40 theorem package: internal route-defect support localizes to endpoint
+support across zero boundary legs, but endpoint support is not faithful to
+path-internal defect excursions.
+-/
+theorem routeDefectExcursionSupport_package :
+    (∀ {left middle right : SourceRefPacket}
+      (_hzero : NoSourceRefPacketHolonomyDefect left middle)
+      (component : SourceRefPacketProtectedComponent),
+      InternalRouteDefectSupport left middle right component ↔
+        EndpointRouteDefectSupport left middle right component) ∧
+    (∀ {left middle right : SourceRefPacket}
+      (_hzero : NoSourceRefPacketHolonomyDefect middle right)
+      (component : SourceRefPacketProtectedComponent),
+      InternalRouteDefectSupport left middle right component ↔
+        EndpointRouteDefectSupport left middle right component) ∧
+    (∀ {p : CodebaseTraceHolonomyPacket.TupleProfile}
+      (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+      {left right : SourceRefPacket},
+      TupleVisibleVisualizationEquivalent gridLeft gridRight left right ->
+        RouteDefectSupportEmpty left right ->
+        SourceRefExactVisualization gridLeft gridRight left right) ∧
+    (∀ component,
+      ¬ EndpointRouteDefectSupport
+        tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight component) ∧
+    TokenSwapUnswapExactInternalTablePairSupport ∧
+    RouteDefectExcursion
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint) ∧
+    SameEndpointRouteDefectSupport
+      flatChainLeft flatChainMiddle flatChainRight
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight ∧
+    ¬ SameInternalRouteDefectSupport
+      flatChainLeft flatChainMiddle flatChainRight
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight := by
+  exact ⟨by
+      intro left middle right hzero component
+      exact internalRouteDefectSupport_eq_endpoint_leftZero hzero component,
+    by
+      intro left middle right hzero component
+      exact internalRouteDefectSupport_eq_endpoint_rightZero hzero component,
+    by
+      intro p gridLeft gridRight left right hvisible hempty
+      exact sourceRefExact_of_visible_and_emptyRouteSupport
+        gridLeft gridRight hvisible hempty,
+    tokenSwapUnswap_endpointSupport_empty,
+    tokenSwapUnswap_internalSupport_exact_tablePair,
+    tokenSwapUnswap_endpointTable_excursion,
+    flat_tokenSwapUnswap_sameEndpointSupport,
+    endpointSupport_not_faithful_to_internalSupport.2⟩
+
+end RouteDefectExcursionSupport
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-route-defect-local-to-global.md
+++ b/research/ideas/g-aat-quality-surface-01-route-defect-local-to-global.md
@@ -1,0 +1,140 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: certificate-transport / obstruction / invariance / computability / repair-potential
+expected_base_score: 75
+expected_evidence_multiplier: 2.0
+expected_final_score: 150
+evidence_stage: proved-in-research
+origin: cycle-40
+tags: [quality-surface, route-defect-support, localization, cancellation]
+created: 2026-06-20
+---
+
+# Route-chain defect excursion support and selected local-to-global localization
+
+## 主張
+
+selected finite route chain `left -> middle -> right` において、片側 boundary leg が protected-zero なら、もう片側 local leg の route defect support は global endpoint route defect support と一致する。したがって selected decomposition の周辺 cell が zero である regime では、global endpoint defect support は selected nonzero cell support に局在する。
+
+主対象は endpoint support ではなく、chain 内部の二つの leg の defect を合併して読む `InternalRouteDefectSupport` である。boundary leg も nonzero の場合には、二つの local route defect support が endpoint で cancellation しうる。特に flat chain `full -> full -> full` と token-swap/un-swap chain `full -> swapped -> full` は同じ empty endpoint support を持つが、internal support は後者だけが endpoint/worker table coordinates に非空である。したがって endpoint support だけを読む surface は、path-internal defect excursion に faithful ではない。
+
+この主張は supplied finite source-ref packets、selected route endpoint chain、explicit packet-to-tuple bridge に相対化される。global additive defect group、canonical transport、canonical repair planning、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
+## 候補種別
+
+`closure`
+
+## Lean 証拠
+
+- `Formal/AG/Research/QualitySurface/RouteDefectExcursionSupport.lean`
+- `Formal/AG/Research.lean`
+
+主要 declaration:
+
+- `InternalRouteDefectSupport`
+- `EndpointRouteDefectSupport`
+- `RouteDefectExcursion`
+- `SameEndpointRouteDefectSupport`
+- `SameInternalRouteDefectSupport`
+- `internalRouteDefectSupport_eq_endpoint_leftZero`
+- `internalRouteDefectSupport_eq_endpoint_rightZero`
+- `sourceRefExact_of_visible_and_emptyRouteSupport`
+- `flatChain_endpointSupport_empty`
+- `flatChain_internalSupport_empty`
+- `tokenSwapUnswap_endpointSupport_empty`
+- `tokenSwapUnswap_internalSupport_endpointTable`
+- `tokenSwapUnswap_internalSupport_workerTable`
+- `tokenSwapUnswap_noInternalObligationSupport`
+- `tokenSwapUnswap_noInternalRepairFrontierSupport`
+- `tokenSwapUnswap_noInternalStorageTableSupport`
+- `TokenSwapUnswapExactInternalTablePairSupport`
+- `tokenSwapUnswap_internalSupport_exact_tablePair`
+- `tokenSwapUnswap_endpointTable_excursion`
+- `flat_tokenSwapUnswap_sameEndpointSupport`
+- `endpointSupport_not_faithful_to_internalSupport`
+- `routeDefectExcursionSupport_package`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/ComponentDefectPropagation.lean`
+- `Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefRepairHolonomy.lean`
+- `Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean`
+- `Formal/AG/Research/QualitySurface/VisibleRepairTransportCommutator.lean`
+
+## 非自明性
+
+Cycle 38 は route defect support の empty criterion、tuple projection、zero-leg propagation、selected exact support computation を与えた。この候補は、endpoint pair ではなく route chain 内部の defect excursion を新しい certificate surface として定義し、どの条件で local defect が endpoint defect と一致するか、またどの条件で endpoint から消えるかを分離する。
+
+## 数学的興味
+
+Quality Surface の endpoint reading は path の内部履歴を忘れる。zero boundary leg があると defect support は正確に伝播するが、二つの nonzero legs では cancellation により endpoint support が空になりうる。この「internal support / endpoint support / cancellation boundary」の三分法は、profile grid や repair/transport square を局所 obstruction geometry として読むための有限 calculus になる。
+
+## GOAL への前進
+
+route defect support を単発 endpoint predicate から finite chain 内部の defect excursion certificate へ上げる。これは selected commutator localization、profile curvature、loss-aware visualization、repair-potential の frontier に直接接続する。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 38 の route support calculus と Cycle 26 の cancellation witness を、`InternalRouteDefectSupport` という新しい chain certificate surface に統合する。G2 再審判は base 75 で一致したため、flat chain と token-swap/un-swap chain の same endpoint / different internal support nonfaithfulness まで Lean-proved できた場合の expected score を base 75 / final 150 に下げる。
+- `dullness_risk`: zero-leg propagation theorem の再掲だけなら dull。internal support object、endpoint-support nonfaithfulness、token-swap/un-swap の exact internal support computation、source-ref exactness criterion を同じ package に入れる必要がある。
+- `proof_or_evidence_plan`: 完了。`InternalRouteDefectSupport`、`RouteDefectExcursion`、`SameEndpointRouteDefectSupport`、`SameInternalRouteDefectSupport` を定義した。既存 zero-leg propagation を internal/endpoint support equality として再利用しつつ、flat chain と token-swap/un-swap chain の endpoint support は同じ empty だが internal support が異なることを Lean で証明した。token-swap/un-swap chain では internal support が endpoint/worker table pair にちょうど局在し、obligation、repair frontier、storage table coordinate には出ないことを明示した。
+
+## CS / SWE への帰結
+
+endpoint dashboard が clean に見えても、profile path の途中で defect excursion が発生している可能性がある。逆に、周辺 boundary が protected-zero であることが確認できる場合には、endpoint defect badge を selected local cell へ正確に戻せる。
+
+## 証明・根拠
+
+Lean では次の declaration を固定した。
+
+- `InternalRouteDefectSupport`
+- `EndpointRouteDefectSupport`
+- `RouteDefectExcursion`
+- `SameEndpointRouteDefectSupport`
+- `SameInternalRouteDefectSupport`
+- `internalRouteDefectSupport_eq_endpoint_leftZero`
+- `internalRouteDefectSupport_eq_endpoint_rightZero`
+- `sourceRefExact_of_visible_and_emptyRouteSupport`
+- `tokenSwapUnswap_internalSupport_exact_tablePair`
+- `tokenSwapUnswap_endpointSupport_empty`
+- `tokenSwapUnswap_internalSupport_endpointTable`
+- `tokenSwapUnswap_internalSupport_workerTable`
+- `tokenSwapUnswap_noInternalObligationSupport`
+- `tokenSwapUnswap_noInternalRepairFrontierSupport`
+- `tokenSwapUnswap_noInternalStorageTableSupport`
+- `endpointSupport_not_faithful_to_internalSupport`
+- `routeDefectExcursionSupport_package`
+
+検証:
+
+- `lake env lean Formal/AG/Research/QualitySurface/RouteDefectExcursionSupport.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `.tmp/route_defect_excursion_axioms.lean`: 全対象 declaration が axiom 依存なし
+- `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal/AG/Research Formal/AG/Research.lean`: 新規差分に該当なし
+
+G3 監査:
+
+- 公理検査: pass。全対象 declaration は `does not depend on any axioms`。`sorryAx`、`propext`、`Classical.choice`、`Quot.sound` は残っていない。
+- Lean 形式化品質監査: pass。zero-boundary localization、token-swap/un-swap exact internal support table pair、off-coordinate nonmembership、flat/token-swap same endpoint but different internal support nonfaithfulness が候補主張の強さで表現されている。arbitrary-length chain abstraction は未主張であり、この候補の claim boundary 外。
+
+## 審判メモ
+
+- 厳密性: 初回 G2 では base 45 revise。既存 propagation の再包装を避け、token-swap/un-swap exact route-level support、endpoint empty、nonmembership、nonfaithfulness を要求された。再審判では base 75 revise。base 85 は過大だが、exact internal support table pair と endpoint/internal nonfaithfulness まで証明すれば進めてよい、という判定。
+- 研究価値: 初回 G2 では base 45 revise。route-chain/internal-excursion object と nonfaithfulness theorem を要求された。再審判では base 75 accept。
+- repo 全体価値: 再審判で base 75 accept。endpoint dashboard が path-internal defect excursion を隠すことを Quality Surface の loss-aware visualization へ接続できる、と判定。
+
+## 関連
+
+- `g-aat-quality-surface-01-route-defect-support-calculus.md`
+- `g-aat-quality-surface-01-visible-law-deletion-protected-zero.md`
+- Cycle 26 component defect cancellation
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 40 候補として作成。
+- 2026-06-20: G2 A/B の revise を受け、既存 propagation の再包装を避けるため `InternalRouteDefectSupport` と endpoint/internal nonfaithfulness を主張へ追加。
+- 2026-06-20: G2 再審判は A revise base 75、B accept base 75、C accept base 75。base 85 は下げ、picked 候補として base 75 で進める。
+- 2026-06-20: `RouteDefectExcursionSupport.lean` で route-chain internal support、zero-boundary localization、token-swap/un-swap exact internal table-pair support、endpoint/internal nonfaithfulness を Lean-proved にした。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 4830
+- total SCORE: 4980
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -44,8 +44,9 @@
   - obstruction / certificate-transport / traceability / invariance / quality-surface: 100
   - certificate-transport / traceability / obstruction / invariance / repair-potential / computability: 140
   - certificate-transport / quality-surface / traceability: 110
+  - certificate-transport / obstruction / invariance / computability / repair-potential: 150
 - evidence portfolio:
-  - proved-in-research: 39
+  - proved-in-research: 40
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1723,10 +1724,59 @@ Lean 証拠は次を固定する。
 canonical transport、canonical repair planning、source extraction completeness、ArchMap correctness、
 実コード全体の品質判定は結論しない。
 
+## Cycle 40: Route-chain defect excursion support and selected local-to-global localization
+
+```text
+candidate: Route-chain defect excursion support and selected local-to-global localization
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 75
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 150
+category: certificate-transport/obstruction/invariance/computability/repair-potential
+goal_delta: route endpoint support を length-two route chain の internal defect excursion certificate に持ち上げ、zero boundary leg では endpoint support へ局在し、token-swap/un-swap では endpoint empty のまま internal exact table-pair support が残ることを固定した。
+project_value_delta: loss-aware Quality Surface / selected commutator localization に対し、endpoint dashboard が path-internal defect excursion に faithful でない有限証拠を追加した。
+formalization_quality: pass。内部 support、zero-boundary localization、exact endpoint/worker table pair、off-coordinate nonmembership、endpoint/internal nonfaithfulness が Lean で表現されている。reported declarations は axiom-free / sorry-free。
+open_questions: arbitrary-length route chain abstraction、minimal internal excursion support family、selected profile curvature path への統合。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/RouteDefectExcursionSupport.lean` は、
+route endpoint pair の defect support を length-two route chain の内部 support として読み直す。
+`InternalRouteDefectSupport left middle right component` は二つの leg の route defect support の合併であり、
+`EndpointRouteDefectSupport` は chain の endpoints だけを見る。
+
+Lean 証拠は次を固定する。
+
+- `internalRouteDefectSupport_eq_endpoint_leftZero` /
+  `internalRouteDefectSupport_eq_endpoint_rightZero`: 片側 boundary leg が protected-zero なら、
+  internal support は endpoint support と componentwise に一致する。
+- `sourceRefExact_of_visible_and_emptyRouteSupport`: visible tuple equivalence と empty route defect support から
+  source-ref exact visualization が得られる。
+- `tokenSwapUnswap_endpointSupport_empty`: token-swap/un-swap chain は endpoint support が空である。
+- `tokenSwapUnswap_internalSupport_exact_tablePair`: 同じ chain の internal support は endpoint/worker source-ref table
+  coordinates に正確に局在し、obligation、全 repair frontier、storage table coordinate には出ない。
+- `tokenSwapUnswap_endpointTable_excursion`: endpoint table coordinate は endpoint では消えるが内部には現れる
+  route defect excursion である。
+- `flat_tokenSwapUnswap_sameEndpointSupport`: flat chain と token-swap/un-swap chain は endpoint support で一致する。
+- `endpointSupport_not_faithful_to_internalSupport`: しかし両者の internal support は一致しないため、
+  endpoint support は path-internal defect excursion に faithful ではない。
+- `routeDefectExcursionSupport_package`: zero-boundary localization、source-ref exactness criterion、
+  token-swap/un-swap exact internal support、endpoint/internal nonfaithfulness を束ねる。
+
+この結果により、Cycle 38 の endpoint route support calculus と Cycle 39 の visible/protected 分離の後に、
+endpoint support だけでは path 内部の defect excursion を失うことが有限証拠として固定された。
+一方で、片側 boundary leg が protected-zero と分かる regime では、endpoint defect support を selected local cell へ戻せる。
+主張は supplied finite source-ref packets、selected length-two route chain、explicit packet-to-tuple bridge に相対化され、
+global additive defect group、canonical transport、canonical repair planning、source extraction completeness、
+ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 39 後の total SCORE は 4830 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 40 後の total SCORE は 4980 である。
 次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
 lawful repair/transport criterion minimality matrix、
-または selected support-defect localization を狙う。threshold までは残り 170 SCORE である。
+または selected support-defect localization を狙う。threshold までは残り 20 SCORE である。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 40 として、route endpoint support を length-two route chain の内部 defect excursion certificate へ持ち上げました。zero boundary leg では endpoint support へ局在し、token-swap/un-swap chain では endpoint support が空でも internal endpoint/worker table support が残ることを Lean で固定しています。

## 証明した定理

- `InternalRouteDefectSupport`
- `EndpointRouteDefectSupport`
- `RouteDefectExcursion`
- `internalRouteDefectSupport_eq_endpoint_leftZero`
- `internalRouteDefectSupport_eq_endpoint_rightZero`
- `sourceRefExact_of_visible_and_emptyRouteSupport`
- `tokenSwapUnswap_internalSupport_exact_tablePair`
- `tokenSwapUnswap_endpointTable_excursion`
- `flat_tokenSwapUnswap_sameEndpointSupport`
- `endpointSupport_not_faithful_to_internalSupport`
- `routeDefectExcursionSupport_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-route-defect-local-to-global.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/RouteDefectExcursionSupport.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/route_defect_excursion_axioms.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] tracking Issue は `Refs #2348` として記載した。research-loop の規律により `Closes` は使用しない
- [x] Lean status は `proved-in-research`
- [x] `research/reports/G-aat-quality-surface-01.md` の SCORE は G4 監査結果と同期済み
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
