### PR TITLE
研究ループ Cycle 45 の loss-aware atlas を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -43,3 +43,4 @@ import Formal.AG.Research.QualitySurface.InternalExcursionMinSupport
 import Formal.AG.Research.QualitySurface.ExactVisualizationCriterionMinimality
 import Formal.AG.Research.QualitySurface.SelectedRouteDefectSupportHitting
 import Formal.AG.Research.QualitySurface.SelectedRouteCorrectionExactness
+import Formal.AG.Research.QualitySurface.LossAwareCommutatorAtlas

--- a/Formal/AG/Research/QualitySurface/LossAwareCommutatorAtlas.lean
+++ b/Formal/AG/Research/QualitySurface/LossAwareCommutatorAtlas.lean
@@ -1,0 +1,280 @@
+import Formal.AG.Research.QualitySurface.SelectedRouteCorrectionExactness
+import Formal.AG.Research.QualitySurface.VisibleLawDeletionProtectedZero
+
+/-!
+Cycle 45 evidence for `G-aat-quality-surface-01`.
+
+This file packages the selected commutator witnesses into a loss-aware atlas.
+Each atlas cell is read through three predicates: visible tuple flatness, empty
+protected route support, and source-ref exact visualization.  The atlas proves
+that exactness is exactly visible flatness plus empty protected support, and it
+exhibits finite witnesses for visible-law loss, protected-support loss, and
+all-hit exact restoration.
+
+The claim is relative to supplied finite source-ref packets, selected
+repair/transport routes, selected correction vocabulary, and the explicit
+packet-to-tuple bridge.  It does not assert complete diagnostic coverage for
+all codebases, source extraction completeness, ArchMap correctness, global
+repair planning, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace LossAwareCommutatorAtlas
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+open RouteDefectSupportTheory
+open ExactVisualizationCriterionMinimality
+open SelectedRouteDefectSupportHitting
+open SelectedRouteCorrectionExactness
+
+/-! ## Atlas cells and readings -/
+
+/-- Selected commutator cells used by the loss-aware atlas. -/
+inductive LossAwareAtlasCell where
+  | visibleLawDeletionCell
+  | tableLawDeletionCell
+  | visibleRepairTransportCell
+  | allHitCorrectionCell
+  | obligationOnlyCorrectionCell
+  deriving DecidableEq, Fintype
+
+open LossAwareAtlasCell
+
+/-- Visible tuple flatness of an atlas cell. -/
+def CellVisibleTupleFlat : LossAwareAtlasCell -> Prop
+  | visibleLawDeletionCell =>
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        VisibleLawDeletionProtectedZero.visibleLawRoute_repairThenTransportPacket
+        VisibleLawDeletionProtectedZero.visibleLawRoute_transportThenRepairPacket
+  | tableLawDeletionCell =>
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        tableRouteLeft tableRouteRight
+  | visibleRepairTransportCell =>
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        visibleRouteLeft visibleRouteRight
+  | allHitCorrectionCell =>
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft allRouteDefectCorrection) visibleRouteRight
+  | obligationOnlyCorrectionCell =>
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight
+
+/-- Empty protected route support of an atlas cell. -/
+def CellProtectedRouteSupportEmpty : LossAwareAtlasCell -> Prop
+  | visibleLawDeletionCell =>
+      RouteDefectSupportEmpty
+        VisibleLawDeletionProtectedZero.visibleLawRoute_repairThenTransportPacket
+        VisibleLawDeletionProtectedZero.visibleLawRoute_transportThenRepairPacket
+  | tableLawDeletionCell =>
+      RouteDefectSupportEmpty tableRouteLeft tableRouteRight
+  | visibleRepairTransportCell =>
+      RouteDefectSupportEmpty visibleRouteLeft visibleRouteRight
+  | allHitCorrectionCell =>
+      RouteDefectSupportEmpty
+        (correctedVisibleRouteLeft allRouteDefectCorrection) visibleRouteRight
+  | obligationOnlyCorrectionCell =>
+      RouteDefectSupportEmpty
+        (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight
+
+/-- Source-ref exact visualization of an atlas cell. -/
+def CellSourceRefExact : LossAwareAtlasCell -> Prop
+  | visibleLawDeletionCell =>
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        VisibleLawDeletionProtectedZero.visibleLawRoute_repairThenTransportPacket
+        VisibleLawDeletionProtectedZero.visibleLawRoute_transportThenRepairPacket
+  | tableLawDeletionCell =>
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        tableRouteLeft tableRouteRight
+  | visibleRepairTransportCell =>
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        visibleRouteLeft visibleRouteRight
+  | allHitCorrectionCell =>
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft allRouteDefectCorrection) visibleRouteRight
+  | obligationOnlyCorrectionCell =>
+      SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight
+
+/-! ## Atlas adequacy criterion -/
+
+/--
+Within the atlas, source-ref exactness is exactly visible tuple flatness plus
+empty protected route support.
+-/
+theorem atlasCell_exact_iff_visible_empty
+    (cell : LossAwareAtlasCell) :
+    CellSourceRefExact cell ↔
+      CellVisibleTupleFlat cell ∧ CellProtectedRouteSupportEmpty cell := by
+  cases cell with
+  | visibleLawDeletionCell =>
+      exact exactVisualization_iff_visible_emptyRouteSupport
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        VisibleLawDeletionProtectedZero.visibleLawRoute_repairThenTransportPacket
+        VisibleLawDeletionProtectedZero.visibleLawRoute_transportThenRepairPacket
+  | tableLawDeletionCell =>
+      exact exactVisualization_iff_visible_emptyRouteSupport
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        tableRouteLeft tableRouteRight
+  | visibleRepairTransportCell =>
+      exact exactVisualization_iff_visible_emptyRouteSupport
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        visibleRouteLeft visibleRouteRight
+  | allHitCorrectionCell =>
+      exact exactVisualization_iff_visible_emptyRouteSupport
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft allRouteDefectCorrection) visibleRouteRight
+  | obligationOnlyCorrectionCell =>
+      exact exactVisualization_iff_visible_emptyRouteSupport
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight
+
+/-- Missing visible flatness blocks exactness, even with empty protected support. -/
+theorem atlasCell_not_exact_of_not_visible
+    {cell : LossAwareAtlasCell}
+    (hnotVisible : ¬ CellVisibleTupleFlat cell) :
+    ¬ CellSourceRefExact cell := by
+  intro hexact
+  exact hnotVisible ((atlasCell_exact_iff_visible_empty cell).mp hexact).1
+
+/-- Nonempty protected support blocks exactness, even when visible flatness holds. -/
+theorem atlasCell_not_exact_of_not_empty
+    {cell : LossAwareAtlasCell}
+    (hnotEmpty : ¬ CellProtectedRouteSupportEmpty cell) :
+    ¬ CellSourceRefExact cell := by
+  intro hexact
+  exact hnotEmpty ((atlasCell_exact_iff_visible_empty cell).mp hexact).2
+
+/-! ## Witnessed atlas modes -/
+
+/-- A cell where protected support is empty but visible flatness fails. -/
+def VisibleLawLossCell (cell : LossAwareAtlasCell) : Prop :=
+  ¬ CellVisibleTupleFlat cell ∧
+    CellProtectedRouteSupportEmpty cell ∧
+    ¬ CellSourceRefExact cell
+
+/-- A cell where visible flatness holds but protected support is nonempty. -/
+def ProtectedSupportLossCell (cell : LossAwareAtlasCell) : Prop :=
+  CellVisibleTupleFlat cell ∧
+    ¬ CellProtectedRouteSupportEmpty cell ∧
+    ¬ CellSourceRefExact cell
+
+/-- A cell where visible flatness and empty protected support restore exactness. -/
+def ExactRestorationCell (cell : LossAwareAtlasCell) : Prop :=
+  CellVisibleTupleFlat cell ∧
+    CellProtectedRouteSupportEmpty cell ∧
+    CellSourceRefExact cell
+
+/-- The visible-law deletion cell witnesses visible-law loss. -/
+theorem visibleLawDeletion_is_visibleLawLoss :
+    VisibleLawLossCell visibleLawDeletionCell :=
+  ⟨VisibleLawDeletionProtectedZero.visibleLawRoute_not_visibleTupleSurface,
+    VisibleLawDeletionProtectedZero.visibleLawRoute_emptyDefectSupport,
+    VisibleLawDeletionProtectedZero.visibleLawRoute_not_sourceRefExactVisualization⟩
+
+/-- The table-law deletion cell witnesses protected-support loss. -/
+theorem tableLawDeletion_is_protectedSupportLoss :
+    ProtectedSupportLossCell tableLawDeletionCell :=
+  ⟨TransportTableLawRouteLocalization.tokenSwapRoute_visibleTupleSurface,
+    tableLawDeletion_not_emptyRouteSupport,
+    TransportTableLawRouteLocalization.tokenSwapRoute_not_sourceRefExactVisualization⟩
+
+/-- The visible repair/transport commutator is another protected-support loss cell. -/
+theorem visibleRepairTransport_is_protectedSupportLoss :
+    ProtectedSupportLossCell visibleRepairTransportCell := by
+  refine ⟨VisibleRepairTransportCommutator.repairTransport_visibleTupleSurface_commutes,
+    ?_, VisibleRepairTransportCommutator.repairTransport_not_sourceRefExactVisualization⟩
+  intro hempty
+  exact visibleRepairTransport_defectSupport_obligation
+    (hempty SourceRefPacketProtectedComponent.obligation)
+
+/-- The all-hit corrected route witnesses exact restoration. -/
+theorem allHitCorrection_is_exactRestoration :
+    ExactRestorationCell allHitCorrectionCell :=
+  ⟨correctedVisibleRoute_tupleVisible allRouteDefectCorrection,
+    allRouteDefectCorrection_supportEmpty,
+    allRouteDefectCorrection_sourceRefExactVisualization⟩
+
+/-- The obligation-only corrected route remains a protected-support loss cell. -/
+theorem obligationOnlyCorrection_is_protectedSupportLoss :
+    ProtectedSupportLossCell obligationOnlyCorrectionCell :=
+  ⟨correctedVisibleRoute_tupleVisible obligationOnlyCorrection,
+    obligationOnlyCorrection_not_supportEmpty,
+    obligationOnlyCorrection_not_sourceRefExactVisualization⟩
+
+/-- The atlas contains witnesses for visible loss, protected-support loss, and exact restoration. -/
+theorem lossAwareAtlas_has_all_modes :
+    (∃ cell, VisibleLawLossCell cell) ∧
+    (∃ cell, ProtectedSupportLossCell cell) ∧
+    (∃ cell, ExactRestorationCell cell) :=
+  ⟨⟨visibleLawDeletionCell, visibleLawDeletion_is_visibleLawLoss⟩,
+    ⟨tableLawDeletionCell, tableLawDeletion_is_protectedSupportLoss⟩,
+    ⟨allHitCorrectionCell, allHitCorrection_is_exactRestoration⟩⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-45 theorem package: a finite loss-aware commutator atlas whose cells are
+adequate for the exact-visualization criterion and which contains witnesses for
+visible-law loss, protected-support loss, and all-hit exact restoration.
+-/
+theorem lossAwareCommutatorAtlasAdequacy_package :
+    (∀ cell,
+      CellSourceRefExact cell ↔
+        CellVisibleTupleFlat cell ∧ CellProtectedRouteSupportEmpty cell) ∧
+    (∀ {cell}, ¬ CellVisibleTupleFlat cell -> ¬ CellSourceRefExact cell) ∧
+    (∀ {cell}, ¬ CellProtectedRouteSupportEmpty cell -> ¬ CellSourceRefExact cell) ∧
+    VisibleLawLossCell visibleLawDeletionCell ∧
+    ProtectedSupportLossCell tableLawDeletionCell ∧
+    ProtectedSupportLossCell visibleRepairTransportCell ∧
+    ExactRestorationCell allHitCorrectionCell ∧
+    ProtectedSupportLossCell obligationOnlyCorrectionCell ∧
+    (∃ cell, VisibleLawLossCell cell) ∧
+    (∃ cell, ProtectedSupportLossCell cell) ∧
+    (∃ cell, ExactRestorationCell cell) := by
+  exact ⟨atlasCell_exact_iff_visible_empty,
+    by
+      intro cell hnotVisible
+      exact atlasCell_not_exact_of_not_visible hnotVisible,
+    by
+      intro cell hnotEmpty
+      exact atlasCell_not_exact_of_not_empty hnotEmpty,
+    visibleLawDeletion_is_visibleLawLoss,
+    tableLawDeletion_is_protectedSupportLoss,
+    visibleRepairTransport_is_protectedSupportLoss,
+    allHitCorrection_is_exactRestoration,
+    obligationOnlyCorrection_is_protectedSupportLoss,
+    lossAwareAtlas_has_all_modes.1,
+    lossAwareAtlas_has_all_modes.2.1,
+    lossAwareAtlas_has_all_modes.2.2⟩
+
+end LossAwareCommutatorAtlas
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-loss-aware-commutator-atlas.md
+++ b/research/ideas/g-aat-quality-surface-01-loss-aware-commutator-atlas.md
@@ -1,0 +1,116 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: obstruction / repair-potential / certificate-transport / traceability / quality-surface / computability
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can detect individual route mismatches, but this atlas proves a finite diagnosis table where exactness, visible-law loss, protected-support loss, and all-hit restoration are separated by Lean-checked predicates.
+origin: G-aat-quality-surface-01-cycle45
+tags: [quality-surface, commutator-atlas, exact-visualization, repair-hitting, loss-aware]
+created: 2026-06-21
+cycle: 45
+lean: proved-in-research
+---
+
+# Loss-aware commutator atlas adequacy
+
+## 主張
+
+selected repair/transport commutator witnesses を loss-aware atlas としてまとめると、各 atlas cell について source-ref exactness は visible tuple flatness と empty protected route support の同時成立に等しい。さらに atlas は visible-law loss、protected-support loss、all-hit exact restoration の三種の witness を持つ。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/ExactVisualizationCriterionMinimality.lean`
+- `Formal/AG/Research/QualitySurface/VisibleLawDeletionProtectedZero.lean`
+- `Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean`
+- `Formal/AG/Research/QualitySurface/SelectedRouteCorrectionExactness.lean`
+- `Formal/AG/Research/QualitySurface/RouteDefectSupport.lean`
+
+## 非自明性
+
+これまでの cycle は個別 route / correction の theorem だった。Cycle 45 はそれらを一つの finite atlas に入れ、visible flatness、protected support empty、source-ref exactness の三 reading predicate で診断する。単なる結果一覧ではなく、atlas 内では exactness iff visible-and-empty が全 cell に対して成り立ち、visible-law loss / protected-support loss / restored exactness の各 mode が witness される。
+
+## 数学的興味
+
+exact visualization failure は一枚岩ではない。visible law が壊れて protected support は空の cell、visible は flat だが protected support が残る cell、all-hit correction で exactness が回復する cell が同じ criterion 上に並ぶ。これは Quality Surface を loss-aware atlas として読むための最小 finite model になる。
+
+## GOAL への前進
+
+この候補は `obstruction`、`repair-potential`、`certificate-transport`、`traceability`、`quality-surface`、`computability` を前進させ、route-level theorem 群を診断可能な finite atlas に統一する。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は route mismatch、component defect、CI gate を出せるが、visible loss と protected-support loss と exact restoration を同じ formal criterion の atlas cell として区別しない。この atlas は、どの reading が失敗し、どの correction が exactness を回復するかを finite theorem package として示す。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 38/39/42/43/44 を一つの loss-aware atlas に統合し、individual theorem から diagnostic table へ上げる unification。G2 では研究価値 / repo 全体価値 / rival 比較が base 85、厳密性が base 70 だったため、既存 theorem 群の package 化リスクを見て保守的に base 70、Lean proof が未完証明なしなら multiplier 2.0。
+- `dullness_risk`: 既存 theorem の package 化に見える危険がある。`atlasCell_exact_iff_visible_empty` を全 cell に対する criterion とし、三種の loss/restoration mode を witness することで単なる列挙から分離する。
+- `proof_or_evidence_plan`: `LossAwareAtlasCell`、`CellVisibleTupleFlat`、`CellProtectedRouteSupportEmpty`、`CellSourceRefExact`、`atlasCell_exact_iff_visible_empty`、`lossAwareAtlas_has_all_modes`、`lossAwareCommutatorAtlasAdequacy_package` を Lean で証明した。
+
+## CS / SWE への帰結
+
+loss-aware view は mismatch を一つの赤信号として表示するだけでなく、visible law failure、protected support failure、exact restoration を分けて説明できる。これは tooling 実装 claim ではなく、finite selected witness 上の atlas adequacy theorem である。
+
+## 証明・根拠の見込み
+
+Lean file: `Formal/AG/Research/QualitySurface/LossAwareCommutatorAtlas.lean`
+
+Planned / proved declarations:
+
+- `LossAwareAtlasCell`
+- `CellVisibleTupleFlat`
+- `CellProtectedRouteSupportEmpty`
+- `CellSourceRefExact`
+- `atlasCell_exact_iff_visible_empty`
+- `atlasCell_not_exact_of_not_visible`
+- `atlasCell_not_exact_of_not_empty`
+- `visibleLawDeletion_is_visibleLawLoss`
+- `tableLawDeletion_is_protectedSupportLoss`
+- `visibleRepairTransport_is_protectedSupportLoss`
+- `allHitCorrection_is_exactRestoration`
+- `obligationOnlyCorrection_is_protectedSupportLoss`
+- `lossAwareAtlas_has_all_modes`
+- `lossAwareCommutatorAtlasAdequacy_package`
+
+Verification:
+
+- `lake env lean Formal/AG/Research/QualitySurface/LossAwareCommutatorAtlas.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `#print axioms` for the reported theorem declarations: all reported theorem declarations have no 公理依存.
+- Forbidden-token scan over the Cycle 45 Lean/card files: no matches.
+- G3 公理監査: pass。reported declarations は clean で、`Formal/AG` 本体は参照のみ。
+- G3 Lean 形式化品質監査: pass。finite selected atlas の theorem として、visible tuple flatness、protected route support、source-ref exactness の三 predicate と三 mode witness が候補主張に対応している。
+
+Boundary:
+
+- selected finite source-ref packet route / correction atlas 上の theorem であり、complete diagnostic coverage for all codebases、global repair planning、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+- atlas cell は supplied finite witnesses に相対化され、runtime tooling surface の実装済み claim ではない。
+
+## 審判メモ
+
+- 厳密性: accept / base 70。claim boundary は守られているが、中核の iff は既存 criterion の cell-wise case split なので base 90 は強すぎる。
+- 研究価値: accept / base 85。既存 cycle 群を finite atlas の診断表へ圧縮し、paper の loss-aware commutator atlas 節として有効。
+- repo 全体価値: accept / base 85。Research / Lean の成果として PR 価値があり、Tooling / Website には将来の loss-aware readout surface として接続可能。
+- ライバル比較: accept / base 85。ADL / conformance checker の mismatch detection を越えて、visible loss / protected-support loss / exact restoration を atlas cell として区別する点を評価。
+- G3 公理監査: pass。`atlasCell_exact_iff_visible_empty`、mode witness、package theorem まで clean。
+- G3 形式化品質監査: pass。主張は selected finite source-ref packet route / correction atlas に限定され、tooling 実装や global diagnostic coverage へ越境していない。
+
+## 関連
+
+- Cycle 39: `Visible-law deletion protected-zero cell`
+- Cycle 42: `Exact-visualization criterion and four-law selected minimality matrix`
+- Cycle 43: `Selected route defect support hitting theorem`
+- Cycle 44: `Selected route correction exactness theorem`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 45 候補として作成。Lean 単体チェックと `lake build FormalAGResearch` は pass。
+- 2026-06-21: G2 で base 70 / multiplier 2.0 に修正。G3 公理監査と Lean 形式化品質監査は pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 5530
+- total SCORE: 5670
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -49,8 +49,9 @@
   - certificate-transport / obstruction / traceability / quality-surface: 140
   - obstruction / repair-potential / traceability / atom-supported-quality-geometry: 140
   - obstruction / repair-potential / certificate-transport / traceability / quality-surface: 140
+  - obstruction / repair-potential / certificate-transport / traceability / quality-surface / computability: 140
 - evidence portfolio:
-  - proved-in-research: 44
+  - proved-in-research: 45
 
 ## Phase synthesis
 
@@ -66,7 +67,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-44 件の Lean-proved research artifacts は、次の paper seed を形成している。
+45 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -109,8 +110,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 44 後の total SCORE は 5530 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 44 件持ち、
+Cycle 45 後の total SCORE は 5670 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 45 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2019,15 +2020,66 @@ Lean 証拠は次を固定する。
 主張は supplied finite source-ref packets、selected endpoint route、selected correction vocabulary、packet-to-tuple bridge に相対化され、
 global correction planner、canonical runtime patch、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 45: Loss-aware commutator atlas adequacy
+
+```text
+candidate: Loss-aware commutator atlas adequacy
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: obstruction/repair-potential/certificate-transport/traceability/quality-surface/computability
+goal_delta: selected repair/transport witness 群を loss-aware atlas に束ね、source-ref exactness、visible-law loss、protected-support loss、all-hit restoration を同じ finite diagnosis table 上で読めるようにした。
+project_value_delta: Cycle 38/39/42/43/44 の route-level theorem 群を、paper seed の loss-aware commutator atlas 節として再利用できる theorem package に圧縮した。
+rival_delta: ADL / conformance checker は route mismatch や rule failure を検出できるが、visible law loss、protected-support loss、all-hit exact restoration を同じ exact-visualization criterion の atlas cell として分離しない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch`、reported declarations の `#print axioms` は pass / no 公理依存。主張は selected finite source-ref packet route / correction atlas に限定され、global diagnostic coverage、tooling implementation、whole-codebase quality へ越境していない。
+open_questions: parametrized loss-aware atlas、arbitrary selected route family への criterion、paper-level synthesis of lawful criterion minimality and correction exactness。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/LossAwareCommutatorAtlas.lean` は、
+selected repair/transport commutator witnesses を finite loss-aware atlas として束ねる。
+各 cell は visible tuple flatness、empty protected route support、source-ref exact visualization の三 reading predicate を持つ。
+
+Lean 証拠は次を固定する。
+
+- `atlasCell_exact_iff_visible_empty`: atlas 内では source-ref exactness は visible tuple flatness と
+  empty protected route support の同時成立に等しい。
+- `atlasCell_not_exact_of_not_visible` /
+  `atlasCell_not_exact_of_not_empty`: visible flatness failure または nonempty protected support は exactness を阻む。
+- `visibleLawDeletion_is_visibleLawLoss`: visible-law deletion cell は protected support が空でも visible flatness と exactness が失敗する。
+- `tableLawDeletion_is_protectedSupportLoss` /
+  `visibleRepairTransport_is_protectedSupportLoss` /
+  `obligationOnlyCorrection_is_protectedSupportLoss`: visible surface が flat でも protected support が残る protected-support loss cell を示す。
+- `allHitCorrection_is_exactRestoration`: all-hit correction は visible flatness、empty protected support、source-ref exactness を同時に回復する。
+- `lossAwareAtlas_has_all_modes` /
+  `lossAwareCommutatorAtlasAdequacy_package`: atlas が visible-law loss、protected-support loss、exact restoration の三 mode を持つことを束ねる。
+
+| atlas cell | source cycle | visible flat | protected support empty | source-ref exact | mode | reason |
+| --- | --- | --- | --- | --- | --- | --- |
+| `visibleLawDeletionCell` | Cycle 39 | no | yes | no | visible-law loss | visible tuple flatness fails while protected support is empty |
+| `tableLawDeletionCell` | Cycle 42 / 37 | yes | no | no | protected-support loss | endpoint / worker table support remains |
+| `visibleRepairTransportCell` | Cycle 28 / 38 | yes | no | no | protected-support loss | obligation / repair-frontier support remains |
+| `allHitCorrectionCell` | Cycle 44 | yes | yes | yes | exact restoration | all selected branches are hit |
+| `obligationOnlyCorrectionCell` | Cycle 43 / 44 | yes | no | no | protected-support loss | storage repair branch is missed |
+
+この結果により、exact visualization failure は単一の mismatch verdict ではなく、
+visible-law loss、protected-support loss、exact restoration の finite atlas として読める。
+主張は supplied finite source-ref packets、selected route endpoints、selected correction vocabulary、
+packet-to-tuple bridge に相対化され、complete diagnostic coverage for all codebases、runtime tooling claim、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 44 後の total SCORE は 5530 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 45 後の total SCORE は 5670 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 次フェーズへ進める場合は、lawful criterion の necessity / minimality、
-selected commutator localization、
-lawful repair/transport criterion minimality matrix、
-selected support-defect localization、
-loss-aware commutator atlas adequacy、
+parametrized loss-aware commutator atlas、
+arbitrary selected route family への exactness criterion、
+selected support-defect localization の generic theorem、
 または selected route correction exactness の parametrized family を狙う。threshold 7000 には未達であるため、次 cycle へ進む。


### PR DESCRIPTION
## 概要
- Cycle 45 の Lean 証拠として `LossAwareCommutatorAtlas` を追加
- selected repair/transport witness 群を loss-aware atlas に束ね、visible-law loss / protected-support loss / exact restoration を分離
- 候補カードと research report を SCORE +140、total 5670 に更新

## SCORE
- candidate: Loss-aware commutator atlas adequacy
- type: unification
- evidence: proved-in-research
- base: 70
- multiplier: 2.0
- penalty: 0
- final: 140
- total: 5670 / 7000

## 検証
- `lake env lean Formal/AG/Research/QualitySurface/LossAwareCommutatorAtlas.lean`
- `lake env lean .tmp/loss_aware_commutator_atlas_axioms.lean`
- `lake build FormalAGResearch`
- `lake build`
- `git diff --check`
- `git diff --cached --check`
- hidden Unicode / local path / forbidden-token scans on the staged diff

Refs #2348