### PR TITLE
研究ループ Cycle 43 の route defect support hitting を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -41,3 +41,4 @@ import Formal.AG.Research.QualitySurface.VisibleLawDeletionProtectedZero
 import Formal.AG.Research.QualitySurface.RouteDefectExcursionSupport
 import Formal.AG.Research.QualitySurface.InternalExcursionMinSupport
 import Formal.AG.Research.QualitySurface.ExactVisualizationCriterionMinimality
+import Formal.AG.Research.QualitySurface.SelectedRouteDefectSupportHitting

--- a/Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean
+++ b/Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean
@@ -1,0 +1,564 @@
+import Formal.AG.Research.QualitySurface.RouteDefectSupport
+
+/-!
+Cycle 43 evidence for `G-aat-quality-surface-01`.
+
+This file turns the selected endpoint route defect support from Cycle 38 into a
+finite hitting calculus.  For the visible-flat repair/transport commutator from
+Cycle 28, the protected endpoint defects are exactly the obligation, storage
+repair-frontier, and storage source-ref table coordinates.  We read those
+coordinates as a selected minimal route-defect support family and prove that an
+selected protected-component correction must hit every selected branch.
+
+The claim is relative to supplied finite source-ref packets, selected route
+endpoints, and a selected defect-support atom vocabulary.  It does not assert a
+global correction planner, canonical repair, source extraction completeness,
+ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SelectedRouteDefectSupportHitting
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open RouteDefectSupportTheory
+
+/-! ## Selected endpoint route-defect atoms -/
+
+/-- Selected protected coordinates used to detect the visible-flat route defect. -/
+inductive RouteDefectAtom where
+  | obligation
+  | storageRepair
+  | storageTable
+  deriving DecidableEq, Fintype
+
+open RouteDefectAtom
+
+/-- Embedding of selected route-defect atoms into protected packet components. -/
+def routeDefectAtomComponent :
+    RouteDefectAtom -> SourceRefPacketProtectedComponent
+  | obligation => SourceRefPacketProtectedComponent.obligation
+  | storageRepair => SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage
+  | storageTable => SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage
+
+/-- Every selected atom is grounded in the Cycle 28 visible-flat endpoint route. -/
+theorem visibleRoute_selectedRouteDefectSupport
+    (atom : RouteDefectAtom) :
+    RouteDefectSupport
+      visibleRouteLeft visibleRouteRight
+      (routeDefectAtomComponent atom) := by
+  cases atom with
+  | obligation => exact visibleRepairTransport_defectSupport_obligation
+  | storageRepair => exact visibleRepairTransport_defectSupport_storageRepair
+  | storageTable => exact visibleRepairTransport_defectSupport_storageTable
+
+/--
+The selected route defect support is exact: obligation, storage repair-frontier,
+and storage table are defects, while off-storage repair/table coordinates are
+flat.
+-/
+def VisibleRouteSelectedDefectSupportGrounded : Prop :=
+    RouteDefectSupport
+      visibleRouteLeft visibleRouteRight
+      (routeDefectAtomComponent obligation) ∧
+    RouteDefectSupport
+      visibleRouteLeft visibleRouteRight
+      (routeDefectAtomComponent storageRepair) ∧
+    RouteDefectSupport
+      visibleRouteLeft visibleRouteRight
+      (routeDefectAtomComponent storageTable) ∧
+    (∀ atom, atom ≠ CodeAtom.storage ->
+      ¬ RouteDefectSupport
+        visibleRouteLeft visibleRouteRight
+        (SourceRefPacketProtectedComponent.repairFrontier atom)) ∧
+    (∀ atom, atom ≠ CodeAtom.storage ->
+      ¬ RouteDefectSupport
+        visibleRouteLeft visibleRouteRight
+        (SourceRefPacketProtectedComponent.sourceRefTable atom))
+
+/-- The selected route support is grounded by the Cycle 38 exact support computation. -/
+theorem visibleRoute_selectedDefectSupport_grounded :
+    VisibleRouteSelectedDefectSupportGrounded :=
+  ⟨visibleRepairTransport_defectSupport_obligation,
+    visibleRepairTransport_defectSupport_storageRepair,
+    visibleRepairTransport_defectSupport_storageTable,
+    visibleRepairTransport_noRepairFrontierDefect_offStorage,
+    visibleRepairTransport_noTableDefect_offStorage⟩
+
+/-! ## Selected minimal route-defect branches -/
+
+/-- Selected minimal support branches for the visible-flat route defect. -/
+inductive RouteDefectBranch where
+  | obligationBranch
+  | storageRepairBranch
+  | storageTableBranch
+  deriving DecidableEq, Fintype
+
+open RouteDefectBranch
+
+/-- The selected atom carried by a minimal route-defect branch. -/
+def routeDefectBranchAtom :
+    RouteDefectBranch -> RouteDefectAtom
+  | obligationBranch => obligation
+  | storageRepairBranch => storageRepair
+  | storageTableBranch => storageTable
+
+/-- A branch is grounded when its selected route-defect atom appears at the endpoint route. -/
+def RouteDefectBranchGrounded (branch : RouteDefectBranch) : Prop :=
+  RouteDefectSupport
+    visibleRouteLeft visibleRouteRight
+    (routeDefectAtomComponent (routeDefectBranchAtom branch))
+
+/-- The singleton selected support carried by a route-defect branch. -/
+def RouteDefectBranchSupport
+    (branch : RouteDefectBranch) : RouteDefectAtom -> Prop :=
+  fun atom => atom = routeDefectBranchAtom branch
+
+/--
+A selected route-defect branch is minimal when its singleton support is
+grounded and every nonempty sub-support of it contains that same atom.
+-/
+def IsSelectedMinimalRouteDefectBranch
+    (branch : RouteDefectBranch) : Prop :=
+  RouteDefectBranchGrounded branch ∧
+    RouteDefectBranchSupport branch (routeDefectBranchAtom branch) ∧
+    (∀ support : RouteDefectAtom -> Prop,
+      (∀ atom, support atom -> RouteDefectBranchSupport branch atom) ->
+        (∃ atom, support atom) ->
+          ∀ atom, RouteDefectBranchSupport branch atom -> support atom)
+
+/-- Every selected minimal route-defect branch is grounded. -/
+theorem routeDefectBranch_grounded
+    (branch : RouteDefectBranch) :
+    RouteDefectBranchGrounded branch := by
+  cases branch with
+  | obligationBranch => exact visibleRepairTransport_defectSupport_obligation
+  | storageRepairBranch => exact visibleRepairTransport_defectSupport_storageRepair
+  | storageTableBranch => exact visibleRepairTransport_defectSupport_storageTable
+
+/-- Every selected route-defect branch is a singleton minimal support branch. -/
+theorem routeDefectBranch_selectedMinimal
+    (branch : RouteDefectBranch) :
+    IsSelectedMinimalRouteDefectBranch branch := by
+  refine ⟨routeDefectBranch_grounded branch, rfl, ?_⟩
+  intro support hsubset hnonempty atom hatom
+  rcases hnonempty with ⟨witness, hwitness⟩
+  have hwitness_eq : witness = routeDefectBranchAtom branch :=
+    hsubset witness hwitness
+  have hatom_eq : atom = routeDefectBranchAtom branch := hatom
+  rw [hatom_eq, ← hwitness_eq]
+  exact hwitness
+
+/-- The selected route-defect family consists of minimal grounded branches. -/
+theorem selectedRouteDefectSupportFamily_minimal :
+    ∀ branch, IsSelectedMinimalRouteDefectBranch branch :=
+  routeDefectBranch_selectedMinimal
+
+/-- A correction hits a selected route-defect branch when it touches that branch's atom. -/
+def CorrectionHitsRouteDefectBranch
+    (correction : RouteDefectAtom -> Bool)
+    (branch : RouteDefectBranch) : Prop :=
+  correction (routeDefectBranchAtom branch) = true
+
+/-- A selected branch remains after correction when it is grounded and missed. -/
+def RouteDefectBranchRemainsAfterCorrection
+    (correction : RouteDefectAtom -> Bool)
+    (branch : RouteDefectBranch) : Prop :=
+  RouteDefectBranchGrounded branch ∧
+    ¬ CorrectionHitsRouteDefectBranch correction branch
+
+/-- A correction eliminates the selected endpoint route defect when no selected branch remains. -/
+def RouteDefectCorrectionEliminates
+    (correction : RouteDefectAtom -> Bool) : Prop :=
+  ∀ branch, ¬ RouteDefectBranchRemainsAfterCorrection correction branch
+
+/-- A hit branch leaves no after-correction route defect on that branch. -/
+theorem no_routeDefectAfterCorrection_of_hits
+    {correction : RouteDefectAtom -> Bool}
+    {branch : RouteDefectBranch}
+    (hhit : CorrectionHitsRouteDefectBranch correction branch) :
+    ¬ RouteDefectBranchRemainsAfterCorrection correction branch := by
+  intro hafter
+  exact hafter.2 hhit
+
+/-- A missed grounded branch remains after correction. -/
+theorem missed_routeDefectBranch_remains
+    {correction : RouteDefectAtom -> Bool}
+    {branch : RouteDefectBranch}
+    (hmiss : ¬ CorrectionHitsRouteDefectBranch correction branch) :
+    RouteDefectBranchRemainsAfterCorrection correction branch :=
+  ⟨routeDefectBranch_grounded branch, hmiss⟩
+
+/-- Any correction that eliminates the selected endpoint route defect hits every selected branch. -/
+theorem hits_every_selectedRouteDefectSupport_of_eliminates
+    {correction : RouteDefectAtom -> Bool}
+    (helim : RouteDefectCorrectionEliminates correction) :
+    ∀ branch, CorrectionHitsRouteDefectBranch correction branch := by
+  intro branch
+  cases branch with
+  | obligationBranch =>
+      cases h : correction obligation with
+      | false =>
+          have hmiss :
+              ¬ CorrectionHitsRouteDefectBranch correction obligationBranch := by
+            intro hhit
+            change correction obligation = true at hhit
+            rw [h] at hhit
+            cases hhit
+          exact False.elim
+            (helim obligationBranch
+              (missed_routeDefectBranch_remains hmiss))
+      | true => exact h
+  | storageRepairBranch =>
+      cases h : correction storageRepair with
+      | false =>
+          have hmiss :
+              ¬ CorrectionHitsRouteDefectBranch correction storageRepairBranch := by
+            intro hhit
+            change correction storageRepair = true at hhit
+            rw [h] at hhit
+            cases hhit
+          exact False.elim
+            (helim storageRepairBranch
+              (missed_routeDefectBranch_remains hmiss))
+      | true => exact h
+  | storageTableBranch =>
+      cases h : correction storageTable with
+      | false =>
+          have hmiss :
+              ¬ CorrectionHitsRouteDefectBranch correction storageTableBranch := by
+            intro hhit
+            change correction storageTable = true at hhit
+            rw [h] at hhit
+            cases hhit
+          exact False.elim
+            (helim storageTableBranch
+              (missed_routeDefectBranch_remains hmiss))
+      | true => exact h
+
+/-! ## Source-ref packet correction semantics -/
+
+/--
+Apply a selected correction to the left visible route endpoint by copying the
+hit protected components from the right endpoint.  Off-selected coordinates
+stay at the original left endpoint.
+-/
+def correctedVisibleRouteLeft
+    (correction : RouteDefectAtom -> Bool) : SourceRefPacket where
+  visibleScalarReading := visibleRouteLeft.visibleScalarReading
+  verdict := visibleRouteLeft.verdict
+  codeSupport := visibleRouteLeft.codeSupport
+  obligation :=
+    if correction obligation = true then
+      visibleRouteRight.obligation
+    else
+      visibleRouteLeft.obligation
+  repairFrontier := fun atom =>
+    match atom with
+    | CodeAtom.storage =>
+        if correction storageRepair = true then
+          visibleRouteRight.repairFrontier CodeAtom.storage
+        else
+          visibleRouteLeft.repairFrontier CodeAtom.storage
+    | CodeAtom.endpoint => visibleRouteLeft.repairFrontier CodeAtom.endpoint
+    | CodeAtom.worker => visibleRouteLeft.repairFrontier CodeAtom.worker
+  sourceRefTable := fun atom =>
+    match atom with
+    | CodeAtom.storage =>
+        if correction storageTable = true then
+          visibleRouteRight.sourceRefTable CodeAtom.storage
+        else
+          visibleRouteLeft.sourceRefTable CodeAtom.storage
+    | CodeAtom.endpoint => visibleRouteLeft.sourceRefTable CodeAtom.endpoint
+    | CodeAtom.worker => visibleRouteLeft.sourceRefTable CodeAtom.worker
+
+/-- A selected correction realizes a branch when the corrected packet agrees with the right endpoint there. -/
+def CorrectionRealizesRouteDefectBranch
+    (correction : RouteDefectAtom -> Bool)
+    (branch : RouteDefectBranch) : Prop :=
+  RouteComponentAgreement
+    (correctedVisibleRouteLeft correction)
+    visibleRouteRight
+    (routeDefectAtomComponent (routeDefectBranchAtom branch))
+
+/--
+For the selected endpoint route defect, hitting a branch is exactly what makes
+the corrected packet agree with the right endpoint on that branch's protected
+component.
+-/
+theorem correctedBranchAgreement_iff_hits
+    (correction : RouteDefectAtom -> Bool)
+    (branch : RouteDefectBranch) :
+    CorrectionRealizesRouteDefectBranch correction branch ↔
+      CorrectionHitsRouteDefectBranch correction branch := by
+  cases branch with
+  | obligationBranch =>
+      constructor
+      · intro hagree
+        change correction obligation = true
+        cases h : correction obligation with
+        | false =>
+            have hcond : ¬ correction obligation = true := by
+              intro htrue
+              rw [h] at htrue
+              cases htrue
+            change
+              (if correction obligation = true then
+                  visibleRouteRight.obligation
+                else
+                  visibleRouteLeft.obligation) =
+                visibleRouteRight.obligation at hagree
+            rw [if_neg hcond] at hagree
+            have hleft :
+                RouteComponentAgreement
+                  visibleRouteLeft visibleRouteRight
+                  SourceRefPacketProtectedComponent.obligation := by
+              exact hagree
+            exact False.elim
+              (visibleRepairTransport_defectSupport_obligation hleft)
+        | true => rfl
+      · intro hhit
+        change correction obligation = true at hhit
+        change
+          (if correction obligation = true then
+              visibleRouteRight.obligation
+            else
+              visibleRouteLeft.obligation) =
+            visibleRouteRight.obligation
+        rw [hhit]
+        rfl
+  | storageRepairBranch =>
+      constructor
+      · intro hagree
+        change correction storageRepair = true
+        cases h : correction storageRepair with
+        | false =>
+            have hcond : ¬ correction storageRepair = true := by
+              intro htrue
+              rw [h] at htrue
+              cases htrue
+            change
+              ((if correction storageRepair = true then
+                  visibleRouteRight.repairFrontier CodeAtom.storage
+                else
+                  visibleRouteLeft.repairFrontier CodeAtom.storage) ↔
+                visibleRouteRight.repairFrontier CodeAtom.storage) at hagree
+            rw [if_neg hcond] at hagree
+            have hleft :
+                RouteComponentAgreement
+                  visibleRouteLeft visibleRouteRight
+                  (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) := by
+              exact hagree
+            exact False.elim
+              (visibleRepairTransport_defectSupport_storageRepair hleft)
+        | true => rfl
+      · intro hhit
+        change correction storageRepair = true at hhit
+        change
+          ((if correction storageRepair = true then
+              visibleRouteRight.repairFrontier CodeAtom.storage
+            else
+              visibleRouteLeft.repairFrontier CodeAtom.storage) ↔
+            visibleRouteRight.repairFrontier CodeAtom.storage)
+        rw [hhit]
+        rfl
+  | storageTableBranch =>
+      constructor
+      · intro hagree
+        change correction storageTable = true
+        cases h : correction storageTable with
+        | false =>
+            have hcond : ¬ correction storageTable = true := by
+              intro htrue
+              rw [h] at htrue
+              cases htrue
+            change
+              (if correction storageTable = true then
+                  visibleRouteRight.sourceRefTable CodeAtom.storage
+                else
+                  visibleRouteLeft.sourceRefTable CodeAtom.storage) =
+                visibleRouteRight.sourceRefTable CodeAtom.storage at hagree
+            rw [if_neg hcond] at hagree
+            have hleft :
+                RouteComponentAgreement
+                  visibleRouteLeft visibleRouteRight
+                  (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) := by
+              exact hagree
+            exact False.elim
+              (visibleRepairTransport_defectSupport_storageTable hleft)
+        | true => rfl
+      · intro hhit
+        change correction storageTable = true at hhit
+        change
+          (if correction storageTable = true then
+              visibleRouteRight.sourceRefTable CodeAtom.storage
+            else
+              visibleRouteLeft.sourceRefTable CodeAtom.storage) =
+            visibleRouteRight.sourceRefTable CodeAtom.storage
+        rw [hhit]
+        rfl
+
+/-- A packet-level selected correction eliminates the selected endpoint defect. -/
+def SourceRefRouteCorrectionEliminates
+    (correction : RouteDefectAtom -> Bool) : Prop :=
+  ∀ branch, CorrectionRealizesRouteDefectBranch correction branch
+
+/-- Packet-level elimination is equivalent to hitting every selected route-defect branch. -/
+theorem sourceRefRouteCorrection_eliminates_iff_hits
+    (correction : RouteDefectAtom -> Bool) :
+    SourceRefRouteCorrectionEliminates correction ↔
+      ∀ branch, CorrectionHitsRouteDefectBranch correction branch := by
+  constructor
+  · intro helim branch
+    exact (correctedBranchAgreement_iff_hits correction branch).mp
+      (helim branch)
+  · intro hhits branch
+    exact (correctedBranchAgreement_iff_hits correction branch).mpr
+      (hhits branch)
+
+/-- Any selected protected-component packet correction must hit every route-defect branch. -/
+theorem sourceRefRouteCorrection_hits_every_of_eliminates
+    {correction : RouteDefectAtom -> Bool}
+    (helim : SourceRefRouteCorrectionEliminates correction) :
+    ∀ branch, CorrectionHitsRouteDefectBranch correction branch :=
+  (sourceRefRouteCorrection_eliminates_iff_hits correction).mp helim
+
+/-! ## Finite witness computations -/
+
+/-- The selected route-defect support family is nonempty. -/
+theorem selectedRouteDefectSupportFamily_nonempty :
+    ∃ branch : RouteDefectBranch, RouteDefectBranchGrounded branch :=
+  ⟨obligationBranch, routeDefectBranch_grounded obligationBranch⟩
+
+/-- The obligation branch and storage table branch are distinct. -/
+theorem selectedRouteDefect_obligation_storageTable_distinct :
+    obligationBranch ≠ storageTableBranch := by
+  intro h
+  cases h
+
+/-- A correction that touches only the obligation branch. -/
+def obligationOnlyCorrection : RouteDefectAtom -> Bool
+  | obligation => true
+  | storageRepair => false
+  | storageTable => false
+
+/-- A correction that touches every selected route-defect branch. -/
+def allRouteDefectCorrection : RouteDefectAtom -> Bool
+  | obligation => true
+  | storageRepair => true
+  | storageTable => true
+
+/-- The obligation-only correction hits the obligation branch. -/
+theorem obligationOnlyCorrection_hits_obligation :
+    CorrectionHitsRouteDefectBranch obligationOnlyCorrection obligationBranch :=
+  rfl
+
+/-- The obligation-only correction misses the storage repair branch. -/
+theorem obligationOnlyCorrection_misses_storageRepair :
+    ¬ CorrectionHitsRouteDefectBranch obligationOnlyCorrection storageRepairBranch := by
+  intro h
+  cases h
+
+/-- The obligation-only correction leaves the storage repair branch. -/
+theorem obligationOnlyCorrection_storageRepair_remains :
+    RouteDefectBranchRemainsAfterCorrection
+      obligationOnlyCorrection storageRepairBranch :=
+  missed_routeDefectBranch_remains
+    obligationOnlyCorrection_misses_storageRepair
+
+/-- A correction that hits only the obligation branch does not eliminate the selected route defect. -/
+theorem obligationOnlyCorrection_does_not_eliminate :
+    ¬ RouteDefectCorrectionEliminates obligationOnlyCorrection := by
+  intro helim
+  exact helim storageRepairBranch
+    obligationOnlyCorrection_storageRepair_remains
+
+/-- The all-branch correction eliminates the selected route defect. -/
+theorem allRouteDefectCorrection_eliminates :
+    RouteDefectCorrectionEliminates allRouteDefectCorrection := by
+  intro branch
+  cases branch with
+  | obligationBranch => exact no_routeDefectAfterCorrection_of_hits rfl
+  | storageRepairBranch => exact no_routeDefectAfterCorrection_of_hits rfl
+  | storageTableBranch => exact no_routeDefectAfterCorrection_of_hits rfl
+
+/-- The all-branch correction hits every selected route-defect branch. -/
+theorem allRouteDefectCorrection_hits_every_selectedRouteDefectSupport :
+    ∀ branch,
+      CorrectionHitsRouteDefectBranch allRouteDefectCorrection branch :=
+  hits_every_selectedRouteDefectSupport_of_eliminates
+    allRouteDefectCorrection_eliminates
+
+/-- The obligation-only packet correction does not eliminate the selected endpoint route defect. -/
+theorem obligationOnly_packetCorrection_does_not_eliminate :
+    ¬ SourceRefRouteCorrectionEliminates obligationOnlyCorrection := by
+  intro helim
+  have hhits :=
+    sourceRefRouteCorrection_hits_every_of_eliminates helim
+  exact obligationOnlyCorrection_misses_storageRepair
+    (hhits storageRepairBranch)
+
+/-- The all-branch packet correction eliminates the selected endpoint route defect. -/
+theorem allRouteDefect_packetCorrection_eliminates :
+    SourceRefRouteCorrectionEliminates allRouteDefectCorrection :=
+  (sourceRefRouteCorrection_eliminates_iff_hits
+    allRouteDefectCorrection).mpr
+    allRouteDefectCorrection_hits_every_selectedRouteDefectSupport
+
+/-! ## Theorem package -/
+
+/--
+Cycle-43 theorem package: the visible-flat route defect has a selected
+three-branch support family, and eliminating that selected defect requires
+hitting every selected branch.
+-/
+theorem selectedRouteDefectSupportHitting_package :
+    VisibleRouteSelectedDefectSupportGrounded ∧
+    supportSurfaceReading.Equivalent visibleRouteLeft visibleRouteRight ∧
+    SourceRefExactVisualizationCriterion.LossyPacketToTupleVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      visibleRouteLeft visibleRouteRight ∧
+    ¬ SourceRefExactVisualizationCriterion.SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      visibleRouteLeft visibleRouteRight ∧
+    (∃ branch : RouteDefectBranch, RouteDefectBranchGrounded branch) ∧
+    (∀ branch, IsSelectedMinimalRouteDefectBranch branch) ∧
+    obligationBranch ≠ storageTableBranch ∧
+    CorrectionHitsRouteDefectBranch obligationOnlyCorrection obligationBranch ∧
+    ¬ CorrectionHitsRouteDefectBranch obligationOnlyCorrection storageRepairBranch ∧
+    RouteDefectBranchRemainsAfterCorrection
+      obligationOnlyCorrection storageRepairBranch ∧
+    ¬ RouteDefectCorrectionEliminates obligationOnlyCorrection ∧
+    RouteDefectCorrectionEliminates allRouteDefectCorrection ∧
+    (∀ branch,
+      CorrectionHitsRouteDefectBranch allRouteDefectCorrection branch) ∧
+    ¬ SourceRefRouteCorrectionEliminates obligationOnlyCorrection ∧
+    SourceRefRouteCorrectionEliminates allRouteDefectCorrection ∧
+    (∀ {correction : RouteDefectAtom -> Bool},
+      SourceRefRouteCorrectionEliminates correction ->
+        ∀ branch, CorrectionHitsRouteDefectBranch correction branch) := by
+  exact ⟨visibleRoute_selectedDefectSupport_grounded,
+    VisibleRepairTransportCommutator.repairTransport_visiblePacketSurface_commutes,
+    VisibleRepairTransportCommutator.repairTransport_lossyPacketToTupleVisualization,
+    VisibleRepairTransportCommutator.repairTransport_not_sourceRefExactVisualization,
+    selectedRouteDefectSupportFamily_nonempty,
+    selectedRouteDefectSupportFamily_minimal,
+    selectedRouteDefect_obligation_storageTable_distinct,
+    obligationOnlyCorrection_hits_obligation,
+    obligationOnlyCorrection_misses_storageRepair,
+    obligationOnlyCorrection_storageRepair_remains,
+    obligationOnlyCorrection_does_not_eliminate,
+    allRouteDefectCorrection_eliminates,
+    allRouteDefectCorrection_hits_every_selectedRouteDefectSupport,
+    obligationOnly_packetCorrection_does_not_eliminate,
+    allRouteDefect_packetCorrection_eliminates,
+    by
+      intro correction helim branch
+      exact sourceRefRouteCorrection_hits_every_of_eliminates helim branch⟩
+
+end SelectedRouteDefectSupportHitting
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-selected-route-defect-support-hitting.md
+++ b/research/ideas/g-aat-quality-surface-01-selected-route-defect-support-hitting.md
@@ -1,0 +1,113 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: obstruction / repair-potential / traceability / atom-supported-quality-geometry
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can detect a selected route mismatch, but this result turns the protected route defect into a selected singleton-minimal support family and proves that packet-level protected-component correction must hit every selected branch.
+origin: G-aat-quality-surface-01-cycle43
+tags: [quality-surface, route-defect-support, repair-hitting, source-ref]
+created: 2026-06-21
+cycle: 43
+lean: proved-in-research
+---
+
+# Selected route defect support hitting theorem
+
+## 主張
+
+visible tuple equivalence が固定された selected repair/transport commutator において、source-ref exact visualization failure を protected route defect support family として読み、その selected singleton-minimal support branches をすべて hit しなければ selected protected-component packet correction は成立しない。Cycle 28 / 38 の visible-flat route では、obligation、storage repair-frontier、storage source-ref table の三つが selected defect branches になる。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`
+- `Formal/AG/Research/QualitySurface/VisibleRepairTransportCommutator.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
+- `Formal/AG/Research/QualitySurface/InternalExcursionMinSupport.lean`
+
+## 非自明性
+
+Cycle 38 の route defect support は endpoint support の exact computation だった。Cycle 43 ではこれを selected singleton-minimal support family と correction hitting theorem に持ち上げる。単なる support 列挙ではなく、missed branch remains、all-hit necessity、hit した branch が実際に corrected packet と右 endpoint の protected component agreement を復元することを証明する。
+
+## 数学的興味
+
+route mismatch を failure として終わらせず、repair-potential / obstruction の対象に変換する。visible-flat でも protected support が非空なら exact visualization は失敗し、その失敗には correction が触るべき selected branch family がある。
+
+## GOAL への前進
+
+この候補は `obstruction`、`repair-potential`、`traceability`、`atom-supported-quality-geometry` を前進させ、selected commutator localization と selected support-defect localization を接続する。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は mismatch component を表示できるが、protected route defect を selected support family として読み、その correction necessity を packet-level protected-component agreement theorem として固定するわけではない。この結果は、source-ref exactness failure から repair planning frontier へ進む AAT 側の差分を与える。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 38 の route support calculus と Cycle 41 の hitting theorem を接続し、さらに selected singleton-minimal branch と selected protected-component packet correction semantics へ持ち上げる closure。G2 改訂審判では厳密性 / repo-wide value が base 70、研究価値 / rival 比較が base 75 だったため、保守的に base 70、Lean proof が未完証明なしなら multiplier 2.0。
+- `dullness_risk`: Cycle 41 の internal excursion hitting theorem の横滑りに見える危険がある。endpoint commutator support、visible-flat exactness failure、selected singleton minimality、corrected packet agreement を明確に分けることで回避する。
+- `proof_or_evidence_plan`: `RouteDefectAtom`、`RouteDefectBranch`、`IsSelectedMinimalRouteDefectBranch`、`CorrectionHitsRouteDefectBranch`、`RouteDefectCorrectionEliminates`、`correctedVisibleRouteLeft`、`SourceRefRouteCorrectionEliminates` を定義し、missed branch remains、all-hit theorem、packet-level correction theorem を Lean で証明した。
+
+## CS / SWE への帰結
+
+loss-aware quality view で route defect を表示するだけでなく、どの protected branch を correction が必ず触るべきかを説明できる。これは tooling 実装 claim ではなく、finite selected witness 上の repair frontier theorem である。
+
+## 証明・根拠の見込み
+
+Lean file: `Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean`
+
+Planned / proved declarations:
+
+- `visibleRoute_selectedDefectSupport_grounded`
+- `routeDefectBranch_grounded`
+- `routeDefectBranch_selectedMinimal`
+- `selectedRouteDefectSupportFamily_minimal`
+- `missed_routeDefectBranch_remains`
+- `hits_every_selectedRouteDefectSupport_of_eliminates`
+- `correctedBranchAgreement_iff_hits`
+- `sourceRefRouteCorrection_eliminates_iff_hits`
+- `sourceRefRouteCorrection_hits_every_of_eliminates`
+- `obligationOnlyCorrection_does_not_eliminate`
+- `allRouteDefectCorrection_eliminates`
+- `obligationOnly_packetCorrection_does_not_eliminate`
+- `allRouteDefect_packetCorrection_eliminates`
+- `selectedRouteDefectSupportHitting_package`
+
+Verification:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `#print axioms` for all listed declarations: all `does not depend on any axioms`
+- forbidden-token scan on the Lean file and candidate card: no matches
+
+Boundary:
+
+- selected finite source-ref packet route 上の theorem であり、global repair planner、canonical correction、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+- `correctedVisibleRouteLeft` は selected protected component を右 endpoint からコピーする有限 packet correction semantics であり、runtime patch や tooling 実装 claim ではない。
+
+## 審判メモ
+
+- 厳密性: 初回 G2 は revise。Bool branch hitting だけでは Cycle 41 の近傍に寄りすぎるため、formal minimal-support predicate、packet/source-ref correction semantics、非 rename bridge が要求された。Cycle 43 revise で `IsSelectedMinimalRouteDefectBranch` と `SourceRefRouteCorrectionEliminates` を追加済み。改訂後は accept / base 70。`SourceRefRouteCorrectionEliminates` は全 packet exactness ではなく selected protected-component agreement と読む。
+- 研究価値: accept / base 75。source-ref exact visualization failure から selected three-branch support family と all-hit correction necessity へ圧縮している点を評価。
+- repo 全体価値: accept / base 70。Cycle 38、41、42 の closure として有効だが、tooling / website 実装 claim ではない。
+- ライバル比較: accept / base 75。ADL / conformance checker の mismatch 表示に対し、support-local repair semantics と all-hit necessity を加える点を評価。
+- G3 公理監査: clean。listed declarations はすべて公理依存なしで、evidence multiplier x2.0 が許可された。
+- G3 形式化品質監査: pass。`SourceRefRouteCorrectionEliminates` は selected protected-component agreement に限定され、全 packet exactness や global correction planner ではないことが確認された。
+
+## 関連
+
+- Cycle 38: `Route defect support calculus for selected repair/transport endpoints`
+- Cycle 41: `Minimal internal excursion support family hitting theorem`
+- Cycle 42: `Exact-visualization criterion and four-law selected minimality matrix`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 43 候補として作成。Lean 単体チェックは `lake env lean Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean` で pass。
+- 2026-06-21: G2 厳密性 revise に対応し、selected branch minimality と packet-level correction semantics を Lean に追加。単体チェックは再度 pass。
+- 2026-06-21: G3 で `lake build FormalAGResearch`、網羅的 `#print axioms`、形式化品質監査が pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 5250
+- total SCORE: 5390
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -47,8 +47,9 @@
   - certificate-transport / obstruction / invariance / computability / repair-potential: 150
   - repair-potential / obstruction / traceability / atom-supported-quality-geometry / invariance: 130
   - certificate-transport / obstruction / traceability / quality-surface: 140
+  - obstruction / repair-potential / traceability / atom-supported-quality-geometry: 140
 - evidence portfolio:
-  - proved-in-research: 42
+  - proved-in-research: 43
 
 ## Phase synthesis
 
@@ -64,7 +65,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-42 件の Lean-proved research artifacts は、次の paper seed を形成している。
+43 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -107,8 +108,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 41 後の total SCORE は 5110 であり、このフェーズの tracking Issue active threshold 5000 を超えた。
-portfolio constraint も満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 42 件持ち、
+Cycle 43 後の total SCORE は 5390 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 43 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -1928,9 +1929,56 @@ law-deletion matrix として扱える。主張は supplied finite source-ref pa
 packet-to-tuple bridge、selected deletion cells に相対化され、global law minimality、canonical repair planning、
 source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 43: Selected route defect support hitting theorem
+
+```text
+candidate: Selected route defect support hitting theorem
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: obstruction/repair-potential/traceability/atom-supported-quality-geometry
+goal_delta: visible-flat endpoint route defect support を selected singleton-minimal branch family と selected protected-component packet correction theorem へ持ち上げ、support-local repair necessity frontier を前進させた。
+project_value_delta: Cycle 38 の endpoint route support、Cycle 41 の hitting calculus、Cycle 42 の exact-visualization criterion を接続し、paper seed の source-ref exact visualization failure / repair-support necessity 節を強化した。
+rival_delta: ADL / conformance checker は selected route mismatch を検出できるが、protected route defect を singleton-minimal support family として読み、selected protected-component correction が全 branch を hit する必要性までは固定しない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch`、reported declarations の `#print axioms` は pass / no axioms。主張は selected finite packet route と selected protected-component agreement に限定され、global repair planner、ArchMap correctness、source extraction completeness、whole-codebase quality へ越境しない。
+open_questions: off-selected flatness を合成した selected route support empty theorem、loss-aware commutator atlas adequacy、lawful criterion minimality と selected correction frontier の paper-level synthesis。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean` は、
+Cycle 28 / 38 の visible-flat repair/transport endpoint route defect を selected branch family として読む。
+selected branch は obligation、storage repair-frontier、storage source-ref table の三つであり、
+`RouteDefectAtom` から protected packet component へ埋め込まれる。
+
+Lean 証拠は次を固定する。
+
+- `visibleRoute_selectedDefectSupport_grounded`: visible-flat route の selected support は obligation、
+  storage repair-frontier、storage source-ref table に grounded であり、off-storage repair/table coordinates は flat である。
+- `IsSelectedMinimalRouteDefectBranch` / `routeDefectBranch_selectedMinimal`:
+  各 selected branch は singleton support として minimal である。
+- `missed_routeDefectBranch_remains`: grounded branch を correction が miss すると、その branch は after-correction defect として残る。
+- `hits_every_selectedRouteDefectSupport_of_eliminates`: selected route defect を eliminate する correction は全 selected branch を hit する。
+- `correctedVisibleRouteLeft`: hit された selected protected component を右 endpoint からコピーする有限 packet correction semantics。
+- `correctedBranchAgreement_iff_hits`: branch を hit することと、corrected packet が右 endpoint とその branch の protected component で一致することは同値である。
+- `sourceRefRouteCorrection_eliminates_iff_hits` /
+  `sourceRefRouteCorrection_hits_every_of_eliminates`: selected protected-component packet correction は全 selected branch hitting と同値であり、eliminate するなら全 branch を hit する。
+- `obligationOnly_packetCorrection_does_not_eliminate` /
+  `allRouteDefect_packetCorrection_eliminates`: obligation-only correction は storage repair branch を miss するため selected route defect を eliminate せず、all-branch correction は eliminate する。
+- `selectedRouteDefectSupportHitting_package`: selected support grounding、source-ref exact visualization failure、singleton minimality、Bool-level hitting、packet-level selected correction theorem を束ねる。
+
+この結果により、visible tuple equivalence の下で残る source-ref exact visualization failure は、
+単なる mismatch list ではなく、selected singleton-minimal support family と selected protected-component correction necessity を持つ
+finite certificate geometry として読める。主張は supplied finite source-ref packets、selected endpoint route、
+selected protected component vocabulary に相対化され、global repair planner、canonical correction、source extraction completeness、
+ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 42 後の total SCORE は 5250 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 43 後の total SCORE は 5390 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 43 として、visible-flat repair/transport endpoint route defect を selected singleton-minimal support family と selected protected-component packet correction theorem に持ち上げました。

SCORE 監査結果は base 70、evidence multiplier 2.0、penalty 0、final +140 です。report の total SCORE は 5390 / 7000、`proved-in-research` は 43 件に更新しています。

## 証明した定理

- `visibleRoute_selectedDefectSupport_grounded`
- `routeDefectBranch_selectedMinimal`
- `selectedRouteDefectSupportFamily_minimal`
- `missed_routeDefectBranch_remains`
- `hits_every_selectedRouteDefectSupport_of_eliminates`
- `correctedBranchAgreement_iff_hits`
- `sourceRefRouteCorrection_eliminates_iff_hits`
- `sourceRefRouteCorrection_hits_every_of_eliminates`
- `obligationOnly_packetCorrection_does_not_eliminate`
- `allRouteDefect_packetCorrection_eliminates`
- `selectedRouteDefectSupportHitting_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-selected-route-defect-support-hitting.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] forbidden-token scan on the Cycle 43 Lean/card files
- [x] `#print axioms` for 14 reported declarations: all no-axiom
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに未完証明・非標準公理・危険指定を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

tracking Issue は threshold 7000 まで継続するため、`Closes #2348` ではなく `Refs #2348` にしています。
