### PR TITLE
研究ループ Cycle 42 の exact visualization minimality を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -40,3 +40,4 @@ import Formal.AG.Research.QualitySurface.RouteDefectSupport
 import Formal.AG.Research.QualitySurface.VisibleLawDeletionProtectedZero
 import Formal.AG.Research.QualitySurface.RouteDefectExcursionSupport
 import Formal.AG.Research.QualitySurface.InternalExcursionMinSupport
+import Formal.AG.Research.QualitySurface.ExactVisualizationCriterionMinimality

--- a/Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean
+++ b/Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean
@@ -1,0 +1,642 @@
+import Formal.AG.Research.QualitySurface.RouteDefectSupport
+import Formal.AG.Research.QualitySurface.RouteDefectExcursionSupport
+import Formal.AG.Research.QualitySurface.VisibleLawDeletionProtectedZero
+
+/-!
+Cycle 42 evidence for `G-aat-quality-surface-01`.
+
+This file turns the exact-visualization criterion into a selected minimality
+statement.  `SourceRefExactVisualization` requires both visible tuple
+equivalence and empty protected route support.  The existing selected deletion
+cells show that neither side can be dropped: deleting only the visible law
+leaves protected route support empty but breaks exact visualization, while
+deleting only the transport table law keeps the visible surface flat but leaves
+an endpoint/worker table defect support.
+
+The claim is a selected finite witness and criterion package.  It is relative
+to supplied source-ref packets, selected route endpoints, packet-to-tuple
+bridges, and selected deletion cells.  It does not assert a global law
+minimality matrix, canonical transport, canonical repair planning, source
+extraction completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ExactVisualizationCriterionMinimality
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+open RouteDefectSupportTheory
+open SourceRefPacketTransport
+open CodebaseTraceRepairTrajectory
+open LawfulRepairTransportCommutator
+
+/-! ## Selected obligation-law and action-naturality deletion cells -/
+
+/-- Packet update that preserves all protected packet data except obligation. -/
+def obligationLawSensitiveTransport : PacketUpdate where
+  map := fun packet =>
+    { visibleScalarReading := packet.visibleScalarReading
+      verdict := packet.verdict
+      codeSupport := packet.codeSupport
+      sourceRefTable := packet.sourceRefTable
+      repairFrontier := packet.repairFrontier
+      obligation := StateSeparation.ObligationKind.measure }
+
+/-- The obligation-sensitive update preserves the visible packet surface. -/
+theorem obligationLawTransport_preservesVisibleSurface :
+    PreservesSourceRefVisibleSurface obligationLawSensitiveTransport := by
+  intro packet
+  change
+    (obligationLawSensitiveTransport.map packet).visibleScalarReading =
+        packet.visibleScalarReading ∧
+      (obligationLawSensitiveTransport.map packet).verdict = packet.verdict
+  exact ⟨rfl, rfl⟩
+
+/-- The obligation-sensitive update preserves code support. -/
+theorem obligationLawTransport_preservesCodeSupport :
+    PreservesCodeSupport obligationLawSensitiveTransport := by
+  intro packet atom hsupport
+  exact hsupport
+
+/-- The obligation-sensitive update reflects code support. -/
+theorem obligationLawTransport_reflectsCodeSupport :
+    ReflectsCodeSupport obligationLawSensitiveTransport := by
+  intro packet atom hsupport
+  exact hsupport
+
+/-- The obligation-sensitive update preserves missing source-ref loci. -/
+theorem obligationLawTransport_preservesMissingLocus :
+    PreservesSourceRefMissingLocus obligationLawSensitiveTransport := by
+  intro packet atom hmissing
+  exact hmissing
+
+/-- The obligation-sensitive update reflects missing source-ref loci. -/
+theorem obligationLawTransport_reflectsMissingLocus :
+    ReflectsSourceRefMissingLocus obligationLawSensitiveTransport := by
+  intro packet atom hmissing
+  exact hmissing
+
+/-- The obligation-sensitive update preserves repair-frontier membership. -/
+theorem obligationLawTransport_preservesRepairFrontier :
+    PreservesSourceRefRepairFrontier obligationLawSensitiveTransport := by
+  intro packet atom hrepair
+  exact hrepair
+
+/-- The obligation-sensitive update reflects repair-frontier membership. -/
+theorem obligationLawTransport_reflectsRepairFrontier :
+    ReflectsSourceRefRepairFrontier obligationLawSensitiveTransport := by
+  intro packet atom hrepair
+  exact hrepair
+
+/-- The obligation-sensitive update preserves the source-ref table pointwise. -/
+theorem obligationLawTransport_preservesSourceRefTable :
+    PreservesSourceRefTable obligationLawSensitiveTransport := by
+  intro packet atom
+  rfl
+
+/-- The obligation-sensitive update satisfies every non-obligation packet law. -/
+theorem obligationLawTransport_packetTransportLaws :
+    BidirectionalSourceRefPacketTransport obligationLawSensitiveTransport where
+  preservesSupport := obligationLawTransport_preservesCodeSupport
+  reflectsSupport := obligationLawTransport_reflectsCodeSupport
+  preservesMissing := obligationLawTransport_preservesMissingLocus
+  reflectsMissing := obligationLawTransport_reflectsMissingLocus
+  preservesRepair := obligationLawTransport_preservesRepairFrontier
+  reflectsRepair := obligationLawTransport_reflectsRepairFrontier
+  preservesSourceRefTable := obligationLawTransport_preservesSourceRefTable
+
+/-- The obligation-sensitive update does not preserve obligation. -/
+theorem obligationLawTransport_not_preservesObligation :
+    ¬ PreservesSourceRefObligation obligationLawSensitiveTransport := by
+  intro hpreserves
+  have h := hpreserves fullPacket
+  change StateSeparation.ObligationKind.measure =
+    StateSeparation.ObligationKind.none at h
+  cases h
+
+/-- The selected square is not lawful exactly because the obligation law is absent. -/
+theorem obligationLawRoute_not_lawfulSquare :
+    ¬ LawfulRepairTransportSquare
+      obligationLawSensitiveTransport
+      TransportTableLawRouteLocalization.fullTableResupplyRepairAction
+      TransportTableLawRouteLocalization.fullTableResupplyRepairAction := by
+  intro hlawful
+  exact obligationLawTransport_not_preservesObligation
+    hlawful.obligation_preserves
+
+/-- Repair first, then apply the obligation-sensitive transport. -/
+def obligationLawRoute_repairThenTransportPacket : SourceRefPacket :=
+  repairThenTransportPacket
+    obligationLawSensitiveTransport
+    TransportTableLawRouteLocalization.fullTableResupplyRepairAction
+    fullPacket
+
+/-- Apply the obligation-sensitive transport first, then repair. -/
+def obligationLawRoute_transportThenRepairPacket : SourceRefPacket :=
+  transportThenRepairPacket
+    obligationLawSensitiveTransport
+    TransportTableLawRouteLocalization.fullTableResupplyRepairAction
+    fullPacket
+
+/-- The obligation-law deletion route is visibly flat. -/
+theorem obligationLawRoute_visibleTupleSurface :
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      obligationLawRoute_repairThenTransportPacket
+      obligationLawRoute_transportThenRepairPacket :=
+  SourceRefTupleBridge.packet_supportSurface_projects_to_tuple_visible
+    (by
+      constructor
+      · exact ⟨rfl, rfl⟩
+      · intro atom
+        constructor <;> intro hsupport <;> exact hsupport)
+
+/-- The obligation-law deletion route has an obligation defect. -/
+theorem obligationLawRoute_defectSupport_obligation :
+    RouteDefectSupport
+      obligationLawRoute_repairThenTransportPacket
+      obligationLawRoute_transportThenRepairPacket
+      SourceRefPacketProtectedComponent.obligation := by
+  intro hagree
+  change StateSeparation.ObligationKind.measure =
+    StateSeparation.ObligationKind.none at hagree
+  cases hagree
+
+/-- The obligation-law deletion route has no repair-frontier defect. -/
+theorem obligationLawRoute_noRepairFrontierDefect
+    (atom : CodeAtom) :
+    ¬ RouteDefectSupport
+      obligationLawRoute_repairThenTransportPacket
+      obligationLawRoute_transportThenRepairPacket
+      (SourceRefPacketProtectedComponent.repairFrontier atom) := by
+  intro hdefect
+  apply hdefect
+  constructor <;> intro hfrontier <;> exact hfrontier
+
+/-- The obligation-law deletion route has no source-ref table defect. -/
+theorem obligationLawRoute_noTableDefect
+    (atom : CodeAtom) :
+    ¬ RouteDefectSupport
+      obligationLawRoute_repairThenTransportPacket
+      obligationLawRoute_transportThenRepairPacket
+      (SourceRefPacketProtectedComponent.sourceRefTable atom) := by
+  intro hdefect
+  exact hdefect rfl
+
+/-- The obligation-law deletion route is not source-ref exact. -/
+theorem obligationLawRoute_not_sourceRefExactVisualization :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      obligationLawRoute_repairThenTransportPacket
+      obligationLawRoute_transportThenRepairPacket :=
+  packetHolonomyDefect_obstructs_sourceRefExactVisualization
+    ((routeDefectSupport_iff_packetHolonomyDefect
+      obligationLawRoute_repairThenTransportPacket
+      obligationLawRoute_transportThenRepairPacket
+      SourceRefPacketProtectedComponent.obligation).mp
+      obligationLawRoute_defectSupport_obligation)
+
+/--
+Selected obligation-law deletion cell: all non-obligation packet laws are flat,
+but the route defect is localized at obligation.
+-/
+def ObligationLawDeletionCell : Prop :=
+    BidirectionalSourceRefPacketTransport obligationLawSensitiveTransport ∧
+    PreservesSourceRefVisibleSurface obligationLawSensitiveTransport ∧
+    ¬ PreservesSourceRefObligation obligationLawSensitiveTransport ∧
+    ¬ LawfulRepairTransportSquare
+      obligationLawSensitiveTransport
+      TransportTableLawRouteLocalization.fullTableResupplyRepairAction
+      TransportTableLawRouteLocalization.fullTableResupplyRepairAction ∧
+    RepairActionTransportNaturality
+      TransportTableLawRouteLocalization.fullTableResupplyRepairAction
+      TransportTableLawRouteLocalization.fullTableResupplyRepairAction ∧
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      obligationLawRoute_repairThenTransportPacket
+      obligationLawRoute_transportThenRepairPacket ∧
+    RouteDefectSupport
+      obligationLawRoute_repairThenTransportPacket
+      obligationLawRoute_transportThenRepairPacket
+      SourceRefPacketProtectedComponent.obligation ∧
+    (∀ atom,
+      ¬ RouteDefectSupport
+        obligationLawRoute_repairThenTransportPacket
+        obligationLawRoute_transportThenRepairPacket
+        (SourceRefPacketProtectedComponent.repairFrontier atom)) ∧
+    (∀ atom,
+      ¬ RouteDefectSupport
+        obligationLawRoute_repairThenTransportPacket
+        obligationLawRoute_transportThenRepairPacket
+        (SourceRefPacketProtectedComponent.sourceRefTable atom)) ∧
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      obligationLawRoute_repairThenTransportPacket
+      obligationLawRoute_transportThenRepairPacket
+
+/-- The selected obligation-law deletion cell is realized by the finite witness. -/
+theorem obligationLawDeletion_cell :
+    ObligationLawDeletionCell :=
+  ⟨obligationLawTransport_packetTransportLaws,
+    obligationLawTransport_preservesVisibleSurface,
+    obligationLawTransport_not_preservesObligation,
+    obligationLawRoute_not_lawfulSquare,
+    TransportTableLawRouteLocalization.tokenSwapRoute_selfActionNaturality,
+    obligationLawRoute_visibleTupleSurface,
+    obligationLawRoute_defectSupport_obligation,
+    obligationLawRoute_noRepairFrontierDefect,
+    obligationLawRoute_noTableDefect,
+    obligationLawRoute_not_sourceRefExactVisualization⟩
+
+/--
+A transported action with the same declared support and obligation as the
+storage repair action, but with a stale source-ref table.
+-/
+def staleTransportedRepairAction : SourceRefRepairAction where
+  repairSupport := storageRepairFrontier
+  repairedSourceRefTable := partialSourceRefTable
+  repairedObligation := StateSeparation.ObligationKind.none
+
+/-- Identity packet update for the action-naturality deletion cell. -/
+def actionLawIdentityTransport : PacketUpdate where
+  map := fun packet => (packet : SourceRefPacket)
+
+/-- Identity transport satisfies all packet transport laws. -/
+theorem actionLawIdentity_packetTransportLaws :
+    BidirectionalSourceRefPacketTransport actionLawIdentityTransport where
+  preservesSupport := by
+    intro packet atom hsupport
+    exact hsupport
+  reflectsSupport := by
+    intro packet atom hsupport
+    exact hsupport
+  preservesMissing := by
+    intro packet atom hmissing
+    exact hmissing
+  reflectsMissing := by
+    intro packet atom hmissing
+    exact hmissing
+  preservesRepair := by
+    intro packet atom hrepair
+    exact hrepair
+  reflectsRepair := by
+    intro packet atom hrepair
+    exact hrepair
+  preservesSourceRefTable := by
+    intro packet atom
+    rfl
+
+/-- Identity transport preserves visible surface. -/
+theorem actionLawIdentity_preservesVisibleSurface :
+    PreservesSourceRefVisibleSurface actionLawIdentityTransport := by
+  intro packet
+  change
+    (actionLawIdentityTransport.map packet).visibleScalarReading =
+        packet.visibleScalarReading ∧
+      (actionLawIdentityTransport.map packet).verdict = packet.verdict
+  exact ⟨rfl, rfl⟩
+
+/-- Identity transport preserves obligation. -/
+theorem actionLawIdentity_preservesObligation :
+    PreservesSourceRefObligation actionLawIdentityTransport := by
+  intro packet
+  change packet.obligation = packet.obligation
+  rfl
+
+/-- The selected transported action is not natural to the storage action. -/
+theorem actionLawRoute_not_actionNaturality :
+    ¬ RepairActionTransportNaturality
+      storageRepairAction
+      staleTransportedRepairAction := by
+  intro hnatural
+  have htable := hnatural.table_eq CodeAtom.storage
+  dsimp [staleTransportedRepairAction, storageRepairAction,
+    partialSourceRefTable, fullSourceRefTable] at htable
+  cases htable
+
+/-- The action-naturality deletion square is not lawful. -/
+theorem actionLawRoute_not_lawfulSquare :
+    ¬ LawfulRepairTransportSquare
+      actionLawIdentityTransport
+      storageRepairAction
+      staleTransportedRepairAction := by
+  intro hlawful
+  exact actionLawRoute_not_actionNaturality
+    hlawful.action_naturality
+
+/-- Repair with the storage action, then identity transport. -/
+def actionLawRoute_repairThenTransportPacket : SourceRefPacket :=
+  repairThenTransportPacket
+    actionLawIdentityTransport
+    storageRepairAction
+    partialPacket
+
+/-- Identity transport, then repair with the stale transported action. -/
+def actionLawRoute_transportThenRepairPacket : SourceRefPacket :=
+  transportThenRepairPacket
+    actionLawIdentityTransport
+    staleTransportedRepairAction
+    partialPacket
+
+/-- The action-naturality deletion route is visibly flat. -/
+theorem actionLawRoute_visibleTupleSurface :
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket :=
+  SourceRefTupleBridge.packet_supportSurface_projects_to_tuple_visible
+    (by
+      constructor
+      · exact ⟨rfl, rfl⟩
+      · intro atom
+        constructor <;> intro hsupport <;> exact hsupport)
+
+/-- The action-naturality deletion route has storage repair-frontier support. -/
+theorem actionLawRoute_defectSupport_storageRepair :
+    RouteDefectSupport
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket
+      (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) := by
+  intro hagree
+  have hright :
+      actionLawRoute_transportThenRepairPacket.repairFrontier CodeAtom.storage := by
+    change partialPacket.codeSupport CodeAtom.storage ∧
+      partialSourceRefTable CodeAtom.storage = none
+    exact ⟨trivial, rfl⟩
+  have hnotleft :
+      ¬ actionLawRoute_repairThenTransportPacket.repairFrontier CodeAtom.storage := by
+    intro h
+    rcases h with ⟨_hsupport, hnone⟩
+    change some SourceRefToken.storageRef = none at hnone
+    cases hnone
+  exact hnotleft ((hagree.mpr) hright)
+
+/-- The action-naturality deletion route has storage table support. -/
+theorem actionLawRoute_defectSupport_storageTable :
+    RouteDefectSupport
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) := by
+  intro hagree
+  change some SourceRefToken.storageRef =
+    (none : Option SourceRefToken) at hagree
+  cases hagree
+
+/-- The action-naturality deletion route has no obligation defect. -/
+theorem actionLawRoute_noObligationDefect :
+    ¬ RouteDefectSupport
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket
+      SourceRefPacketProtectedComponent.obligation := by
+  intro hdefect
+  exact hdefect rfl
+
+/-- The action-naturality deletion route is not source-ref exact. -/
+theorem actionLawRoute_not_sourceRefExactVisualization :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket :=
+  packetHolonomyDefect_obstructs_sourceRefExactVisualization
+    ((routeDefectSupport_iff_packetHolonomyDefect
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage)).mp
+      actionLawRoute_defectSupport_storageTable)
+
+/--
+Selected action-naturality deletion cell: packet transport, visible, and
+obligation laws are flat, but action table naturality fails and the defect is
+localized at the storage repair/table coordinates.
+-/
+def ActionNaturalityDeletionCell : Prop :=
+    BidirectionalSourceRefPacketTransport actionLawIdentityTransport ∧
+    PreservesSourceRefVisibleSurface actionLawIdentityTransport ∧
+    PreservesSourceRefObligation actionLawIdentityTransport ∧
+    ¬ RepairActionTransportNaturality
+      storageRepairAction
+      staleTransportedRepairAction ∧
+    ¬ LawfulRepairTransportSquare
+      actionLawIdentityTransport
+      storageRepairAction
+      staleTransportedRepairAction ∧
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket ∧
+    RouteDefectSupport
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket
+      (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) ∧
+    RouteDefectSupport
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) ∧
+    ¬ RouteDefectSupport
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket
+      SourceRefPacketProtectedComponent.obligation ∧
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      actionLawRoute_repairThenTransportPacket
+      actionLawRoute_transportThenRepairPacket
+
+/-- The selected action-naturality deletion cell is realized by the finite witness. -/
+theorem actionNaturalityDeletion_cell :
+    ActionNaturalityDeletionCell :=
+  ⟨actionLawIdentity_packetTransportLaws,
+    actionLawIdentity_preservesVisibleSurface,
+    actionLawIdentity_preservesObligation,
+    actionLawRoute_not_actionNaturality,
+    actionLawRoute_not_lawfulSquare,
+    actionLawRoute_visibleTupleSurface,
+    actionLawRoute_defectSupport_storageRepair,
+    actionLawRoute_defectSupport_storageTable,
+    actionLawRoute_noObligationDefect,
+    actionLawRoute_not_sourceRefExactVisualization⟩
+
+/-! ## Generic criterion, stated through route support -/
+
+/--
+Exact visualization implies both visible tuple equivalence and empty protected
+route support.  This is the route-support version of the packet-zero-holonomy
+criterion from Cycle 24.
+-/
+theorem exactVisualization_requires_visible_and_emptyRouteSupport
+    {p : SourceRefExactVisualizationCriterion.TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket}
+    (hexact : SourceRefExactVisualization gridLeft gridRight left right) :
+    TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+      RouteDefectSupportEmpty left right := by
+  have hpacket :
+      TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+        NoSourceRefPacketHolonomyDefect left right :=
+    (sourceRefExactVisualization_iff_visible_packetZeroHolonomy
+      gridLeft gridRight left right).mp hexact
+  exact ⟨hpacket.1,
+    (routeDefectSupport_empty_iff_noPacketHolonomy left right).mpr
+      hpacket.2⟩
+
+/--
+Visible tuple equivalence plus empty protected route support is sufficient for
+source-ref exact visualization.
+-/
+theorem visible_and_emptyRouteSupport_suffices_exactVisualization
+    {p : SourceRefExactVisualizationCriterion.TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket}
+    (hvisible : TupleVisibleVisualizationEquivalent gridLeft gridRight left right)
+    (hempty : RouteDefectSupportEmpty left right) :
+    SourceRefExactVisualization gridLeft gridRight left right :=
+  RouteDefectExcursionSupport.sourceRefExact_of_visible_and_emptyRouteSupport
+    gridLeft gridRight hvisible hempty
+
+/--
+The route-support exact-visualization criterion: for packet-induced tuple
+views, exactness is equivalent to visible tuple equivalence plus empty protected
+route support.
+-/
+theorem exactVisualization_iff_visible_emptyRouteSupport
+    {p : SourceRefExactVisualizationCriterion.TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    (left right : SourceRefPacket) :
+    SourceRefExactVisualization gridLeft gridRight left right ↔
+      TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+        RouteDefectSupportEmpty left right := by
+  constructor
+  · intro hexact
+    exact exactVisualization_requires_visible_and_emptyRouteSupport
+      gridLeft gridRight hexact
+  · intro hcriterion
+    exact visible_and_emptyRouteSupport_suffices_exactVisualization
+      gridLeft gridRight hcriterion.1 hcriterion.2
+
+/-! ## Selected necessity witnesses -/
+
+/--
+Deleting only the visible law gives the first necessity witness: protected
+packet holonomy is zero and route support is empty, but visible tuple
+equivalence and exact visualization fail.
+-/
+def VisibleLawDeletionNecessityWitness : Prop :=
+    NoSourceRefPacketHolonomyDefect
+      VisibleLawDeletionProtectedZero.visibleLawRoute_repairThenTransportPacket
+      VisibleLawDeletionProtectedZero.visibleLawRoute_transportThenRepairPacket ∧
+    RouteDefectSupportEmpty
+      VisibleLawDeletionProtectedZero.visibleLawRoute_repairThenTransportPacket
+      VisibleLawDeletionProtectedZero.visibleLawRoute_transportThenRepairPacket ∧
+    ¬ TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      VisibleLawDeletionProtectedZero.visibleLawRoute_repairThenTransportPacket
+      VisibleLawDeletionProtectedZero.visibleLawRoute_transportThenRepairPacket ∧
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      VisibleLawDeletionProtectedZero.visibleLawRoute_repairThenTransportPacket
+      VisibleLawDeletionProtectedZero.visibleLawRoute_transportThenRepairPacket
+
+/-- The selected visible-law deletion cell witnesses visible-law necessity. -/
+theorem visibleLawDeletion_witnesses_visibleNecessity :
+    VisibleLawDeletionNecessityWitness :=
+  ⟨VisibleLawDeletionProtectedZero.visibleLawRoute_noPacketHolonomy,
+    VisibleLawDeletionProtectedZero.visibleLawRoute_emptyDefectSupport,
+    VisibleLawDeletionProtectedZero.visibleLawRoute_not_visibleTupleSurface,
+    VisibleLawDeletionProtectedZero.visibleLawRoute_not_sourceRefExactVisualization⟩
+
+/-- The table-law deletion cell does not have empty protected route support. -/
+theorem tableLawDeletion_not_emptyRouteSupport :
+    ¬ RouteDefectSupportEmpty tableRouteLeft tableRouteRight := by
+  intro hempty
+  exact tokenSwapRoute_defectSupport_endpointTable
+    (hempty (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.endpoint))
+
+/--
+Deleting only the transport table law gives the second necessity witness:
+visible tuple equivalence is flat, but protected route support is nonempty and
+exact visualization fails.
+-/
+def TableLawDeletionNecessityWitness : Prop :=
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      tableRouteLeft tableRouteRight ∧
+    TokenSwapRouteExactTablePairSupport ∧
+    ¬ RouteDefectSupportEmpty tableRouteLeft tableRouteRight ∧
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      tableRouteLeft tableRouteRight
+
+/-- The selected table-law deletion cell witnesses protected-zero necessity. -/
+theorem tableLawDeletion_witnesses_emptyRouteSupportNecessity :
+    TableLawDeletionNecessityWitness :=
+  ⟨TransportTableLawRouteLocalization.tokenSwapRoute_visibleTupleSurface,
+    tokenSwapRoute_defectSupport_exact_tablePair,
+    tableLawDeletion_not_emptyRouteSupport,
+    TransportTableLawRouteLocalization.tokenSwapRoute_not_sourceRefExactVisualization⟩
+
+/--
+Four selected deletion cells for the lawful repair/transport criterion.  The
+visible, obligation, table, and action-naturalness laws fail in distinct cells,
+and each failure blocks source-ref exact visualization in its own way.
+-/
+def FourLawSelectedMinimalityMatrix : Prop :=
+    VisibleLawDeletionNecessityWitness ∧
+    ObligationLawDeletionCell ∧
+    TableLawDeletionNecessityWitness ∧
+    ActionNaturalityDeletionCell
+
+/-- The selected four-law minimality matrix is realized by finite witnesses. -/
+theorem fourLawSelectedMinimalityMatrix :
+    FourLawSelectedMinimalityMatrix :=
+  ⟨visibleLawDeletion_witnesses_visibleNecessity,
+    obligationLawDeletion_cell,
+    tableLawDeletion_witnesses_emptyRouteSupportNecessity,
+    actionNaturalityDeletion_cell⟩
+
+/-! ## Selected minimality package -/
+
+/--
+Cycle-42 theorem package: source-ref exact visualization is exactly visible
+tuple equivalence plus empty protected route support, and the selected
+visible-law / table-law deletion cells show that both conjuncts are necessary.
+-/
+theorem exactVisualizationCriterionMinimality_package :
+    (∀ {p : SourceRefExactVisualizationCriterion.TupleProfile}
+      (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+      (left right : SourceRefPacket),
+      SourceRefExactVisualization gridLeft gridRight left right ↔
+        TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+          RouteDefectSupportEmpty left right) ∧
+      VisibleLawDeletionNecessityWitness ∧
+      ObligationLawDeletionCell ∧
+      TableLawDeletionNecessityWitness ∧
+      ActionNaturalityDeletionCell ∧
+      FourLawSelectedMinimalityMatrix ∧
+      ¬ RouteDefectSupportEmpty tableRouteLeft tableRouteRight := by
+  exact ⟨by
+      intro p gridLeft gridRight left right
+      exact exactVisualization_iff_visible_emptyRouteSupport
+        gridLeft gridRight left right,
+    visibleLawDeletion_witnesses_visibleNecessity,
+    obligationLawDeletion_cell,
+    tableLawDeletion_witnesses_emptyRouteSupportNecessity,
+    actionNaturalityDeletion_cell,
+    fourLawSelectedMinimalityMatrix,
+    tableLawDeletion_not_emptyRouteSupport⟩
+
+end ExactVisualizationCriterionMinimality
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-exact-visualization-minimality-matrix.md
+++ b/research/ideas/g-aat-quality-surface-01-exact-visualization-minimality-matrix.md
@@ -1,0 +1,102 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: certificate-transport / obstruction / traceability / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / architecture conformance checker can report route or view failures, but this result turns the selected repair/transport criterion into a finite law-deletion matrix that explains which visible, obligation, table, and action-naturalness laws are independently needed for source-ref exact visualization.
+origin: G-aat-quality-surface-01-cycle42
+tags: [quality-surface, repair-transport, exact-visualization, minimality]
+created: 2026-06-21
+cycle: 42
+lean: proved-in-research
+---
+
+# Exact-visualization criterion and four-law selected minimality matrix
+
+## 主張
+
+`SourceRefExactVisualization` は、packet-induced tuple view 上で `TupleVisibleVisualizationEquivalent` と protected `RouteDefectSupportEmpty` の同時成立と同値である。さらに selected finite repair/transport square において、visible law、obligation law、transport table law、action naturality はそれぞれ独立に削れるが、各 deletion cell は異なる protected / visible defect を生み、source-ref exact visualization を阻害する。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
+- `Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean`
+- `Formal/AG/Research/QualitySurface/TransportTableLawRouteLocalization.lean`
+- `Formal/AG/Research/QualitySurface/VisibleLawDeletionProtectedZero.lean`
+- `Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`
+
+## 非自明性
+
+Cycle 24 の exactness criterion、Cycle 37 の table-law deletion、Cycle 39 の visible-law deletion を単に並べるのではなく、新規に obligation-law deletion cell と action-naturality deletion cell を追加し、四つの law が selected commutator exactness に対して別々の失敗 mode を持つことを同じ theorem package に束ねる。
+
+## 数学的興味
+
+lawful repair/transport square の条件を、十分条件としての便利な仮定ではなく、selected finite witness 上で削ると何が壊れるかを表す minimality matrix として読める。visible failure、obligation holonomy、table defect、action mismatch が同じ `RouteDefectSupport` / exact visualization criterion の中で比較可能になる。
+
+## GOAL への前進
+
+この候補は `certificate-transport`、`obstruction`、`traceability`、`quality-surface` を前進させ、Quality Surface の lawful repair/transport criterion minimality frontier を埋める。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は route mismatch や view failure を検出できるが、visible law、obligation law、table law、action naturality のどれを削るとどの protected component が exact visualization を壊すかを、finite certificate geometry の law-deletion matrix として返すわけではない。この結果はその差分を Lean 証拠として固定する。
+
+## SCORE 見込み
+
+- `score_reason`: lawful criterion minimality matrix frontier に対応し、既存 two-cell witness に obligation/action cells を足して四 law を比較できる。ただし exactness criterion は既存同値の合成でもあるため、G2 厳密性審判に従い base 70 に下げる。Lean proof が sorry-free で通れば multiplier 2.0。
+- `dullness_risk`: 既存 witness の再包装だけなら低価値。新規 obligation/action deletion cells と `exactVisualization_iff_visible_emptyRouteSupport` を同時に入れることで回避する。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean` に selected packet updates、stale transported action、route support defects、four-law matrix package を証明する。
+
+## CS / SWE への帰結
+
+loss-aware quality view で、見た目の flatness と protected exactness を分けるだけでなく、どの commutator law が失敗したかを drill-down する根拠になる。これは UI / tooling claim ではなく、finite certificate surface の theorem として読む。
+
+## 証明・根拠の見込み
+
+Lean file: `Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean`
+
+Planned / proved declarations:
+
+- `exactVisualization_requires_visible_and_emptyRouteSupport`
+- `visible_and_emptyRouteSupport_suffices_exactVisualization`
+- `exactVisualization_iff_visible_emptyRouteSupport`
+- `obligationLawDeletion_cell`
+- `actionNaturalityDeletion_cell`
+- `fourLawSelectedMinimalityMatrix`
+- `exactVisualizationCriterionMinimality_package`
+
+Verification:
+
+- `lake env lean Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `#print axioms` for the reported declarations: no axioms
+- `sorryAx`: none
+- Formal boundary: `Formal/AG/Research` only; `Formal/AG` proper is imported but not edited.
+
+## 審判メモ
+
+- 厳密性: `accept`、base 70。exactness criterion は既存同値の合成に近いが、新規 obligation/action deletion cells は rename ではない。selected finite witness として書くこと。
+- 研究価値: `accept`、base 80。Cycle 24/37/39/38 の exactness、route support、deletion cell を一つの criterion package に束ねる。
+- repo 全体価値: `accept`、base 75。paper seed 強化として価値あり。ただし global minimality や tooling 実装済み capability として言い過ぎない。
+- ライバル比較: `accept`、base 80。ADL / conformance checker との差分として、law deletion ごとの visible/protected defect localization を theorem-level で固定する。
+
+## 関連
+
+- Cycle 37: `Transport table-law deletion localizes the selected route defect`
+- Cycle 39: `Visible-law deletion separates protected zero holonomy from source-ref exact visualization`
+- Cycle 41: `Minimal internal excursion support family hitting theorem`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 42 候補として作成。Lean 単体チェックは `lake env lean Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean` で pass。
+- 2026-06-21: G2 四審判は全員 `accept`。厳密性審判に従い expected score を base 70 / final 140 へ下げ、obligation deletion cell に action naturality 保存を明記。
+- 2026-06-21: G3 公理検査は pass。reported declarations はすべて no axioms / no `sorryAx`。形式化品質監査も pass。
+- 2026-06-21: G3.5 sync audit は `synced`。G4 SCORE audit は `confirm`、base 70、multiplier 2.0、penalty 0、final 140。`research/reports/G-aat-quality-surface-01.md` Cycle 42 と total SCORE 5250 を更新。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 5110
+- total SCORE: 5250
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -46,6 +46,7 @@
   - certificate-transport / quality-surface / traceability: 110
   - certificate-transport / obstruction / invariance / computability / repair-potential: 150
   - repair-potential / obstruction / traceability / atom-supported-quality-geometry / invariance: 130
+  - certificate-transport / obstruction / traceability / quality-surface: 140
 - evidence portfolio:
   - proved-in-research: 41
 
@@ -1886,13 +1887,55 @@ correction necessity を持つことが分かる。Cycle 1 の support-hitting i
 selected internal support atom vocabulary に相対化され、global repair planning、source extraction completeness、
 ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 42: Exact-visualization criterion and four-law selected minimality matrix
+
+```text
+candidate: Exact-visualization criterion and four-law selected minimality matrix
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: certificate-transport/obstruction/traceability/quality-surface
+goal_delta: selected repair/transport exact-visualization criterion を、visible equivalence + empty protected route support の同値と四 law deletion cell に整理し、transport / obstruction frontier を前進させた。
+project_value_delta: Cycle 24/37/39 の exactness / deletion witness に新規 obligation/action deletion cells を加え、lawful criterion minimality matrix を paper seed 用の theorem package として固定した。
+rival_delta: ADL / conformance checker が失敗検出に留まりやすいところを、どの law の欠落がどの visible / protected defect を生むかという finite certificate geometry の matrix として示した。ただし selected finite witness であり、global ADL replacement ではない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch`、reported declarations の `#print axioms` は pass / no axioms。主張は selected finite witness に限定され、global law minimality、tooling completeness、whole-codebase quality へ越境していない。
+open_questions: arbitrary deletion matrix の parametrized structure、selected commutator defect support の hitting necessity、loss-aware commutator atlas adequacy。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean` は、
+source-ref exact visualization を route-support calculus へ接続する。
+packet-induced tuple view では、`SourceRefExactVisualization` は
+`TupleVisibleVisualizationEquivalent` と `RouteDefectSupportEmpty` の同時成立と同値である。
+
+Lean 証拠は次を固定する。
+
+- `exactVisualization_iff_visible_emptyRouteSupport`: exact visualization は visible tuple equivalence と empty protected route support の同値条件である。
+- `VisibleLawDeletionNecessityWitness`: visible law を削ると protected route support は empty のままでも visible tuple equivalence と exact visualization が失敗する。
+- `ObligationLawDeletionCell`: obligation law を削ると他の packet transport / action naturality を保っても obligation defect が局在し、exact visualization が失敗する。
+- `TableLawDeletionNecessityWitness`: transport table law を削ると visible surface は flat でも endpoint / worker table defect support が残り、exact visualization が失敗する。
+- `ActionNaturalityDeletionCell`: action naturality を削ると visible / obligation / packet transport laws は保たれても storage repair-frontier / table support に defect が残る。
+- `fourLawSelectedMinimalityMatrix`: visible、obligation、table、action-naturalness の selected deletion cells を一つの matrix として束ねる。
+- `exactVisualizationCriterionMinimality_package`: criterion と four-law selected matrix をまとめる theorem package。
+
+この結果により、lawful repair/transport criterion は単なる十分条件ではなく、
+selected finite commutator 上でどの law を落とすとどの visible / protected 成分が exactness を壊すかを読む
+law-deletion matrix として扱える。主張は supplied finite source-ref packets、selected route endpoints、
+packet-to-tuple bridge、selected deletion cells に相対化され、global law minimality、canonical repair planning、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-このフェーズの tracking Issue active threshold は 5000 であり、cycle 41 後の total SCORE は 5110 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 42 後の total SCORE は 5250 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 次フェーズへ進める場合は、lawful criterion の necessity / minimality、
 selected commutator localization、
 lawful repair/transport criterion minimality matrix、
-または selected support-defect localization を狙う。threshold は達成済みであるため、PR マージ後に phase boundary 判定へ進む。
+selected support-defect localization、
+または loss-aware commutator atlas adequacy を狙う。threshold 7000 には未達であるため、次 cycle へ進む。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -48,7 +48,7 @@
   - repair-potential / obstruction / traceability / atom-supported-quality-geometry / invariance: 130
   - certificate-transport / obstruction / traceability / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 41
+  - proved-in-research: 42
 
 ## Phase synthesis
 
@@ -64,7 +64,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-41 件の Lean-proved research artifacts は、次の paper seed を形成している。
+42 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -108,7 +108,7 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 41 後の total SCORE は 5110 であり、このフェーズの tracking Issue active threshold 5000 を超えた。
-portfolio constraint も満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 41 件持ち、
+portfolio constraint も満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 42 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 42 として、source-ref exact visualization を visible tuple equivalence + empty protected route support の criterion に整理し、visible / obligation / table / action naturality の selected deletion cells を four-law minimality matrix として追加しました。

tracking Issue は研究状態の正本として開いたまま維持するため、`Closes` は使っていません。

## 証明した定理

- `ExactVisualizationCriterionMinimality.exactVisualization_iff_visible_emptyRouteSupport`
- `ExactVisualizationCriterionMinimality.obligationLawDeletion_cell`
- `ExactVisualizationCriterionMinimality.actionNaturalityDeletion_cell`
- `ExactVisualizationCriterionMinimality.fourLawSelectedMinimalityMatrix`
- `ExactVisualizationCriterionMinimality.exactVisualizationCriterionMinimality_package`

Lean status: `proved`。reported declarations は `#print axioms` で no axioms / no `sorryAx`。

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-exact-visualization-minimality-matrix.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] changed-file `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（Lean/research 変更のため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（Lean/research 変更のため未実施）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348` を使用）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない