### PR TITLE
研究ループ Cycle 44 の route correction exactness を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -42,3 +42,4 @@ import Formal.AG.Research.QualitySurface.RouteDefectExcursionSupport
 import Formal.AG.Research.QualitySurface.InternalExcursionMinSupport
 import Formal.AG.Research.QualitySurface.ExactVisualizationCriterionMinimality
 import Formal.AG.Research.QualitySurface.SelectedRouteDefectSupportHitting
+import Formal.AG.Research.QualitySurface.SelectedRouteCorrectionExactness

--- a/Formal/AG/Research/QualitySurface/SelectedRouteCorrectionExactness.lean
+++ b/Formal/AG/Research/QualitySurface/SelectedRouteCorrectionExactness.lean
@@ -1,0 +1,266 @@
+import Formal.AG.Research.QualitySurface.SelectedRouteDefectSupportHitting
+import Formal.AG.Research.QualitySurface.ExactVisualizationCriterionMinimality
+
+/-!
+Cycle 44 evidence for `G-aat-quality-surface-01`.
+
+This file closes the gap left by Cycle 43.  Cycle 43 showed that selected
+protected-component correction is equivalent to hitting every selected
+route-defect branch.  Here we add the off-selected flatness computation from
+Cycle 38 and prove that hitting every selected branch is equivalent to empty
+protected route support for the corrected endpoint route.  By the Cycle 42
+criterion, the corrected endpoint route is source-ref exact precisely when the
+selected route-defect family is hit.
+
+The claim is relative to supplied finite source-ref packets, the selected
+visible-flat route endpoints, and the selected protected component vocabulary.
+It does not assert a global correction planner, canonical runtime patch,
+source extraction completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SelectedRouteCorrectionExactness
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+open RouteDefectSupportTheory
+open SelectedRouteDefectSupportHitting
+open ExactVisualizationCriterionMinimality
+open RouteDefectBranch
+
+/-! ## Visible surface of corrected endpoint routes -/
+
+/-- Selected correction does not change the visible packet surface. -/
+theorem correctedVisibleRoute_supportSurface_equivalent
+    (correction : RouteDefectAtom -> Bool) :
+    supportSurfaceReading.Equivalent
+      (correctedVisibleRouteLeft correction) visibleRouteRight := by
+  have hvisible :
+      supportSurfaceReading.Equivalent visibleRouteLeft visibleRouteRight :=
+    VisibleRepairTransportCommutator.repairTransport_visiblePacketSurface_commutes
+  exact hvisible
+
+/-- Selected correction preserves visible tuple equivalence with the right endpoint. -/
+theorem correctedVisibleRoute_tupleVisible
+    (correction : RouteDefectAtom -> Bool) :
+    TupleVisibleVisualizationEquivalent
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (correctedVisibleRouteLeft correction) visibleRouteRight :=
+  SourceRefTupleBridge.packet_supportSurface_projects_to_tuple_visible
+    (correctedVisibleRoute_supportSurface_equivalent correction)
+
+/-! ## Empty protected route support iff all selected branches are hit -/
+
+/--
+If a selected correction hits every selected branch, then the corrected endpoint
+route has empty protected route support.  The selected coordinates are repaired
+by copying the right endpoint, while off-storage repair/table coordinates stay
+flat by the Cycle 38 exact support computation.
+-/
+theorem correctedVisibleRoute_supportEmpty_of_hits
+    {correction : RouteDefectAtom -> Bool}
+    (hhits : ∀ branch, CorrectionHitsRouteDefectBranch correction branch) :
+    RouteDefectSupportEmpty
+      (correctedVisibleRouteLeft correction) visibleRouteRight := by
+  intro component
+  cases component with
+  | obligation =>
+      exact (correctedBranchAgreement_iff_hits
+        correction obligationBranch).mpr (hhits obligationBranch)
+  | repairFrontier atom =>
+      cases atom with
+      | endpoint =>
+          change
+            (visibleRouteLeft.repairFrontier CodeAtom.endpoint ↔
+              visibleRouteRight.repairFrontier CodeAtom.endpoint)
+          dsimp [visibleRouteLeft, visibleRouteRight]
+          rw [VisibleRepairTransportCommutator.repairThenTransportPacket_eq_partial,
+            VisibleRepairTransportCommutator.transportThenRepairPacket_eq_storageRepair]
+          constructor <;> intro hfrontier
+          · cases hfrontier
+          · rcases hfrontier with ⟨_hsupport, htable⟩
+            cases htable
+      | storage =>
+          exact (correctedBranchAgreement_iff_hits
+            correction storageRepairBranch).mpr (hhits storageRepairBranch)
+      | worker =>
+          change
+            (visibleRouteLeft.repairFrontier CodeAtom.worker ↔
+              visibleRouteRight.repairFrontier CodeAtom.worker)
+          dsimp [visibleRouteLeft, visibleRouteRight]
+          rw [VisibleRepairTransportCommutator.repairThenTransportPacket_eq_partial,
+            VisibleRepairTransportCommutator.transportThenRepairPacket_eq_storageRepair]
+          constructor <;> intro hfrontier
+          · cases hfrontier
+          · rcases hfrontier with ⟨_hsupport, htable⟩
+            cases htable
+  | sourceRefTable atom =>
+      cases atom with
+      | endpoint =>
+          change
+            visibleRouteLeft.sourceRefTable CodeAtom.endpoint =
+              visibleRouteRight.sourceRefTable CodeAtom.endpoint
+          dsimp [visibleRouteLeft, visibleRouteRight]
+          rw [VisibleRepairTransportCommutator.repairThenTransportPacket_eq_partial,
+            VisibleRepairTransportCommutator.transportThenRepairPacket_eq_storageRepair]
+          rfl
+      | storage =>
+          exact (correctedBranchAgreement_iff_hits
+            correction storageTableBranch).mpr (hhits storageTableBranch)
+      | worker =>
+          change
+            visibleRouteLeft.sourceRefTable CodeAtom.worker =
+              visibleRouteRight.sourceRefTable CodeAtom.worker
+          dsimp [visibleRouteLeft, visibleRouteRight]
+          rw [VisibleRepairTransportCommutator.repairThenTransportPacket_eq_partial,
+            VisibleRepairTransportCommutator.transportThenRepairPacket_eq_storageRepair]
+          rfl
+
+/-- Empty protected route support of the corrected route forces every selected branch hit. -/
+theorem hits_every_selectedRouteDefectSupport_of_correctedSupportEmpty
+    {correction : RouteDefectAtom -> Bool}
+    (hempty :
+      RouteDefectSupportEmpty
+        (correctedVisibleRouteLeft correction) visibleRouteRight) :
+    ∀ branch, CorrectionHitsRouteDefectBranch correction branch := by
+  intro branch
+  exact (correctedBranchAgreement_iff_hits correction branch).mp
+    (hempty (routeDefectAtomComponent (routeDefectBranchAtom branch)))
+
+/-- Corrected endpoint route support is empty exactly when every selected branch is hit. -/
+theorem correctedVisibleRoute_supportEmpty_iff_hits
+    (correction : RouteDefectAtom -> Bool) :
+    RouteDefectSupportEmpty
+      (correctedVisibleRouteLeft correction) visibleRouteRight ↔
+      ∀ branch, CorrectionHitsRouteDefectBranch correction branch := by
+  constructor
+  · exact hits_every_selectedRouteDefectSupport_of_correctedSupportEmpty
+  · exact correctedVisibleRoute_supportEmpty_of_hits
+
+/-! ## Exact visualization restored by all-hit selected correction -/
+
+/--
+The corrected endpoint route is source-ref exact exactly when every selected
+route-defect branch is hit.
+-/
+theorem correctedVisibleRoute_exactVisualization_iff_hits
+    (correction : RouteDefectAtom -> Bool) :
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (correctedVisibleRouteLeft correction) visibleRouteRight ↔
+      ∀ branch, CorrectionHitsRouteDefectBranch correction branch := by
+  constructor
+  · intro hexact
+    have hempty :
+        RouteDefectSupportEmpty
+          (correctedVisibleRouteLeft correction) visibleRouteRight :=
+      (exactVisualization_requires_visible_and_emptyRouteSupport
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        hexact).2
+    exact hits_every_selectedRouteDefectSupport_of_correctedSupportEmpty hempty
+  · intro hhits
+    exact visible_and_emptyRouteSupport_suffices_exactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (correctedVisibleRoute_tupleVisible correction)
+      (correctedVisibleRoute_supportEmpty_of_hits hhits)
+
+/-- The all-branch correction empties protected route support. -/
+theorem allRouteDefectCorrection_supportEmpty :
+    RouteDefectSupportEmpty
+      (correctedVisibleRouteLeft allRouteDefectCorrection) visibleRouteRight :=
+  (correctedVisibleRoute_supportEmpty_iff_hits
+    allRouteDefectCorrection).mpr
+    allRouteDefectCorrection_hits_every_selectedRouteDefectSupport
+
+/-- The all-branch correction restores source-ref exact visualization. -/
+theorem allRouteDefectCorrection_sourceRefExactVisualization :
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (correctedVisibleRouteLeft allRouteDefectCorrection) visibleRouteRight :=
+  (correctedVisibleRoute_exactVisualization_iff_hits
+    allRouteDefectCorrection).mpr
+    allRouteDefectCorrection_hits_every_selectedRouteDefectSupport
+
+/-- Obligation-only correction still leaves nonempty protected route support. -/
+theorem obligationOnlyCorrection_not_supportEmpty :
+    ¬ RouteDefectSupportEmpty
+      (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight := by
+  intro hempty
+  have hhits :=
+    hits_every_selectedRouteDefectSupport_of_correctedSupportEmpty hempty
+  exact obligationOnlyCorrection_misses_storageRepair
+    (hhits storageRepairBranch)
+
+/-- Obligation-only correction does not restore source-ref exact visualization. -/
+theorem obligationOnlyCorrection_not_sourceRefExactVisualization :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight := by
+  intro hexact
+  have hempty :
+      RouteDefectSupportEmpty
+        (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight :=
+    (exactVisualization_requires_visible_and_emptyRouteSupport
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      hexact).2
+  exact obligationOnlyCorrection_not_supportEmpty hempty
+
+/-! ## Theorem package -/
+
+/--
+Cycle-44 theorem package: all-hit selected correction is equivalent to empty
+protected route support and, because the visible tuple surface is fixed, to
+source-ref exact visualization of the corrected endpoint route.
+-/
+theorem selectedRouteCorrectionExactness_package :
+    (∀ correction,
+      supportSurfaceReading.Equivalent
+        (correctedVisibleRouteLeft correction) visibleRouteRight) ∧
+    (∀ correction,
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft correction) visibleRouteRight) ∧
+    (∀ correction,
+      RouteDefectSupportEmpty
+        (correctedVisibleRouteLeft correction) visibleRouteRight ↔
+        ∀ branch, CorrectionHitsRouteDefectBranch correction branch) ∧
+    (∀ correction,
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft correction) visibleRouteRight ↔
+        ∀ branch, CorrectionHitsRouteDefectBranch correction branch) ∧
+    RouteDefectSupportEmpty
+      (correctedVisibleRouteLeft allRouteDefectCorrection) visibleRouteRight ∧
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (correctedVisibleRouteLeft allRouteDefectCorrection) visibleRouteRight ∧
+    ¬ RouteDefectSupportEmpty
+      (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight ∧
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight := by
+  exact ⟨correctedVisibleRoute_supportSurface_equivalent,
+    correctedVisibleRoute_tupleVisible,
+    correctedVisibleRoute_supportEmpty_iff_hits,
+    correctedVisibleRoute_exactVisualization_iff_hits,
+    allRouteDefectCorrection_supportEmpty,
+    allRouteDefectCorrection_sourceRefExactVisualization,
+    obligationOnlyCorrection_not_supportEmpty,
+    obligationOnlyCorrection_not_sourceRefExactVisualization⟩
+
+end SelectedRouteCorrectionExactness
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-selected-route-correction-exactness.md
+++ b/research/ideas/g-aat-quality-surface-01-selected-route-correction-exactness.md
@@ -1,0 +1,109 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: obstruction / repair-potential / certificate-transport / traceability / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can detect route mismatch, but this result proves that selected branch hitting is equivalent to empty protected route support and source-ref exact visualization for the corrected endpoint route.
+origin: G-aat-quality-surface-01-cycle44
+tags: [quality-surface, route-defect-support, exact-visualization, repair-hitting]
+created: 2026-06-21
+cycle: 44
+lean: proved-in-research
+---
+
+# Selected route correction exactness theorem
+
+## 主張
+
+Cycle 43 の selected protected-component correction を off-selected flatness と合成すると、corrected visible route endpoint について、全 selected route-defect branch を hit すること、protected route support が空になること、source-ref exact visualization が回復することが同値になる。all-branch correction は exact visualization を回復し、obligation-only correction は storage repair branch を miss するため exactness を回復しない。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean`
+- `Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`
+- `Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean`
+- `Formal/AG/Research/QualitySurface/VisibleRepairTransportCommutator.lean`
+
+## 非自明性
+
+Cycle 43 は selected branch agreement に留まっていた。Cycle 44 は Cycle 38 の off-storage flatness と Cycle 42 の exact visualization criterion を合成し、selected branch hitting が corrected endpoint route 全体の protected support empty と source-ref exact visualization に一致することを証明する。単なる Bool hitting の言い換えではなく、selected correction theorem を route-support exactness theorem へ上げる。
+
+## 数学的興味
+
+visible tuple surface が固定されたまま、repair frontier は selected branch hitting の有無で source-ref exactness の回復 / 非回復に分かれる。これにより、support-local repair theorem が exact visualization criterion と同じ finite certificate geometry の中で接続される。
+
+## GOAL への前進
+
+この候補は `obstruction`、`repair-potential`、`certificate-transport`、`traceability`、`quality-surface` を前進させ、selected defect support と exact visualization restoration を一つの iff theorem に圧縮する。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は mismatch component や route inconsistency を表示できるが、どの selected support branches を hit すれば protected route support が空になり source-ref exact visualization が回復するかを証明対象として固定しない。この結果は検出から repair-exactness criterion へ進む AAT 側の差分を与える。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 43 の明示的 open question を閉じ、Cycle 38/42/43 を exactness restoration iff theorem として合成する closure。G2 では研究価値 / repo 全体価値 / rival 比較が base 80、厳密性が base 70 だったため、保守的に base 70、Lean proof が未完証明なしなら multiplier 2.0。
+- `dullness_risk`: Cycle 43 の近接系に見える危険がある。off-selected flatness と Cycle 42 criterion を明示的に使い、branch hit から protected route support empty / exact visualization まで到達する点を差分にする。
+- `proof_or_evidence_plan`: `correctedVisibleRoute_supportEmpty_iff_hits`、`correctedVisibleRoute_exactVisualization_iff_hits`、`allRouteDefectCorrection_sourceRefExactVisualization`、`obligationOnlyCorrection_not_sourceRefExactVisualization` を Lean で証明した。
+
+## CS / SWE への帰結
+
+loss-aware quality view が route defect branch を表示するだけでなく、selected branch hitting が exact visualization restoration の criterion であることを説明できる。これは tooling 実装 claim ではなく、finite selected witness 上の repair-exactness theorem である。
+
+## 証明・根拠の見込み
+
+Lean file: `Formal/AG/Research/QualitySurface/SelectedRouteCorrectionExactness.lean`
+
+Planned / proved declarations:
+
+- `correctedVisibleRoute_supportSurface_equivalent`
+- `correctedVisibleRoute_tupleVisible`
+- `correctedVisibleRoute_supportEmpty_of_hits`
+- `hits_every_selectedRouteDefectSupport_of_correctedSupportEmpty`
+- `correctedVisibleRoute_supportEmpty_iff_hits`
+- `correctedVisibleRoute_exactVisualization_iff_hits`
+- `allRouteDefectCorrection_supportEmpty`
+- `allRouteDefectCorrection_sourceRefExactVisualization`
+- `obligationOnlyCorrection_not_supportEmpty`
+- `obligationOnlyCorrection_not_sourceRefExactVisualization`
+- `selectedRouteCorrectionExactness_package`
+
+Verification:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SelectedRouteCorrectionExactness.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `#print axioms` for all listed declarations: all `does not depend on any axioms`
+- forbidden-token scan on the Cycle 44 Lean/card files: no matches
+
+Boundary:
+
+- selected finite source-ref packet route 上の theorem であり、global correction planner、canonical runtime patch、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+- exact visualization は supplied packet-to-tuple bridge と selected endpoint route に相対化される。
+
+## 審判メモ
+
+- 厳密性: accept / base 70。Cycle 42 / 43 の合成成分が大きいが、off-selected flatness を埋めて `RouteDefectSupportEmpty` と `SourceRefExactVisualization` へ上げる差分はある。
+- 研究価値: accept / base 80。selected branch hitting、protected route support empty、source-ref exact visualization restoration を iff に圧縮する点を評価。
+- repo 全体価値: accept / base 80。Research / Lean の成果として PR 価値があり、Tooling / Website には将来の loss-aware visualization surface として接続可能。
+- ライバル比較: accept / base 80。route mismatch detection を越えて、repair-exactness criterion を finite certificate geometry として固定する点を評価。
+- G3 公理監査: clean。listed declarations はすべて公理依存なしで、evidence multiplier x2.0 が許可された。
+- G3 形式化品質監査: pass。`correctedVisibleRoute_supportEmpty_iff_hits` と `correctedVisibleRoute_exactVisualization_iff_hits` が candidate claim と対応し、global correction planner / tooling 実装 claim に越境していないことが確認された。
+
+## 関連
+
+- Cycle 38: `Route defect support calculus for selected repair/transport endpoints`
+- Cycle 42: `Exact-visualization criterion and four-law selected minimality matrix`
+- Cycle 43: `Selected route defect support hitting theorem`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 44 候補として作成。Lean 単体チェックと `lake build FormalAGResearch` は pass。
+- 2026-06-21: G2 は accept。G3 で網羅的 `#print axioms` と形式化品質監査が pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 5390
+- total SCORE: 5530
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -48,8 +48,9 @@
   - repair-potential / obstruction / traceability / atom-supported-quality-geometry / invariance: 130
   - certificate-transport / obstruction / traceability / quality-surface: 140
   - obstruction / repair-potential / traceability / atom-supported-quality-geometry: 140
+  - obstruction / repair-potential / certificate-transport / traceability / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 43
+  - proved-in-research: 44
 
 ## Phase synthesis
 
@@ -65,7 +66,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-43 件の Lean-proved research artifacts は、次の paper seed を形成している。
+44 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -108,8 +109,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 43 後の total SCORE は 5390 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 43 件持ち、
+Cycle 44 後の total SCORE は 5530 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 44 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -1976,9 +1977,51 @@ finite certificate geometry として読める。主張は supplied finite sourc
 selected protected component vocabulary に相対化され、global repair planner、canonical correction、source extraction completeness、
 ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 44: Selected route correction exactness theorem
+
+```text
+candidate: Selected route correction exactness theorem
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: obstruction/repair-potential/certificate-transport/traceability/quality-surface
+goal_delta: selected branch hitting、protected route support empty、source-ref exact visualization restoration を同値として束ね、support-local repair theorem を exactness restoration criterion へ接続した。
+project_value_delta: Cycle 38 の off-selected flatness、Cycle 42 の exact-visualization criterion、Cycle 43 の selected hitting theorem を一つの finite route correction theorem として合成した。
+rival_delta: ADL / conformance checker は route mismatch を検出できるが、selected support branches を hit することが protected support empty と source-ref exact visualization restoration に同値であることまでは証明対象にしない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch`、reported declarations の `#print axioms` は pass / no axioms。主張は supplied finite route と selected correction semantics に限定され、global correction planner、canonical runtime patch、ArchMap correctness、source extraction completeness、whole-codebase quality へ越境しない。
+open_questions: loss-aware commutator atlas adequacy、lawful criterion minimality と selected correction frontier の paper-level synthesis、selected route correction exactness の parametrized family。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SelectedRouteCorrectionExactness.lean` は、
+Cycle 43 の selected protected-component correction を Cycle 38 の off-selected flatness と Cycle 42 の
+exact visualization criterion に接続する。
+
+Lean 証拠は次を固定する。
+
+- `correctedVisibleRoute_supportSurface_equivalent` /
+  `correctedVisibleRoute_tupleVisible`: selected correction は visible packet / tuple surface を変えない。
+- `correctedVisibleRoute_supportEmpty_of_hits`: 全 selected branch を hit すると、corrected endpoint route の protected route support は空になる。
+- `hits_every_selectedRouteDefectSupport_of_correctedSupportEmpty`: corrected endpoint route の protected support が空なら、全 selected branch が hit されている。
+- `correctedVisibleRoute_supportEmpty_iff_hits`: protected route support empty と all selected branch hitting は同値である。
+- `correctedVisibleRoute_exactVisualization_iff_hits`: visible tuple surface が固定されているため、source-ref exact visualization restoration と all selected branch hitting は同値である。
+- `allRouteDefectCorrection_supportEmpty` /
+  `allRouteDefectCorrection_sourceRefExactVisualization`: all-branch correction は protected route support を空にし、source-ref exact visualization を回復する。
+- `obligationOnlyCorrection_not_supportEmpty` /
+  `obligationOnlyCorrection_not_sourceRefExactVisualization`: obligation-only correction は storage repair branch を miss するため、protected support empty も exact visualization restoration も成立しない。
+- `selectedRouteCorrectionExactness_package`: visible surface preservation、support-empty iff、exact-visualization iff、positive / negative witness を束ねる。
+
+この結果により、route mismatch の検出面から repair-exactness criterion へ進む有限 theorem が得られた。
+主張は supplied finite source-ref packets、selected endpoint route、selected correction vocabulary、packet-to-tuple bridge に相対化され、
+global correction planner、canonical runtime patch、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 43 後の total SCORE は 5390 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 44 後の total SCORE は 5530 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
@@ -1986,4 +2029,5 @@ finite grid phenomena、related-work separation を備えた。
 selected commutator localization、
 lawful repair/transport criterion minimality matrix、
 selected support-defect localization、
-または loss-aware commutator atlas adequacy を狙う。threshold 7000 には未達であるため、次 cycle へ進む。
+loss-aware commutator atlas adequacy、
+または selected route correction exactness の parametrized family を狙う。threshold 7000 には未達であるため、次 cycle へ進む。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 44 として、selected branch hitting、corrected route support empty、source-ref exact visualization restoration を同値として固定しました。

SCORE 監査結果は base 70、evidence multiplier 2.0、penalty 0、final +140 です。report の total SCORE は 5530 / 7000、`proved-in-research` は 44 件に更新しています。

## 証明した定理

- `correctedVisibleRoute_supportSurface_equivalent`
- `correctedVisibleRoute_tupleVisible`
- `correctedVisibleRoute_supportEmpty_of_hits`
- `hits_every_selectedRouteDefectSupport_of_correctedSupportEmpty`
- `correctedVisibleRoute_supportEmpty_iff_hits`
- `correctedVisibleRoute_exactVisualization_iff_hits`
- `allRouteDefectCorrection_supportEmpty`
- `allRouteDefectCorrection_sourceRefExactVisualization`
- `obligationOnlyCorrection_not_supportEmpty`
- `obligationOnlyCorrection_not_sourceRefExactVisualization`
- `selectedRouteCorrectionExactness_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-selected-route-correction-exactness.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SelectedRouteCorrectionExactness.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] forbidden-token scan on the Cycle 44 Lean/card files
- [x] `#print axioms` for 11 reported declarations: all no-axiom
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに未完証明・非標準公理・危険指定を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

tracking Issue は threshold 7000 まで継続するため、`Closes #2348` ではなく `Refs #2348` にしています。
