### PR TITLE
Cycle 48: parametrized selected correction system を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -46,3 +46,4 @@ import Formal.AG.Research.QualitySurface.SelectedRouteCorrectionExactness
 import Formal.AG.Research.QualitySurface.LossAwareCommutatorAtlas
 import Formal.AG.Research.QualitySurface.RouteDefectLocalRepairCalculusBridge
 import Formal.AG.Research.QualitySurface.SelectedRouteFamilyExactness
+import Formal.AG.Research.QualitySurface.ParametrizedSelectedCorrectionSystem

--- a/Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean
+++ b/Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean
@@ -1,0 +1,317 @@
+import Formal.AG.Research.QualitySurface.SelectedRouteFamilyExactness
+
+/-!
+Cycle 48 evidence for `G-aat-quality-surface-01`.
+
+This file turns the selected route correction theorem into a parametrized
+correction-system theorem.  Corrections are ordered by touched selected atoms;
+source-ref exactness is monotone along that order, and any monotone correction
+system has an upward-closed exact locus.  A concrete three-stage schedule shows
+that touching only the obligation branch is still non-exact, while the all-hit
+stage is exact.
+
+The claim is relative to the selected route-defect atom vocabulary, selected
+correction semantics, and the explicit source-ref packet bridge.  It does not
+assert a global repair planner, runtime patch synthesis, source extraction
+completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ParametrizedSelectedCorrectionSystem
+
+open CodebaseTracePacket
+open SourceRefExactVisualizationCriterion
+open RouteDefectSupportTheory
+open SelectedRouteDefectSupportHitting
+open SelectedRouteCorrectionExactness
+open RouteDefectAtom
+open RouteDefectBranch
+
+universe u
+
+/-! ## Correction order and exactness -/
+
+/-- A selected correction is below another when every hit selected atom remains hit. -/
+def CorrectionLe
+    (left right : RouteDefectAtom -> Bool) : Prop :=
+  ∀ atom, left atom = true -> right atom = true
+
+/-- A selected correction hits every selected route-defect branch. -/
+def CorrectionHitsAllBranches
+    (correction : RouteDefectAtom -> Bool) : Prop :=
+  ∀ branch, CorrectionHitsRouteDefectBranch correction branch
+
+/-- Source-ref exactness of the corrected selected endpoint route. -/
+def CorrectionSourceRefExact
+    (correction : RouteDefectAtom -> Bool) : Prop :=
+  SourceRefExactVisualization
+    SourceRefTupleBridge.endpointGridCertificate
+    SourceRefTupleBridge.endpointGridCertificate
+    (correctedVisibleRouteLeft correction) visibleRouteRight
+
+/-- Correction order is reflexive. -/
+theorem correctionLe_refl
+    (correction : RouteDefectAtom -> Bool) :
+    CorrectionLe correction correction := by
+  intro atom hhit
+  exact hhit
+
+/-- Correction order is transitive. -/
+theorem correctionLe_trans
+    {first middle last : RouteDefectAtom -> Bool}
+    (hfirstMiddle : CorrectionLe first middle)
+    (hmiddleLast : CorrectionLe middle last) :
+    CorrectionLe first last := by
+  intro atom hhit
+  exact hmiddleLast atom (hfirstMiddle atom hhit)
+
+/-- Source-ref exactness of a correction is exactly all selected branch hitting. -/
+theorem correctionSourceRefExact_iff_hitsAllBranches
+    (correction : RouteDefectAtom -> Bool) :
+    CorrectionSourceRefExact correction ↔
+      CorrectionHitsAllBranches correction :=
+  correctedVisibleRoute_exactVisualization_iff_hits correction
+
+/-- Branch hitting is monotone along correction order. -/
+theorem correctionHitsAllBranches_monotone
+    {left right : RouteDefectAtom -> Bool}
+    (hle : CorrectionLe left right)
+    (hhits : CorrectionHitsAllBranches left) :
+    CorrectionHitsAllBranches right := by
+  intro branch
+  exact hle (routeDefectBranchAtom branch) (hhits branch)
+
+/-- Source-ref exactness is monotone along correction order. -/
+theorem correctionSourceRefExact_monotone
+    {left right : RouteDefectAtom -> Bool}
+    (hle : CorrectionLe left right)
+    (hexact : CorrectionSourceRefExact left) :
+    CorrectionSourceRefExact right :=
+  (correctionSourceRefExact_iff_hitsAllBranches right).mpr
+    (correctionHitsAllBranches_monotone hle
+      ((correctionSourceRefExact_iff_hitsAllBranches left).mp hexact))
+
+/-! ## Parametrized correction systems -/
+
+/-- A correction system indexed by an external parameter type. -/
+abbrev CorrectionSystem (Parameter : Type u) :=
+  Parameter -> RouteDefectAtom -> Bool
+
+/-- A correction system is exact at a parameter when its correction is exact. -/
+def SystemExactAt {Parameter : Type u}
+    (system : CorrectionSystem Parameter)
+    (parameter : Parameter) : Prop :=
+  CorrectionSourceRefExact (system parameter)
+
+/-- A correction system hits every selected branch at every parameter. -/
+def SystemHitsAllBranches {Parameter : Type u}
+    (system : CorrectionSystem Parameter) : Prop :=
+  ∀ parameter, CorrectionHitsAllBranches (system parameter)
+
+/-- A correction system is source-ref exact at every parameter. -/
+def SystemSourceRefExact {Parameter : Type u}
+    (system : CorrectionSystem Parameter) : Prop :=
+  ∀ parameter, SystemExactAt system parameter
+
+/-- System-level exactness is equivalent to all-branch hitting at every parameter. -/
+theorem systemSourceRefExact_iff_hitsAllBranches {Parameter : Type u}
+    (system : CorrectionSystem Parameter) :
+    SystemSourceRefExact system ↔
+      SystemHitsAllBranches system := by
+  constructor
+  · intro hexact parameter
+    exact (correctionSourceRefExact_iff_hitsAllBranches
+      (system parameter)).mp (hexact parameter)
+  · intro hhits parameter
+    exact (correctionSourceRefExact_iff_hitsAllBranches
+      (system parameter)).mpr (hhits parameter)
+
+/-- A correction system is monotone when larger parameters only add selected hits. -/
+def MonotoneCorrectionSystem {Parameter : Type u}
+    (le : Parameter -> Parameter -> Prop)
+    (system : CorrectionSystem Parameter) : Prop :=
+  ∀ left right, le left right ->
+    CorrectionLe (system left) (system right)
+
+/-- In a monotone correction system, the exact locus is upward closed. -/
+theorem monotoneCorrectionSystem_exact_upwardClosed {Parameter : Type u}
+    {le : Parameter -> Parameter -> Prop}
+    {system : CorrectionSystem Parameter}
+    (hmonotone : MonotoneCorrectionSystem le system)
+    {left right : Parameter}
+    (hle : le left right)
+    (hexact : SystemExactAt system left) :
+    SystemExactAt system right :=
+  correctionSourceRefExact_monotone (hmonotone left right hle) hexact
+
+/-! ## Concrete three-stage selected correction system -/
+
+/-- A concrete staged selected correction schedule. -/
+inductive RepairStage where
+  | uncorrected
+  | obligationOnly
+  | allBranches
+  deriving DecidableEq, Fintype
+
+open RepairStage
+
+/-- The selected correction at each stage of the concrete schedule. -/
+def stagedCorrection : RepairStage -> RouteDefectAtom -> Bool
+  | uncorrected, _ => false
+  | obligationOnly, obligation => true
+  | obligationOnly, storageRepair => false
+  | obligationOnly, storageTable => false
+  | allBranches, _ => true
+
+/-- The concrete schedule as a parametrized correction system. -/
+def stagedCorrectionSystem : CorrectionSystem RepairStage :=
+  stagedCorrection
+
+/-- Stage order for the concrete correction schedule. -/
+def StageLe : RepairStage -> RepairStage -> Prop
+  | uncorrected, _ => True
+  | obligationOnly, obligationOnly => True
+  | obligationOnly, allBranches => True
+  | allBranches, allBranches => True
+  | _, _ => False
+
+/-- The staged correction system is monotone in the stage order. -/
+theorem stagedCorrectionSystem_monotone :
+    MonotoneCorrectionSystem StageLe stagedCorrectionSystem := by
+  intro left right hle atom hhit
+  cases left <;> cases right <;> cases atom <;>
+    simp [StageLe, stagedCorrectionSystem, stagedCorrection] at hle hhit ⊢
+
+/-- The uncorrected stage misses the obligation branch. -/
+theorem stagedCorrection_uncorrected_misses_obligation :
+    ¬ CorrectionHitsRouteDefectBranch
+      (stagedCorrection uncorrected) obligationBranch := by
+  intro hhit
+  simp [CorrectionHitsRouteDefectBranch, stagedCorrection] at hhit
+
+/-- The uncorrected stage is not source-ref exact. -/
+theorem stagedCorrection_uncorrected_not_exact :
+    ¬ CorrectionSourceRefExact (stagedCorrection uncorrected) := by
+  intro hexact
+  have hhits :=
+    (correctionSourceRefExact_iff_hitsAllBranches
+      (stagedCorrection uncorrected)).mp hexact
+  exact stagedCorrection_uncorrected_misses_obligation
+    (hhits obligationBranch)
+
+/-- The obligation-only stage is the existing obligation-only correction. -/
+theorem stagedCorrection_obligationOnly_eq :
+    stagedCorrection obligationOnly = obligationOnlyCorrection := by
+  funext atom
+  cases atom <;> rfl
+
+/-- The all-branches stage is the existing all-hit correction. -/
+theorem stagedCorrection_allBranches_eq :
+    stagedCorrection allBranches = allRouteDefectCorrection := by
+  funext atom
+  cases atom <;> rfl
+
+/-- The obligation-only stage is not source-ref exact. -/
+theorem stagedCorrection_obligationOnly_not_exact :
+    ¬ CorrectionSourceRefExact (stagedCorrection obligationOnly) := by
+  intro hexact
+  exact obligationOnlyCorrection_not_sourceRefExactVisualization
+    (by
+      simpa [CorrectionSourceRefExact, stagedCorrection_obligationOnly_eq]
+        using hexact)
+
+/-- The all-branches stage is source-ref exact. -/
+theorem stagedCorrection_allBranches_exact :
+    CorrectionSourceRefExact (stagedCorrection allBranches) := by
+  simpa [CorrectionSourceRefExact, stagedCorrection_allBranches_eq]
+    using allRouteDefectCorrection_sourceRefExactVisualization
+
+/-- The exact locus of the staged schedule is exactly the all-branches stage. -/
+theorem stagedCorrection_exact_iff_allBranches
+    (stage : RepairStage) :
+    CorrectionSourceRefExact (stagedCorrection stage) ↔
+      stage = allBranches := by
+  cases stage with
+  | uncorrected =>
+      constructor
+      · intro hexact
+        exact False.elim (stagedCorrection_uncorrected_not_exact hexact)
+      · intro hstage
+        cases hstage
+  | obligationOnly =>
+      constructor
+      · intro hexact
+        exact False.elim (stagedCorrection_obligationOnly_not_exact hexact)
+      · intro hstage
+        cases hstage
+  | allBranches =>
+      constructor
+      · intro _hexact
+        rfl
+      · intro _hstage
+        exact stagedCorrection_allBranches_exact
+
+/-- The staged correction system is not exact at every stage. -/
+theorem stagedCorrectionSystem_not_sourceRefExact :
+    ¬ SystemSourceRefExact stagedCorrectionSystem := by
+  intro hexact
+  exact stagedCorrection_uncorrected_not_exact
+    (hexact uncorrected)
+
+/-- The staged correction system is exact at a stage exactly when that stage is all-branches. -/
+theorem stagedCorrectionSystem_exactAt_iff_allBranches
+    (stage : RepairStage) :
+    SystemExactAt stagedCorrectionSystem stage ↔
+      stage = allBranches :=
+  stagedCorrection_exact_iff_allBranches stage
+
+/-! ## Theorem package -/
+
+/--
+Cycle-48 theorem package: selected corrections form a parametrized system whose
+exact locus is upward closed under hit-set monotonicity.  The concrete staged
+schedule has a precise exact locus: only the all-branches stage is exact.
+-/
+theorem parametrizedSelectedCorrectionSystem_package :
+    (∀ correction,
+      CorrectionSourceRefExact correction ↔
+        CorrectionHitsAllBranches correction) ∧
+    (∀ left right,
+      CorrectionLe left right ->
+        CorrectionHitsAllBranches left ->
+          CorrectionHitsAllBranches right) ∧
+    (∀ left right,
+      CorrectionLe left right ->
+        CorrectionSourceRefExact left ->
+          CorrectionSourceRefExact right) ∧
+    (∀ {Parameter : Type u} (system : CorrectionSystem Parameter),
+      SystemSourceRefExact system ↔
+        SystemHitsAllBranches system) ∧
+    (∀ {Parameter : Type u}
+      (le : Parameter -> Parameter -> Prop)
+      (system : CorrectionSystem Parameter),
+      MonotoneCorrectionSystem le system ->
+        ∀ left right, le left right ->
+          SystemExactAt system left ->
+            SystemExactAt system right) ∧
+    MonotoneCorrectionSystem StageLe stagedCorrectionSystem ∧
+    (∀ stage,
+      SystemExactAt stagedCorrectionSystem stage ↔
+        stage = allBranches) ∧
+    ¬ SystemSourceRefExact stagedCorrectionSystem := by
+  exact ⟨correctionSourceRefExact_iff_hitsAllBranches,
+    fun _left _right hle hhits =>
+      correctionHitsAllBranches_monotone hle hhits,
+    fun _left _right hle hexact =>
+      correctionSourceRefExact_monotone hle hexact,
+    systemSourceRefExact_iff_hitsAllBranches,
+    fun _le _system hmonotone _left _right hle hexact =>
+      monotoneCorrectionSystem_exact_upwardClosed hmonotone hle hexact,
+    stagedCorrectionSystem_monotone,
+    stagedCorrectionSystem_exactAt_iff_allBranches,
+    stagedCorrectionSystem_not_sourceRefExact⟩
+
+end ParametrizedSelectedCorrectionSystem
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-parametrized-selected-correction-system.md
+++ b/research/ideas/g-aat-quality-surface-01-parametrized-selected-correction-system.md
@@ -1,0 +1,125 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure / parametrization
+capability_category: repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can report route violations and possible fixes, but this theorem proves exactness monotonicity and upward-closed exact loci for parametrized selected correction systems.
+origin: G-aat-quality-surface-01-cycle48
+tags: [quality-surface, selected-correction, parametrized-system, monotonicity, exact-locus]
+created: 2026-06-21
+cycle: 48
+lean: proved-in-research
+---
+
+# Parametrized selected correction system
+
+## 主張
+
+selected route correction を parameterized system として読み、correction order を「hit した selected atom が失われない」順序として定義する。この順序に沿って selected branch hitting と source-ref exactness は monotone であり、monotone correction system の exact locus は upward-closed になる。具体例として `uncorrected -> obligationOnly -> allBranches` の三段階 schedule を置き、exact locus が `allBranches` のみであることを証明する。
+
+## 候補種別
+
+`closure / parametrization`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/SelectedRouteDefectSupportHitting.lean`
+- `Formal/AG/Research/QualitySurface/SelectedRouteCorrectionExactness.lean`
+- `Formal/AG/Research/QualitySurface/SelectedRouteFamilyExactness.lean`
+
+## 非自明性
+
+Cycle 44 は単一 correction の exactness iff all branch hitting を証明し、Cycle 47 は correction family exactness を localized branch agreement へ上げた。Cycle 48 は correction を parameterized system として扱い、hit-set order による monotonicity と upward-closed exact locus を theorem として固定する。三段階 schedule により、partial repair が visible surface を保っても exact locus には入らないことを具体的に示す。
+
+## 数学的興味
+
+quality surface 上の repair trajectory は、単なる fix list ではなく、selected atom hit-set による順序付き family として扱える。exact locus が upward-closed であることは、repair-potential を order-theoretic certificate geometry として読むための核になる。
+
+## GOAL への前進
+
+この候補は `repair-potential`、`obstruction`、`certificate-transport`、`traceability`、`invariance`、`quality-surface` を前進させる。特に Next Frontier の `parametrized selected correction system` を直接埋める。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は violation と fix candidate を列挙できるが、修正 parameter の順序上で exactness が upward-closed になることや、partial correction と all-hit correction の exact locus の分離を theorem として与えない。
+
+## SCORE 見込み
+
+- `score_reason`: Next Frontier の `parametrized selected correction system` を直接進め、generic correction order、system exactness criterion、monotone exact-locus theorem、concrete three-stage schedule witness を Lean で持つ。ただし Cycle 44 の exactness iff all-branch hitting から自然に出る構造でもあるため、G2 の厳しめ判定に合わせて base70 とする。
+- `dullness_risk`: 単なる `∀ parameter` 包装なら弱い。`CorrectionLe`、`MonotoneCorrectionSystem`、`monotoneCorrectionSystem_exact_upwardClosed`、`stagedCorrection_exact_iff_allBranches` を追加して、order-theoretic structure と concrete exact locus を固定する。
+- `proof_or_evidence_plan`: Lean file `ParametrizedSelectedCorrectionSystem.lean` で proved-in-research。G2/G3/G4 監査後に report と Issue score を同期する。
+
+## CS / SWE への帰結
+
+repair pipeline の stage や policy parameter を、選択された defect atom の hit-set order として読むと、exactness restoration は upward-closed な safe region になる。ただしこれは tooling 実装 claim ではなく、選ばれた route-defect atom vocabulary と correction semantics に相対化された theorem である。
+
+## 証明・根拠
+
+Lean file: `Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean`
+
+Proved declarations:
+
+- `CorrectionLe`
+- `CorrectionHitsAllBranches`
+- `CorrectionSourceRefExact`
+- `correctionLe_refl`
+- `correctionLe_trans`
+- `correctionSourceRefExact_iff_hitsAllBranches`
+- `correctionHitsAllBranches_monotone`
+- `correctionSourceRefExact_monotone`
+- `CorrectionSystem`
+- `SystemExactAt`
+- `SystemHitsAllBranches`
+- `SystemSourceRefExact`
+- `systemSourceRefExact_iff_hitsAllBranches`
+- `MonotoneCorrectionSystem`
+- `monotoneCorrectionSystem_exact_upwardClosed`
+- `RepairStage`
+- `stagedCorrection`
+- `stagedCorrectionSystem`
+- `StageLe`
+- `stagedCorrectionSystem_monotone`
+- `stagedCorrection_uncorrected_not_exact`
+- `stagedCorrection_obligationOnly_not_exact`
+- `stagedCorrection_allBranches_exact`
+- `stagedCorrection_exact_iff_allBranches`
+- `stagedCorrectionSystem_not_sourceRefExact`
+- `stagedCorrectionSystem_exactAt_iff_allBranches`
+- `parametrizedSelectedCorrectionSystem_package`
+
+Boundary:
+
+- selected route-defect atom vocabulary、selected correction semantics、explicit source-ref packet bridge に相対化する。
+- global repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+
+## 審判メモ
+
+- 厳密性: A/C/D は accept/base80。B は accept/base70 とし、Cycle 44 から自然に出る構造なので G4/report は base70 に同期すべきと判定。採用する base は 70。
+- 研究価値: selected correction を単発 repair から hit-set order 上の repair trajectory として読む構造を追加する。
+- repo 全体価値: Cycle 44/47 の exactness theorem を monotone correction system と staged exact locus に接続する。
+- ライバル比較: ADL / conformance checker との差分は global repair planning ではなく、hit-set order 上の exactness monotonicity と upward-closed exact locus に限定する。
+
+## Verification
+
+- `lake env lean Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean`: pass
+- `lake build FormalAGResearch`: pass
+- forbidden-token scan for `sorry` / `admit` / `axiom` / `unsafe` / broad autoImplicit setting: pass
+- `.tmp/parametrized_selected_correction_system_axioms.lean`: pass
+  - axiom-free: `correctionLe_refl`, `correctionLe_trans`, `correctionSourceRefExact_iff_hitsAllBranches`, `correctionHitsAllBranches_monotone`, `correctionSourceRefExact_monotone`, `systemSourceRefExact_iff_hitsAllBranches`, `monotoneCorrectionSystem_exact_upwardClosed`
+  - standard axioms only: concrete staged schedule witnesses and package depend only on `propext` / `Quot.sound`
+- G3 independent audit: pass; blocking findings none
+
+## 関連
+
+- Cycle 43: `Selected route-defect support hitting`
+- Cycle 44: `Selected route correction exactness theorem`
+- Cycle 46: `Route-defect local repair calculus bridge`
+- Cycle 47: `Selected route family exactness criterion`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 48 候補として作成し、Lean 証明を追加。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 5970
+- total SCORE: 6110
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -52,8 +52,9 @@
   - obstruction / repair-potential / certificate-transport / traceability / quality-surface / computability: 140
   - obstruction / repair-potential / certificate-transport / traceability / invariance / quality-surface: 140
   - certificate-transport / obstruction / repair-potential / traceability / quality-surface: 160
+  - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 47
+  - proved-in-research: 48
 
 ## Phase synthesis
 
@@ -69,7 +70,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-47 件の Lean-proved research artifacts は、次の paper seed を形成している。
+48 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -112,8 +113,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 47 後の total SCORE は 5970 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 47 件持ち、
+Cycle 48 後の total SCORE は 6110 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 48 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2163,13 +2164,55 @@ concrete localization cover の主張は singleton corrected route family に限
 complete diagnostic coverage for all codebases、ArchMap correctness、source extraction completeness、
 global repair planning、実コード全体の品質判定は結論しない。
 
+## Cycle 48: Parametrized selected correction system
+
+```text
+candidate: Parametrized selected correction system
+candidate_type: closure / parametrization
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: repair-potential/obstruction/certificate-transport/traceability/invariance/quality-surface
+goal_delta: selected correction を hit-set order 上の parametrized correction system として読み、source-ref exactness の monotonicity と upward-closed exact locus を Lean で固定した。
+project_value_delta: Cycle 44/47 の exactness theorem を、monotone correction system と concrete staged exact locus に接続し、repair trajectory を certificate geometry として扱う adapter を追加した。
+rival_delta: ADL / conformance checker は violation と fix candidate を列挙できるが、selected hit-set order 上の exactness monotonicity と upward-closed exact locus を theorem として与えない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch` は pass。generic monotonicity theorem は axiom-free、concrete staged witness と package は標準 `propext` / `Quot.sound` のみに依存する。`StageLe` は一般 poset ではなく、concrete three-stage schedule の relation として使う。
+open_questions: parametrized loss-aware atlas、generic selected support-defect localization、multi-route non-singleton correction systems。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean` は、
+selected route correction を parameterized system として読むための順序構造を追加する。
+`CorrectionLe left right` は、`left` が hit した selected atom を `right` も hit するという hit-set order である。
+
+Lean 証拠は次を固定する。
+
+- `correctionSourceRefExact_iff_hitsAllBranches`: correction の source-ref exactness は all selected branch hitting と同値である。
+- `correctionHitsAllBranches_monotone` /
+  `correctionSourceRefExact_monotone`: `CorrectionLe` に沿って selected branch hitting と source-ref exactness は monotone である。
+- `systemSourceRefExact_iff_hitsAllBranches`: parameterized correction system 全体の exactness は、各 parameter で all selected branch hitting が成り立つことに同値である。
+- `MonotoneCorrectionSystem` /
+  `monotoneCorrectionSystem_exact_upwardClosed`: monotone correction system では exact locus が upward-closed である。
+- `stagedCorrectionSystem_monotone`: `uncorrected -> obligationOnly -> allBranches` の concrete staged schedule は `StageLe` に沿って monotone である。
+- `stagedCorrection_exact_iff_allBranches` /
+  `stagedCorrectionSystem_exactAt_iff_allBranches`: concrete staged schedule の exact locus は `allBranches` stage のみである。
+- `stagedCorrectionSystem_not_sourceRefExact`: staged system は全 stage exact ではない。
+- `parametrizedSelectedCorrectionSystem_package`: correction-level criterion、system-level criterion、upward-closed exact locus、concrete staged exact locus を束ねる。
+
+この結果により、repair trajectory は fix candidate list ではなく、selected atom hit-set order 上の certificate trajectory として読める。
+ただし `StageLe` はこの concrete schedule の relation であり、一般 poset law までは主張しない。
+主張は selected route-defect atom vocabulary、selected correction semantics、explicit source-ref packet bridge に相対化され、
+global repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 47 後の total SCORE は 5970 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 48 後の total SCORE は 6110 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 次フェーズへ進める場合は、lawful criterion の necessity / minimality、
-parametrized selected correction system、
 selected support-defect localization の generic theorem、
 または parametrized loss-aware commutator atlas を狙う。threshold 7000 には未達であるため、次 cycle へ進む。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 48 として、selected correction を parametrized correction system として扱う Lean research artifact を追加しました。`CorrectionLe` による hit-set order、source-ref exactness monotonicity、monotone correction system の upward-closed exact locus、 concrete three-stage schedule の exact locus を証明しています。

tracking Issue は score 7000 まで継続するため、この PR では close しません。

## 証明した定理

- `correctionLe_refl`
- `correctionLe_trans`
- `correctionSourceRefExact_iff_hitsAllBranches`
- `correctionHitsAllBranches_monotone`
- `correctionSourceRefExact_monotone`
- `systemSourceRefExact_iff_hitsAllBranches`
- `monotoneCorrectionSystem_exact_upwardClosed`
- `stagedCorrectionSystem_monotone`
- `stagedCorrection_uncorrected_not_exact`
- `stagedCorrection_obligationOnly_not_exact`
- `stagedCorrection_allBranches_exact`
- `stagedCorrection_exact_iff_allBranches`
- `stagedCorrectionSystem_not_sourceRefExact`
- `stagedCorrectionSystem_exactAt_iff_allBranches`
- `parametrizedSelectedCorrectionSystem_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-parametrized-selected-correction-system.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean`
- [x] `lake env lean .tmp/parametrized_selected_correction_system_axioms.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue 継続のため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
