### PR TITLE
研究: internal excursion minimal support を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -39,3 +39,4 @@ import Formal.AG.Research.QualitySurface.TransportTableLawRouteLocalization
 import Formal.AG.Research.QualitySurface.RouteDefectSupport
 import Formal.AG.Research.QualitySurface.VisibleLawDeletionProtectedZero
 import Formal.AG.Research.QualitySurface.RouteDefectExcursionSupport
+import Formal.AG.Research.QualitySurface.InternalExcursionMinSupport

--- a/Formal/AG/Research/QualitySurface/InternalExcursionMinSupport.lean
+++ b/Formal/AG/Research/QualitySurface/InternalExcursionMinSupport.lean
@@ -1,0 +1,293 @@
+import Formal.AG.Research.QualitySurface.RouteDefectExcursionSupport
+
+/-!
+Cycle 41 evidence for `G-aat-quality-surface-01`.
+
+This file connects the route-internal excursion witness from Cycle 40 with a
+finite minimal-support hitting calculus.  The selected finite witness is the
+token-swap/un-swap route chain: its endpoint route support is empty, but its
+internal support is grounded at the endpoint/worker source-ref table
+coordinates.  We read those two coordinates as selected minimal internal
+support branches and prove that a correction hitting only one branch does not
+eliminate the internal excursion, while a correction hitting both branches hits
+every selected branch.
+
+The claim is relative to supplied finite source-ref packets, a selected
+length-two route chain, and a selected internal support atom vocabulary.  It
+does not assert global repair planning, source extraction completeness, ArchMap
+correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace InternalExcursionMinSupport
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open RouteDefectExcursionSupport
+
+/-! ## Internal excursion support atoms -/
+
+/-- Selected protected coordinates used to detect the token-swap/un-swap excursion. -/
+inductive InternalExcursionAtom where
+  | endpointTable
+  | workerTable
+  deriving DecidableEq, Fintype
+
+open InternalExcursionAtom
+
+/-- Embedding of the selected internal-excursion atom vocabulary into packet components. -/
+def internalExcursionAtomComponent :
+    InternalExcursionAtom -> SourceRefPacketProtectedComponent
+  | endpointTable => SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint
+  | workerTable => SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.worker
+
+/-- Each selected internal-excursion atom is grounded in the token-swap/un-swap internal support. -/
+theorem tokenSwapUnswap_internalExcursionAtomSupport
+    (atom : InternalExcursionAtom) :
+    InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (internalExcursionAtomComponent atom) := by
+  cases atom with
+  | endpointTable => exact tokenSwapUnswap_internalSupport_endpointTable
+  | workerTable => exact tokenSwapUnswap_internalSupport_workerTable
+
+/-- The token-swap/un-swap witness carries both selected internal support atoms. -/
+def TokenSwapUnswapSelectedInternalSupportGrounded : Prop :=
+    InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (internalExcursionAtomComponent endpointTable) ∧
+    InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (internalExcursionAtomComponent workerTable) ∧
+    ¬ InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      SourceRefPacketProtectedComponent.obligation ∧
+    (∀ atom,
+      ¬ InternalRouteDefectSupport
+        tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+        (SourceRefPacketProtectedComponent.repairFrontier atom)) ∧
+    ¬ InternalRouteDefectSupport
+      tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage)
+
+/-- The selected internal atom support is grounded by the Cycle-40 exact table-pair computation. -/
+theorem tokenSwapUnswap_selectedInternalSupport_grounded :
+    TokenSwapUnswapSelectedInternalSupportGrounded :=
+  tokenSwapUnswap_internalSupport_exact_tablePair
+
+/-! ## Selected minimal internal support branches -/
+
+/-- Selected minimal internal support branches for the token-swap/un-swap excursion. -/
+inductive InternalExcursionBranch where
+  | endpointTableBranch
+  | workerTableBranch
+  deriving DecidableEq, Fintype
+
+open InternalExcursionBranch
+
+/-- The selected atom carried by a minimal internal support branch. -/
+def internalExcursionBranchAtom :
+    InternalExcursionBranch -> InternalExcursionAtom
+  | endpointTableBranch => endpointTable
+  | workerTableBranch => workerTable
+
+/-- A branch is grounded when its selected internal atom appears in the internal support. -/
+def InternalExcursionBranchGrounded (branch : InternalExcursionBranch) : Prop :=
+  InternalRouteDefectSupport
+    tokenSwapChainLeft tokenSwapChainMiddle tokenSwapChainRight
+    (internalExcursionAtomComponent (internalExcursionBranchAtom branch))
+
+/-- Every selected minimal branch is grounded in the token-swap/un-swap internal support. -/
+theorem internalExcursionBranch_grounded
+    (branch : InternalExcursionBranch) :
+    InternalExcursionBranchGrounded branch := by
+  cases branch with
+  | endpointTableBranch => exact tokenSwapUnswap_internalSupport_endpointTable
+  | workerTableBranch => exact tokenSwapUnswap_internalSupport_workerTable
+
+/-- A correction hits a selected branch when it touches that branch's selected atom. -/
+def CorrectionHitsBranch
+    (correction : InternalExcursionAtom -> Bool)
+    (branch : InternalExcursionBranch) : Prop :=
+  correction (internalExcursionBranchAtom branch) = true
+
+/-- A selected branch remains after correction when it is grounded and missed. -/
+def BranchRemainsAfterCorrection
+    (correction : InternalExcursionAtom -> Bool)
+    (branch : InternalExcursionBranch) : Prop :=
+  InternalExcursionBranchGrounded branch ∧
+    ¬ CorrectionHitsBranch correction branch
+
+/-- A correction eliminates the selected internal excursion when it hits every selected branch. -/
+def InternalExcursionEliminates
+    (correction : InternalExcursionAtom -> Bool) : Prop :=
+  ∀ branch, ¬ BranchRemainsAfterCorrection correction branch
+
+/-- A hit branch leaves no after-correction support on that branch. -/
+theorem no_afterCorrection_of_hits
+    {correction : InternalExcursionAtom -> Bool}
+    {branch : InternalExcursionBranch}
+    (hhit : CorrectionHitsBranch correction branch) :
+    ¬ BranchRemainsAfterCorrection correction branch := by
+  intro hafter
+  exact hafter.2 hhit
+
+/-- If a correction eliminates the excursion, no selected branch remains. -/
+theorem eliminates_no_afterCorrection
+    {correction : InternalExcursionAtom -> Bool}
+    (helim : InternalExcursionEliminates correction)
+    (branch : InternalExcursionBranch) :
+    ¬ BranchRemainsAfterCorrection correction branch :=
+  helim branch
+
+/-- If a selected grounded branch is missed, it remains after correction. -/
+theorem missed_branch_remains_afterCorrection
+    {correction : InternalExcursionAtom -> Bool}
+    {branch : InternalExcursionBranch}
+    (hmiss : ¬ CorrectionHitsBranch correction branch) :
+    BranchRemainsAfterCorrection correction branch :=
+  ⟨internalExcursionBranch_grounded branch, hmiss⟩
+
+/-- The finite hitting theorem for selected internal excursion branches. -/
+theorem hits_every_minInternalSupport_of_eliminates
+    {correction : InternalExcursionAtom -> Bool}
+    (helim : InternalExcursionEliminates correction) :
+    ∀ branch, CorrectionHitsBranch correction branch := by
+  intro branch
+  cases branch with
+  | endpointTableBranch =>
+      cases h : correction endpointTable with
+      | false =>
+          have hmiss :
+              ¬ CorrectionHitsBranch correction endpointTableBranch := by
+            intro hhit
+            change correction endpointTable = true at hhit
+            rw [h] at hhit
+            cases hhit
+          exact False.elim
+            (helim endpointTableBranch
+              (missed_branch_remains_afterCorrection hmiss))
+      | true =>
+          exact h
+  | workerTableBranch =>
+      cases h : correction workerTable with
+      | false =>
+          have hmiss :
+              ¬ CorrectionHitsBranch correction workerTableBranch := by
+            intro hhit
+            change correction workerTable = true at hhit
+            rw [h] at hhit
+            cases hhit
+          exact False.elim
+            (helim workerTableBranch
+              (missed_branch_remains_afterCorrection hmiss))
+      | true =>
+          exact h
+
+/-! ## Finite witness computations -/
+
+/-- The endpoint table branch is grounded. -/
+theorem endpointTable_minInternalSupport :
+    InternalExcursionBranchGrounded endpointTableBranch :=
+  internalExcursionBranch_grounded endpointTableBranch
+
+/-- The worker table branch is grounded. -/
+theorem workerTable_minInternalSupport :
+    InternalExcursionBranchGrounded workerTableBranch :=
+  internalExcursionBranch_grounded workerTableBranch
+
+/-- The selected minimal internal support family is nonempty. -/
+theorem internalExcursion_minSupportFamily_nonempty :
+    ∃ branch : InternalExcursionBranch, InternalExcursionBranchGrounded branch :=
+  ⟨endpointTableBranch, endpointTable_minInternalSupport⟩
+
+/-- The two selected minimal internal support branches are distinct. -/
+theorem internalExcursion_minSupportBranches_distinct :
+    endpointTableBranch ≠ workerTableBranch := by
+  intro h
+  cases h
+
+/-- A correction that touches only the endpoint table branch. -/
+def endpointTableCorrection : InternalExcursionAtom -> Bool
+  | endpointTable => true
+  | workerTable => false
+
+/-- A correction that touches both selected table branches. -/
+def endpointWorkerCorrection : InternalExcursionAtom -> Bool
+  | endpointTable => true
+  | workerTable => true
+
+/-- The endpoint-only correction hits the endpoint table branch. -/
+theorem endpointOnlyCorrection_hits_endpointTable :
+    CorrectionHitsBranch endpointTableCorrection endpointTableBranch :=
+  rfl
+
+/-- The endpoint-only correction misses the worker table branch. -/
+theorem endpointOnlyCorrection_misses_workerTable :
+    ¬ CorrectionHitsBranch endpointTableCorrection workerTableBranch := by
+  intro h
+  cases h
+
+/-- A correction that hits only the endpoint branch leaves the worker branch after correction. -/
+theorem endpointOnlyCorrection_workerBranch_remains :
+    BranchRemainsAfterCorrection endpointTableCorrection workerTableBranch :=
+  missed_branch_remains_afterCorrection endpointOnlyCorrection_misses_workerTable
+
+/-- A correction that hits only the endpoint branch does not eliminate the internal excursion. -/
+theorem endpointOnlyCorrection_does_not_eliminate :
+    ¬ InternalExcursionEliminates endpointTableCorrection := by
+  intro helim
+  exact helim workerTableBranch endpointOnlyCorrection_workerBranch_remains
+
+/-- The endpoint/worker correction eliminates the selected internal excursion. -/
+theorem endpointWorkerCorrection_eliminates :
+    InternalExcursionEliminates endpointWorkerCorrection := by
+  intro branch
+  cases branch with
+  | endpointTableBranch =>
+      exact no_afterCorrection_of_hits rfl
+  | workerTableBranch =>
+      exact no_afterCorrection_of_hits rfl
+
+/-- The endpoint/worker correction hits every selected minimal internal support branch. -/
+theorem endpointWorkerCorrection_hits_every_minInternalSupport :
+    ∀ branch, CorrectionHitsBranch endpointWorkerCorrection branch :=
+  hits_every_minInternalSupport_of_eliminates
+    endpointWorkerCorrection_eliminates
+
+/-! ## Theorem package -/
+
+/--
+Cycle-41 theorem package: the token-swap/un-swap internal excursion has a
+selected two-branch minimal internal support family; hitting only one branch
+does not eliminate the excursion, while hitting endpoint and worker branches
+meets every selected minimal support.
+-/
+theorem internalExcursionMinimalSupport_package :
+    TokenSwapUnswapSelectedInternalSupportGrounded ∧
+    InternalExcursionBranchGrounded endpointTableBranch ∧
+    InternalExcursionBranchGrounded workerTableBranch ∧
+    (∃ branch : InternalExcursionBranch, InternalExcursionBranchGrounded branch) ∧
+    endpointTableBranch ≠ workerTableBranch ∧
+    CorrectionHitsBranch endpointTableCorrection endpointTableBranch ∧
+    ¬ CorrectionHitsBranch endpointTableCorrection workerTableBranch ∧
+    BranchRemainsAfterCorrection endpointTableCorrection workerTableBranch ∧
+    ¬ InternalExcursionEliminates endpointTableCorrection ∧
+    InternalExcursionEliminates endpointWorkerCorrection ∧
+    (∀ branch, CorrectionHitsBranch endpointWorkerCorrection branch) := by
+  exact ⟨tokenSwapUnswap_selectedInternalSupport_grounded,
+    endpointTable_minInternalSupport,
+    workerTable_minInternalSupport,
+    internalExcursion_minSupportFamily_nonempty,
+    internalExcursion_minSupportBranches_distinct,
+    endpointOnlyCorrection_hits_endpointTable,
+    endpointOnlyCorrection_misses_workerTable,
+    endpointOnlyCorrection_workerBranch_remains,
+    endpointOnlyCorrection_does_not_eliminate,
+    endpointWorkerCorrection_eliminates,
+    endpointWorkerCorrection_hits_every_minInternalSupport⟩
+
+end InternalExcursionMinSupport
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-endpoint-exact-internal-excursion.md
+++ b/research/ideas/g-aat-quality-surface-01-endpoint-exact-internal-excursion.md
@@ -1,0 +1,106 @@
+---
+status: archived
+goal: G-aat-quality-surface-01
+candidate_type: orientation
+capability_category: certificate-transport / obstruction / invariance / quality-surface / computability
+expected_base_score: 55
+expected_evidence_multiplier: 2.0
+expected_final_score: 110
+evidence_stage: planned
+origin: cycle-41
+tags: [quality-surface, route-defect-support, source-ref-exactness, nonfaithfulness]
+created: 2026-06-21
+---
+
+# Endpoint-exact visualization is not faithful to internal excursions
+
+## 主張
+
+selected length-two route chain `left -> middle -> right` において、endpoint pair
+`left -> right` が source-ref exact visualization を満たし、endpoint route defect support が空であっても、
+chain 内部の route defect excursion は非空になりうる。
+
+主 witness は Cycle 40 の token-swap/un-swap chain `full -> swapped -> full` である。
+endpoint は `full -> full` なので source-ref exact visualization を満たすが、内部 leg は endpoint/worker
+source-ref table coordinates に exact internal support を持つ。したがって endpoint exact reading は
+path-internal clean reading に faithful ではない。
+
+この主張は supplied finite source-ref packets、selected length-two route chain、explicit packet-to-tuple bridge に
+相対化される。global additive defect group、canonical transport、canonical repair planning、source extraction
+completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
+## 候補種別
+
+`orientation`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/RouteDefectExcursionSupport.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefTupleBridge.lean`
+
+## 非自明性
+
+Cycle 40 は endpoint support と internal support の非忠実性を固定した。この候補は、その非忠実性を
+source-ref exact visualization 層へ持ち上げる。つまり「endpoint defect support が空」というだけでなく、
+packet-to-tuple bridge 上の exact visualization まで成立していても、内部 route excursion は隠れうる。
+
+## 数学的興味
+
+endpoint exactness は local path history を quotient する読みである。Quality Surface の loss-aware reading では、
+endpoint exact badge と internal excursion badge を別の保証として扱う必要がある。この分離は、phase-boundary report
+における source-ref exactness と route-history memory の境界を明確にする。
+
+## GOAL への前進
+
+source-ref exact visualization を endpoint-level exactness として位置づけ、path-internal obstruction memory とは別層で
+あることを Lean-proved finite witness にする。これは loss-aware visualization、selected commutator localization、
+route-history-aware quality surface へ接続する。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 40 の internal/endpoint support 非忠実性を exact visualization 層へ上げる orientation result。
+  新しい大域不変量ではないため base 55 に抑えるが、phase-boundary report の境界整理に効く。
+- `dullness_risk`: 単に Cycle 40 の theorem を再包装するだけなら dull。endpoint source-ref exact visualization と
+  internal route excursion の同時成立を明示し、flat chain との same endpoint exact / different internal support
+  comparison まで入れる必要がある。
+- `proof_or_evidence_plan`: `full -> full` endpoint の source-ref exact visualization を Lean で証明する。
+  その上で token-swap/un-swap chain が endpoint exact / endpoint support empty / internal endpoint-table excursion を
+  同時に持つこと、さらに flat chain と token-swap/un-swap chain は endpoint exact reading では区別できないが
+  internal support では区別できることを証明する。
+
+## CS / SWE への帰結
+
+endpoint exact dashboard が clean でも、route の途中で token identity が往復していた可能性は消えない。
+監査・可視化 surface では、endpoint exactness と route-internal excursion history を別レイヤとして表示すべきである。
+
+## 証明・根拠の見込み
+
+Lean では次の declaration を狙う。
+
+- `flatChain_sourceRefExactVisualization`
+- `tokenSwapUnswap_endpointSourceRefExactVisualization`
+- `tokenSwapUnswap_endpointExact_internalExcursion`
+- `flat_tokenSwapUnswap_sameEndpointExactReading`
+- `endpointExactVisualization_not_faithful_to_internalExcursion`
+- `endpointExactInternalExcursion_package`
+
+## 審判メモ
+
+- 厳密性: G2 A reject。主張は真になりそうだが、Cycle 40 の `sourceRefExact_of_visible_and_emptyRouteSupport`、
+  `tokenSwapUnswap_endpointSupport_empty`、`tokenSwapUnswap_internalSupport_exact_tablePair`、
+  `tokenSwapUnswap_endpointTable_excursion`、`endpointSupport_not_faithful_to_internalSupport` の即時合成に見えるため、
+  base 55 の orientation result としては不足。
+- 研究価値: G2 B accept base 55。endpoint exact badge と route-history obstruction memory の分離として report 価値はあると判定。
+- repo 全体価値: G2 C accept base 55。loss-aware visualization / route-history-aware Quality Surface への説明力はあるが、Cycle 40 の再包装リスクを指摘。
+
+## 関連
+
+- `g-aat-quality-surface-01-route-defect-support-calculus.md`
+- `g-aat-quality-surface-01-route-defect-local-to-global.md`
+- Cycle 40 route defect excursion support
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 41 候補として作成。
+- 2026-06-21: G2 A reject により archived。即時系リスクが高いため、このサイクルの picked にはしない。

--- a/research/ideas/g-aat-quality-surface-01-internal-excursion-min-support.md
+++ b/research/ideas/g-aat-quality-surface-01-internal-excursion-min-support.md
@@ -1,0 +1,177 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: repair-potential / obstruction / traceability / atom-supported-quality-geometry / invariance
+expected_base_score: 65
+expected_evidence_multiplier: 2.0
+expected_final_score: 130
+evidence_stage: proved-in-research
+origin: cycle-41
+tags: [quality-surface, internal-excursion, minimal-support, hitting]
+created: 2026-06-21
+---
+
+# Minimal internal excursion support family hitting theorem
+
+## 主張
+
+route-chain internal excursion に対して selected minimal support family を置き、internal excursion を eliminate する
+correction は、その selected minimal internal support family の全 branch を hit しなければならない。
+
+主 witness は Cycle 40 の token-swap/un-swap chain である。この chain の internal support は endpoint/worker
+source-ref table coordinates に exact に局在する。これを route-internal support atom vocabulary の二つの singleton
+minimal branch として読み、片方だけを correction が触る場合にはもう片方の internal excursion support が残ることを
+Lean で固定する。
+
+この主張は supplied finite source-ref packets、selected length-two route chain、selected internal support atom vocabulary、
+explicit endpoint/worker table coordinates に相対化される。global additive defect group、canonical repair planning、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/SupportHitting.lean`
+- `Formal/AG/Research/QualitySurface/RouteDefectExcursionSupport.lean`
+- `Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`
+
+## Lean 証拠
+
+- `Formal/AG/Research/QualitySurface/InternalExcursionMinSupport.lean`
+- `Formal/AG/Research.lean`
+
+主要 declaration:
+
+- `InternalExcursionAtom`
+- `internalExcursionAtomComponent`
+- `tokenSwapUnswap_internalExcursionAtomSupport`
+- `TokenSwapUnswapSelectedInternalSupportGrounded`
+- `tokenSwapUnswap_selectedInternalSupport_grounded`
+- `InternalExcursionBranch`
+- `internalExcursionBranchAtom`
+- `InternalExcursionBranchGrounded`
+- `internalExcursionBranch_grounded`
+- `CorrectionHitsBranch`
+- `BranchRemainsAfterCorrection`
+- `InternalExcursionEliminates`
+- `no_afterCorrection_of_hits`
+- `eliminates_no_afterCorrection`
+- `missed_branch_remains_afterCorrection`
+- `hits_every_minInternalSupport_of_eliminates`
+- `endpointTable_minInternalSupport`
+- `workerTable_minInternalSupport`
+- `internalExcursion_minSupportFamily_nonempty`
+- `internalExcursion_minSupportBranches_distinct`
+- `endpointTableCorrection`
+- `endpointWorkerCorrection`
+- `endpointOnlyCorrection_hits_endpointTable`
+- `endpointOnlyCorrection_misses_workerTable`
+- `endpointOnlyCorrection_workerBranch_remains`
+- `endpointOnlyCorrection_does_not_eliminate`
+- `endpointWorkerCorrection_eliminates`
+- `endpointWorkerCorrection_hits_every_minInternalSupport`
+- `internalExcursionMinimalSupport_package`
+
+## 非自明性
+
+Cycle 40 は token-swap/un-swap の exact internal support table pair を固定した。この候補は、それを単なる二つの
+positive support fact ではなく、minimal support family と hitting theorem の言語へ持ち上げる。これにより、
+endpoint-empty な internal excursion にも correction requirement を与えられる。
+
+## 数学的興味
+
+endpoint support からは消える route-internal excursion が、minimal support family としては repair / correction の
+必要条件を持つ。obstruction support と route excursion support を同じ hitting-set calculus で読むことで、
+Quality Surface の repair-potential と route-history memory が接続される。
+
+## GOAL への前進
+
+support-local repair theorem frontier と internal route defect excursion frontier を統合する。これは minimal atom support
+family、repair-potential、obstruction、traceability の各カテゴリを、endpoint support を越えた route-history surface へ
+拡張する。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 1 の hitting theorem と Cycle 40 の exact internal support を統合し、endpoint-empty excursion に
+  selected minimal support family と correction necessity を与える。任意 route chain や大域 repair planning ではないため
+  base 65 に抑える。ただし G2 A の指摘通り、Lean-grounded bridge evidence が弱ければ base 50 以下に落とす。
+- `dullness_risk`: `SupportHitting` の名前替えだけなら dull。token-swap/un-swap internal support の endpoint/worker table
+  pair に grounded な finite support family、off-coordinate nonmembership、片側 correction failure を同時に固定する必要がある。
+  特に exact support set `{endpoint, worker}` と selected minimal family `{endpoint}`, `{worker}` を混同しない。
+- `proof_or_evidence_plan`: route-internal support atom vocabulary を endpoint table / worker table の二 atom として定義する。
+  それを `SourceRefPacketProtectedComponent` へ写し、Cycle 40 の `tokenSwapUnswap_internalSupport_exact_tablePair` と接続する。
+  selected minimal family を二つの singleton branch とし、`AfterCorrection` は correction が miss した selected branch を
+  残す semantics として定義する。endpoint-only correction が worker branch を miss して eliminate できないこと、
+  endpoint+worker correction が all-branch hitting になることを Lean で証明する。
+
+## CS / SWE への帰結
+
+endpoint が clean に見える route でも、内部 excursion を消す correction は少なくとも endpoint-table と worker-table
+の両 coordinate を見る必要がある、という drill-down requirement を表現できる。
+
+## 証明・根拠の見込み
+
+Lean では次の declaration を固定した。
+
+- `InternalExcursionAtom`
+- `internalExcursionAtomComponent`
+- `tokenSwapUnswap_internalExcursionAtomSupport`
+- `TokenSwapUnswapSelectedInternalSupportGrounded`
+- `tokenSwapUnswap_selectedInternalSupport_grounded`
+- `InternalExcursionBranch`
+- `internalExcursionBranchAtom`
+- `InternalExcursionBranchGrounded`
+- `internalExcursionBranch_grounded`
+- `CorrectionHitsBranch`
+- `BranchRemainsAfterCorrection`
+- `InternalExcursionEliminates`
+- `missed_branch_remains_afterCorrection`
+- `hits_every_minInternalSupport_of_eliminates`
+- `endpointTable_minInternalSupport`
+- `workerTable_minInternalSupport`
+- `endpointOnlyCorrection_misses_workerTable`
+- `endpointOnlyCorrection_workerBranch_remains`
+- `endpointOnlyCorrection_does_not_eliminate`
+- `endpointWorkerCorrection_hits_every_minInternalSupport`
+- `internalExcursionMinimalSupport_package`
+
+検証:
+
+- `lake env lean Formal/AG/Research/QualitySurface/InternalExcursionMinSupport.lean`: pass
+- `lake build Formal.AG.Research.QualitySurface.InternalExcursionMinSupport`: pass
+- `lake build FormalAGResearch`: pass
+- `.tmp/internal_excursion_min_support_axioms.lean`: 全対象 declaration が axiom 依存なし
+- `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal/AG/Research/QualitySurface/InternalExcursionMinSupport.lean Formal/AG/Research.lean`: 該当なし
+
+G3 監査:
+
+- 公理検査: pass。全対象 declaration は `does not depend on any axioms`。`sorryAx`、`propext`、`Classical.choice`、`Quot.sound` は残っていない。
+- Lean 形式化品質監査: pass。初回 revise で、`InternalExcursionEliminates` が all-hit の定義そのものだと hitting theorem が薄い、という指摘を受けた。修正版では `InternalExcursionEliminates` を after-correction branch 不在として定義し、`hits_every_minInternalSupport_of_eliminates` を missed branch remains との矛盾から導く。`CorrectionHitsBranch` は `Bool` correction にして generic Prop の classical split を避けた。
+
+## 審判メモ
+
+- 厳密性: G2 A revise。方向は妥当だが、Cycle 40 の exact two-coordinate support から二 singleton minimal branch は
+  自動では出ないため、selected family、after-correction semantics、endpoint-only failure、endpoint+worker all-hit を
+  Lean で固定することを要求された。base 50 provisional、Lean-grounded bridge evidence が揃えば base 65。実装後の
+  再審判では accept base 65。`InternalExcursionEliminates` が after-correction branch 不在として定義され、
+  selected branch grounding、off-coordinate nonmembership、endpoint-only failure、endpoint+worker all-hit が Lean 上で固定されたため、
+  `SupportHitting` の単純 rename ではないと判定された。
+- 研究価値: G2 B accept base 65。support-local repair theorem、route defect support calculus、internal excursion support
+  を同じ hitting-set language にまとめる研究価値あり。
+- repo 全体価値: G2 C accept base 65。Cycle 40 の open question `minimal internal excursion support family` を閉じる候補として妥当。
+
+## 関連
+
+- `g-aat-quality-surface-01-route-defect-local-to-global.md`
+- `g-aat-quality-surface-01-route-defect-support-calculus.md`
+- Cycle 1 minimal-support hitting theorem
+- Cycle 40 route-chain internal support
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 41 候補として作成。
+- 2026-06-21: G2 A revise を受け、二 singleton family と after-correction semantics を追加定義として明示する方針へ修正。
+- 2026-06-21: `InternalExcursionMinSupport.lean` で selected branch type、Cycle 40 exact support grounding、branch-remains-after-correction、endpoint-only failure、endpoint+worker all-hit package を Lean-proved にした。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 4980
+- total SCORE: 5110
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -45,8 +45,9 @@
   - certificate-transport / traceability / obstruction / invariance / repair-potential / computability: 140
   - certificate-transport / quality-surface / traceability: 110
   - certificate-transport / obstruction / invariance / computability / repair-potential: 150
+  - repair-potential / obstruction / traceability / atom-supported-quality-geometry / invariance: 130
 - evidence portfolio:
-  - proved-in-research: 40
+  - proved-in-research: 41
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1773,10 +1774,60 @@ endpoint support だけでは path 内部の defect excursion を失うことが
 global additive defect group、canonical transport、canonical repair planning、source extraction completeness、
 ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 41: Minimal internal excursion support family hitting theorem
+
+```text
+candidate: Minimal internal excursion support family hitting theorem
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 65
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 130
+category: repair-potential/obstruction/traceability/atom-supported-quality-geometry/invariance
+goal_delta: Cycle 40 の internal excursion exact support を selected minimal internal support family と hitting necessity へ持ち上げ、endpoint-only correction failure と endpoint+worker all-hit を固定した。
+project_value_delta: support-local repair calculus と route-history internal excursion support を接続し、Quality Surface の repair-potential / obstruction / traceability frontier を前進させた。
+formalization_quality: pass。`InternalExcursionEliminates` は all-hit そのものではなく after-correction branch 不在として定義され、hitting theorem は missed branch remains との矛盾から導かれる。reported declarations は axiom-free / sorry-free。
+open_questions: arbitrary-length route-chain support compression、profile path integrated internal support、non-selected branch semantics。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/InternalExcursionMinSupport.lean` は、
+Cycle 40 の token-swap/un-swap internal excursion を selected minimal support family として読む。
+`InternalExcursionAtom` は endpoint table と worker table の二つの selected protected coordinates を持ち、
+`internalExcursionAtomComponent` がそれらを `SourceRefPacketProtectedComponent` へ埋め込む。
+
+Lean 証拠は次を固定する。
+
+- `tokenSwapUnswap_selectedInternalSupport_grounded`: token-swap/un-swap chain の selected endpoint/worker
+  internal support は Cycle 40 の exact table-pair computation に grounded であり、obligation、全 repair frontier、
+  storage table coordinate には出ない。
+- `InternalExcursionBranch` / `internalExcursionBranchAtom`: endpoint branch と worker branch を selected minimal
+  internal support branch として分ける。
+- `BranchRemainsAfterCorrection`: branch は grounded かつ correction に hit されないとき after-correction support として残る。
+- `InternalExcursionEliminates`: correction が internal excursion を eliminate するとは、after-correction branch が残らないこと。
+- `missed_branch_remains_afterCorrection`: missed branch は残る。
+- `hits_every_minInternalSupport_of_eliminates`: elimination する correction は全 selected branch を hit する。
+- `endpointOnlyCorrection_misses_workerTable` /
+  `endpointOnlyCorrection_workerBranch_remains` /
+  `endpointOnlyCorrection_does_not_eliminate`: endpoint-only correction は worker branch を miss し、internal excursion を
+  eliminate しない。
+- `endpointWorkerCorrection_eliminates` /
+  `endpointWorkerCorrection_hits_every_minInternalSupport`: endpoint+worker correction は selected branch をすべて hit する。
+- `internalExcursionMinimalSupport_package`: selected branch grounding、nonempty/distinct branches、endpoint-only failure、
+  endpoint+worker all-hit を束ねる。
+
+この結果により、endpoint support からは消える route-internal excursion でも、selected minimal support family としては
+correction necessity を持つことが分かる。Cycle 1 の support-hitting idea と Cycle 40 の endpoint-empty internal excursion
+を同じ有限 support calculus で接続した。主張は supplied finite source-ref packets、selected length-two route chain、
+selected internal support atom vocabulary に相対化され、global repair planning、source extraction completeness、
+ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 40 後の total SCORE は 4980 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 41 後の total SCORE は 5110 である。
 次に進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
 lawful repair/transport criterion minimality matrix、
-または selected support-defect localization を狙う。threshold までは残り 20 SCORE である。
+または selected support-defect localization を狙う。threshold は達成済みであるため、PR マージ後に phase boundary 判定へ進む。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 41 として、Cycle 40 の token-swap/un-swap internal excursion exact support を selected minimal internal support family と correction hitting theorem へ持ち上げました。endpoint-only correction は worker branch を miss して eliminate できず、endpoint+worker correction は selected branch をすべて hit することを Lean で固定しています。

## 証明した定理

- `InternalExcursionAtom`
- `internalExcursionAtomComponent`
- `tokenSwapUnswap_internalExcursionAtomSupport`
- `TokenSwapUnswapSelectedInternalSupportGrounded`
- `tokenSwapUnswap_selectedInternalSupport_grounded`
- `InternalExcursionBranch`
- `BranchRemainsAfterCorrection`
- `InternalExcursionEliminates`
- `missed_branch_remains_afterCorrection`
- `hits_every_minInternalSupport_of_eliminates`
- `endpointOnlyCorrection_workerBranch_remains`
- `endpointOnlyCorrection_does_not_eliminate`
- `endpointWorkerCorrection_eliminates`
- `endpointWorkerCorrection_hits_every_minInternalSupport`
- `internalExcursionMinimalSupport_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-endpoint-exact-internal-excursion.md`
- `research/ideas/g-aat-quality-surface-01-internal-excursion-min-support.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/InternalExcursionMinSupport.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.InternalExcursionMinSupport`
- [x] `lake env lean .tmp/internal_excursion_min_support_axioms.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] tracking Issue は `Refs #2348` として記載した。research-loop の規律により `Closes` は使用しない
- [x] Lean status は `proved-in-research`
- [x] `research/reports/G-aat-quality-surface-01.md` の SCORE は G4 監査結果と同期済み
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
