### PR TITLE
Cycle 49: parametrized loss-aware atlas を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -47,3 +47,4 @@ import Formal.AG.Research.QualitySurface.LossAwareCommutatorAtlas
 import Formal.AG.Research.QualitySurface.RouteDefectLocalRepairCalculusBridge
 import Formal.AG.Research.QualitySurface.SelectedRouteFamilyExactness
 import Formal.AG.Research.QualitySurface.ParametrizedSelectedCorrectionSystem
+import Formal.AG.Research.QualitySurface.ParametrizedLossAwareAtlas

--- a/Formal/AG/Research/QualitySurface/ParametrizedLossAwareAtlas.lean
+++ b/Formal/AG/Research/QualitySurface/ParametrizedLossAwareAtlas.lean
@@ -1,0 +1,241 @@
+import Formal.AG.Research.QualitySurface.ParametrizedSelectedCorrectionSystem
+
+/-!
+Cycle 49 evidence for `G-aat-quality-surface-01`.
+
+This file combines the loss-aware commutator atlas with the parametrized
+selected correction system.  The atlas has baseline loss-aware cells and staged
+correction cells.  For staged correction cells, visible tuple flatness is
+constant while protected-support emptiness and source-ref exactness occur
+exactly at the all-branches stage.
+
+The claim is relative to the selected route-defect atom vocabulary, staged
+selected correction semantics, the baseline loss-aware cells, and the explicit
+source-ref packet bridge.  It does not assert global repair planning, runtime
+patch synthesis, source extraction completeness, ArchMap correctness, or
+whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ParametrizedLossAwareAtlas
+
+open CodebaseTracePacket
+open SourceRefExactVisualizationCriterion
+open RouteDefectSupportTheory
+open ExactVisualizationCriterionMinimality
+open SelectedRouteDefectSupportHitting
+open SelectedRouteCorrectionExactness
+open LossAwareCommutatorAtlas
+open LossAwareAtlasCell
+open ParametrizedSelectedCorrectionSystem
+open RepairStage
+
+/-! ## Parametrized loss-aware atlas cells -/
+
+/-- A loss-aware atlas with baseline cells and staged selected correction cells. -/
+inductive ParametrizedLossAwareCell where
+  | baselineCell : LossAwareAtlasCell -> ParametrizedLossAwareCell
+  | stagedCorrectionCell : RepairStage -> ParametrizedLossAwareCell
+  deriving DecidableEq, Fintype
+
+open ParametrizedLossAwareCell
+
+/-- Visible tuple flatness of a parametrized loss-aware atlas cell. -/
+def ParamCellVisibleTupleFlat : ParametrizedLossAwareCell -> Prop
+  | baselineCell cell => CellVisibleTupleFlat cell
+  | stagedCorrectionCell stage =>
+      TupleVisibleVisualizationEquivalent
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft (stagedCorrection stage)) visibleRouteRight
+
+/-- Empty protected route support of a parametrized loss-aware atlas cell. -/
+def ParamCellProtectedRouteSupportEmpty : ParametrizedLossAwareCell -> Prop
+  | baselineCell cell => CellProtectedRouteSupportEmpty cell
+  | stagedCorrectionCell stage =>
+      RouteDefectSupportEmpty
+        (correctedVisibleRouteLeft (stagedCorrection stage)) visibleRouteRight
+
+/-- Source-ref exactness of a parametrized loss-aware atlas cell. -/
+def ParamCellSourceRefExact : ParametrizedLossAwareCell -> Prop
+  | baselineCell cell => CellSourceRefExact cell
+  | stagedCorrectionCell stage =>
+      CorrectionSourceRefExact (stagedCorrection stage)
+
+/-! ## Parametrized exactness criterion -/
+
+/-- Parametrized atlas exactness is visible flatness plus empty protected support. -/
+theorem paramCell_exact_iff_visible_empty
+    (cell : ParametrizedLossAwareCell) :
+    ParamCellSourceRefExact cell ↔
+      ParamCellVisibleTupleFlat cell ∧
+        ParamCellProtectedRouteSupportEmpty cell := by
+  cases cell with
+  | baselineCell base =>
+      exact atlasCell_exact_iff_visible_empty base
+  | stagedCorrectionCell stage =>
+      exact exactVisualization_iff_visible_emptyRouteSupport
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft (stagedCorrection stage)) visibleRouteRight
+
+/-- Every staged correction cell is visibly flat. -/
+theorem stagedCell_visibleTupleFlat
+    (stage : RepairStage) :
+    ParamCellVisibleTupleFlat (stagedCorrectionCell stage) :=
+  correctedVisibleRoute_tupleVisible (stagedCorrection stage)
+
+/-- Staged correction cells have empty protected support exactly at all-branches. -/
+theorem stagedCell_supportEmpty_iff_allBranches
+    (stage : RepairStage) :
+    ParamCellProtectedRouteSupportEmpty (stagedCorrectionCell stage) ↔
+      stage = allBranches := by
+  constructor
+  · intro hempty
+    have hhits :
+        CorrectionHitsAllBranches (stagedCorrection stage) :=
+      (correctedVisibleRoute_supportEmpty_iff_hits
+        (stagedCorrection stage)).mp hempty
+    have hexact :
+        CorrectionSourceRefExact (stagedCorrection stage) :=
+      (correctionSourceRefExact_iff_hitsAllBranches
+        (stagedCorrection stage)).mpr hhits
+    exact (stagedCorrection_exact_iff_allBranches stage).mp hexact
+  · intro hstage
+    subst hstage
+    have hhits :
+        CorrectionHitsAllBranches (stagedCorrection allBranches) :=
+      (correctionSourceRefExact_iff_hitsAllBranches
+        (stagedCorrection allBranches)).mp stagedCorrection_allBranches_exact
+    exact (correctedVisibleRoute_supportEmpty_iff_hits
+      (stagedCorrection allBranches)).mpr hhits
+
+/-- Staged correction cells are source-ref exact exactly at all-branches. -/
+theorem stagedCell_sourceRefExact_iff_allBranches
+    (stage : RepairStage) :
+    ParamCellSourceRefExact (stagedCorrectionCell stage) ↔
+      stage = allBranches :=
+  stagedCorrection_exact_iff_allBranches stage
+
+/-! ## Parametrized loss modes -/
+
+/-- A cell where protected support is empty but visible flatness fails. -/
+def ParamVisibleLawLossCell (cell : ParametrizedLossAwareCell) : Prop :=
+  ¬ ParamCellVisibleTupleFlat cell ∧
+    ParamCellProtectedRouteSupportEmpty cell ∧
+    ¬ ParamCellSourceRefExact cell
+
+/-- A cell where visible flatness holds but protected support is nonempty. -/
+def ParamProtectedSupportLossCell (cell : ParametrizedLossAwareCell) : Prop :=
+  ParamCellVisibleTupleFlat cell ∧
+    ¬ ParamCellProtectedRouteSupportEmpty cell ∧
+    ¬ ParamCellSourceRefExact cell
+
+/-- A cell where visible flatness and empty protected support restore exactness. -/
+def ParamExactRestorationCell (cell : ParametrizedLossAwareCell) : Prop :=
+  ParamCellVisibleTupleFlat cell ∧
+    ParamCellProtectedRouteSupportEmpty cell ∧
+    ParamCellSourceRefExact cell
+
+/-- Baseline visible-law deletion remains a visible-law loss cell. -/
+theorem baseline_visibleLawDeletion_is_visibleLawLoss :
+    ParamVisibleLawLossCell (baselineCell visibleLawDeletionCell) :=
+  visibleLawDeletion_is_visibleLawLoss
+
+/-- Baseline table-law deletion remains a protected-support loss cell. -/
+theorem baseline_tableLawDeletion_is_protectedSupportLoss :
+    ParamProtectedSupportLossCell (baselineCell tableLawDeletionCell) :=
+  tableLawDeletion_is_protectedSupportLoss
+
+/-- A staged correction cell is protected-support loss before all branches are hit. -/
+theorem stagedCell_protectedSupportLoss_of_not_allBranches
+    {stage : RepairStage}
+    (hstage : stage ≠ allBranches) :
+    ParamProtectedSupportLossCell (stagedCorrectionCell stage) := by
+  refine ⟨stagedCell_visibleTupleFlat stage, ?_, ?_⟩
+  · intro hempty
+    exact hstage ((stagedCell_supportEmpty_iff_allBranches stage).mp hempty)
+  · intro hexact
+    exact hstage ((stagedCell_sourceRefExact_iff_allBranches stage).mp hexact)
+
+/-- The all-branches staged correction cell is an exact restoration cell. -/
+theorem stagedCell_allBranches_is_exactRestoration :
+    ParamExactRestorationCell (stagedCorrectionCell allBranches) :=
+  ⟨stagedCell_visibleTupleFlat allBranches,
+    (stagedCell_supportEmpty_iff_allBranches allBranches).mpr rfl,
+    stagedCorrection_allBranches_exact⟩
+
+/-- The staged exact-restoration locus is exactly the all-branches stage. -/
+theorem stagedCell_exactRestoration_iff_allBranches
+    (stage : RepairStage) :
+    ParamExactRestorationCell (stagedCorrectionCell stage) ↔
+      stage = allBranches := by
+  constructor
+  · intro hrestored
+    exact (stagedCell_sourceRefExact_iff_allBranches stage).mp hrestored.2.2
+  · intro hstage
+    subst hstage
+    exact stagedCell_allBranches_is_exactRestoration
+
+/-- The parametrized atlas contains visible-law loss, protected-support loss, and exact restoration. -/
+theorem parametrizedLossAwareAtlas_has_all_modes :
+    (∃ cell, ParamVisibleLawLossCell cell) ∧
+    (∃ cell, ParamProtectedSupportLossCell cell) ∧
+    (∃ cell, ParamExactRestorationCell cell) :=
+  ⟨⟨baselineCell visibleLawDeletionCell,
+      baseline_visibleLawDeletion_is_visibleLawLoss⟩,
+    ⟨stagedCorrectionCell obligationOnly,
+      stagedCell_protectedSupportLoss_of_not_allBranches (by intro h; cases h)⟩,
+    ⟨stagedCorrectionCell allBranches,
+      stagedCell_allBranches_is_exactRestoration⟩⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-49 theorem package: the loss-aware atlas is parametrized by staged
+selected correction cells.  Staged cells are visibly flat at every stage, and
+their support-empty / exact / exact-restoration loci are exactly all-branches.
+-/
+theorem parametrizedLossAwareAtlas_package :
+    (∀ cell,
+      ParamCellSourceRefExact cell ↔
+        ParamCellVisibleTupleFlat cell ∧
+          ParamCellProtectedRouteSupportEmpty cell) ∧
+    (∀ stage, ParamCellVisibleTupleFlat (stagedCorrectionCell stage)) ∧
+    (∀ stage,
+      ParamCellProtectedRouteSupportEmpty (stagedCorrectionCell stage) ↔
+        stage = allBranches) ∧
+    (∀ stage,
+      ParamCellSourceRefExact (stagedCorrectionCell stage) ↔
+        stage = allBranches) ∧
+    (∀ {stage},
+      stage ≠ allBranches ->
+        ParamProtectedSupportLossCell (stagedCorrectionCell stage)) ∧
+    ParamExactRestorationCell (stagedCorrectionCell allBranches) ∧
+    (∀ stage,
+      ParamExactRestorationCell (stagedCorrectionCell stage) ↔
+        stage = allBranches) ∧
+    ParamVisibleLawLossCell (baselineCell visibleLawDeletionCell) ∧
+    ParamProtectedSupportLossCell (baselineCell tableLawDeletionCell) ∧
+    (∃ cell, ParamVisibleLawLossCell cell) ∧
+    (∃ cell, ParamProtectedSupportLossCell cell) ∧
+    (∃ cell, ParamExactRestorationCell cell) := by
+  exact ⟨paramCell_exact_iff_visible_empty,
+    stagedCell_visibleTupleFlat,
+    stagedCell_supportEmpty_iff_allBranches,
+    stagedCell_sourceRefExact_iff_allBranches,
+    by
+      intro stage hstage
+      exact stagedCell_protectedSupportLoss_of_not_allBranches hstage,
+    stagedCell_allBranches_is_exactRestoration,
+    stagedCell_exactRestoration_iff_allBranches,
+    baseline_visibleLawDeletion_is_visibleLawLoss,
+    baseline_tableLawDeletion_is_protectedSupportLoss,
+    parametrizedLossAwareAtlas_has_all_modes.1,
+    parametrizedLossAwareAtlas_has_all_modes.2.1,
+    parametrizedLossAwareAtlas_has_all_modes.2.2⟩
+
+end ParametrizedLossAwareAtlas
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-parametrized-loss-aware-atlas.md
+++ b/research/ideas/g-aat-quality-surface-01-parametrized-loss-aware-atlas.md
@@ -1,0 +1,113 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure / atlas-parametrization
+capability_category: certificate-transport / obstruction / repair-potential / traceability / invariance / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can list violations and fixes, but this atlas proves that staged correction cells keep visible flatness while support-empty / exact / exact-restoration loci occur exactly at the all-branches stage.
+origin: G-aat-quality-surface-01-cycle49
+tags: [quality-surface, loss-aware-atlas, staged-correction, exact-locus, protected-support]
+created: 2026-06-21
+cycle: 49
+lean: proved-in-research
+---
+
+# Parametrized loss-aware atlas
+
+## 主張
+
+Cycle 45 の loss-aware atlas と Cycle 48 の staged selected correction system を結合し、baseline loss cells と staged correction cells を同じ finite atlas に入れる。staged correction cells では visible tuple flatness は全 stage で保たれ、protected support empty、source-ref exactness、exact restoration は `allBranches` stage でのみ成立する。
+
+## 候補種別
+
+`closure / atlas-parametrization`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/LossAwareCommutatorAtlas.lean`
+- `Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean`
+
+## 非自明性
+
+Cycle 45 は static な loss-aware atlas、Cycle 48 は staged correction system を証明した。Cycle 49 は両者を合わせ、loss-aware atlas の cell type 自体を baseline / staged correction の和として拡張する。特に staged cell の exactness locus だけでなく、protected support empty locus と exact restoration locus も `allBranches` に一致することを固定する。
+
+## 数学的興味
+
+Quality Surface の atlas は、単一 snapshot の loss classification だけでなく、repair stage parameter に沿って exact locus がどこで開くかを読める。visible layer が一定でも protected support と exactness が stage によって分岐するため、loss-aware geometry と repair trajectory が同じ finite atlas 上で接続される。
+
+## GOAL への前進
+
+この候補は `certificate-transport`、`obstruction`、`repair-potential`、`traceability`、`invariance`、`quality-surface` を前進させる。Next Frontier の `parametrized loss-aware commutator atlas` を直接進める。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は violation と fix candidate を列挙できるが、visible flatness が一定の staged correction cells で protected support empty / source-ref exact / exact restoration の locus が一致することを theorem として与えない。
+
+## SCORE 見込み
+
+- `score_reason`: Next Frontier の `parametrized loss-aware atlas` を直接進め、baseline loss cells と staged correction cells の finite atlas、exactness criterion、stage exact/support/restoration locus、mode witnesses を Lean で持つ。ただし Cycle 45 と Cycle 48 の合成色も強いため、G2 の厳しめ判定に合わせて base70 とする。
+- `dullness_risk`: Cycle 45 と Cycle 48 の単純な合成だけだと弱い。`ParametrizedLossAwareCell` を新しい atlas cell type として定義し、staged cells の support-empty / exact / exact-restoration loci がすべて `allBranches` に一致する theorem を追加して差分を作る。
+- `proof_or_evidence_plan`: Lean file `ParametrizedLossAwareAtlas.lean` で proved-in-research。G2/G3/G4 監査後に report と Issue score を同期する。
+
+## CS / SWE への帰結
+
+repair stage UI や diagnostic table は、visible pass/fail だけではなく、protected support と exact restoration locus を同じ atlas 上で示せる。ただしこれは tooling 実装 claim ではなく、selected staged correction semantics と baseline loss-aware cells に相対化された theorem である。
+
+## 証明・根拠
+
+Lean file: `Formal/AG/Research/QualitySurface/ParametrizedLossAwareAtlas.lean`
+
+Proved declarations:
+
+- `ParametrizedLossAwareCell`
+- `ParamCellVisibleTupleFlat`
+- `ParamCellProtectedRouteSupportEmpty`
+- `ParamCellSourceRefExact`
+- `paramCell_exact_iff_visible_empty`
+- `stagedCell_visibleTupleFlat`
+- `stagedCell_supportEmpty_iff_allBranches`
+- `stagedCell_sourceRefExact_iff_allBranches`
+- `ParamVisibleLawLossCell`
+- `ParamProtectedSupportLossCell`
+- `ParamExactRestorationCell`
+- `baseline_visibleLawDeletion_is_visibleLawLoss`
+- `baseline_tableLawDeletion_is_protectedSupportLoss`
+- `stagedCell_protectedSupportLoss_of_not_allBranches`
+- `stagedCell_allBranches_is_exactRestoration`
+- `stagedCell_exactRestoration_iff_allBranches`
+- `parametrizedLossAwareAtlas_has_all_modes`
+- `parametrizedLossAwareAtlas_package`
+
+Boundary:
+
+- selected route-defect atom vocabulary、staged selected correction semantics、baseline loss-aware cells、explicit source-ref packet bridge に相対化する。
+- global repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+
+## 審判メモ
+
+- 厳密性: A/C/D は accept/base80。B は accept/base70 とし、Cycle 45/48 の合成に近いので G4/report は base70 に下げるべきと判定。採用する base は 70。
+- 研究価値: baseline loss cells と staged correction cells を一つの finite atlas type に入れ、staged support-empty / exact / restoration locus を `allBranches` に一致させる。
+- repo 全体価値: Cycle 45 の atlas と Cycle 48 の staged correction system を、parametrized atlas の theorem package に接続する。
+- ライバル比較: ADL / conformance checker との差分は、visible flatness が一定でも protected support / exact restoration locus を theorem 化する点に限定する。
+
+## Verification
+
+- `lake env lean Formal/AG/Research/QualitySurface/ParametrizedLossAwareAtlas.lean`: pass
+- `lake build FormalAGResearch`: pass
+- forbidden-token scan for `sorry` / `admit` / `axiom` / `unsafe` / broad autoImplicit setting: pass
+- `.tmp/parametrized_loss_aware_atlas_axioms.lean`: pass
+  - axiom-free: `paramCell_exact_iff_visible_empty`, `stagedCell_visibleTupleFlat`, `baseline_visibleLawDeletion_is_visibleLawLoss`, `baseline_tableLawDeletion_is_protectedSupportLoss`
+  - standard axioms only: staged locus/mode/package declarations depend only on `propext` / `Quot.sound`
+- G3 independent audit: pass; blocking findings none
+
+## 関連
+
+- Cycle 45: `Loss-aware commutator atlas adequacy`
+- Cycle 48: `Parametrized selected correction system`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 49 候補として作成し、Lean 証明を追加。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 6110
+- total SCORE: 6250
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -53,8 +53,9 @@
   - obstruction / repair-potential / certificate-transport / traceability / invariance / quality-surface: 140
   - certificate-transport / obstruction / repair-potential / traceability / quality-surface: 160
   - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
+  - certificate-transport / obstruction / repair-potential / traceability / invariance / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 48
+  - proved-in-research: 49
 
 ## Phase synthesis
 
@@ -70,7 +71,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-48 件の Lean-proved research artifacts は、次の paper seed を形成している。
+49 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -113,8 +114,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 48 後の total SCORE は 6110 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 48 件持ち、
+Cycle 49 後の total SCORE は 6250 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 49 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2207,12 +2208,58 @@ Lean 証拠は次を固定する。
 主張は selected route-defect atom vocabulary、selected correction semantics、explicit source-ref packet bridge に相対化され、
 global repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 49: Parametrized loss-aware atlas
+
+```text
+candidate: Parametrized loss-aware atlas
+candidate_type: closure / atlas-parametrization
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: certificate-transport/obstruction/repair-potential/traceability/invariance/quality-surface
+goal_delta: baseline loss-aware cells と staged correction cells を同じ finite atlas type に入れ、staged cells の visible flatness と protected-support / exactness / exact-restoration locus を Lean で固定した。
+project_value_delta: Cycle 45 の loss-aware atlas と Cycle 48 の correction-stage exact locus を接続し、repair stage parameter を loss-aware certificate atlas に載せる adapter を追加した。
+rival_delta: ADL / conformance checker は violation と fix candidate を列挙できるが、visible flatness が一定でも protected support empty / source-ref exact / exact restoration locus が一致することを theorem として与えない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch` は pass。baseline exactness criterion は axiom-free、staged locus/mode/package declarations は標準 `propext` / `Quot.sound` のみに依存する。claim は baseline cells + staged correction cells の finite atlas に限定される。
+open_questions: generic selected support-defect localization、multi-route non-singleton correction systems、parametrized atlas transition maps。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ParametrizedLossAwareAtlas.lean` は、
+baseline loss-aware cells と staged correction cells を
+`ParametrizedLossAwareCell` にまとめる。
+baseline cells は Cycle 45 の `LossAwareAtlasCell` をそのまま読み、
+staged correction cells は Cycle 48 の `RepairStage` に沿った corrected route を読む。
+
+Lean 証拠は次を固定する。
+
+- `paramCell_exact_iff_visible_empty`: parametrized atlas cell の source-ref exactness は visible flatness と empty protected support に同値である。
+- `stagedCell_visibleTupleFlat`: staged correction cell は全 stage で visible tuple flatness を保つ。
+- `stagedCell_supportEmpty_iff_allBranches`: staged correction cell の protected support empty locus は `allBranches` stage と一致する。
+- `stagedCell_sourceRefExact_iff_allBranches`: staged correction cell の source-ref exact locus も `allBranches` stage と一致する。
+- `stagedCell_protectedSupportLoss_of_not_allBranches`: `allBranches` 以外の staged correction cell は protected-support loss cell である。
+- `stagedCell_allBranches_is_exactRestoration` /
+  `stagedCell_exactRestoration_iff_allBranches`: exact restoration locus も `allBranches` stage と一致する。
+- `baseline_visibleLawDeletion_is_visibleLawLoss` /
+  `baseline_tableLawDeletion_is_protectedSupportLoss`: baseline visible-law loss と protected-support loss を parametrized atlas に持ち上げる。
+- `parametrizedLossAwareAtlas_has_all_modes` /
+  `parametrizedLossAwareAtlas_package`: visible-law loss、protected-support loss、exact restoration の mode witness と staged locus theorem を束ねる。
+
+この結果により、loss-aware atlas は static な mismatch table ではなく、
+repair stage parameter に沿って protected support と exact restoration locus がどこで開くかを読む finite certificate atlas になる。
+主張は baseline cells + staged correction cells の finite atlas に限定され、任意の parametrized atlas や transition map までは主張しない。
+global repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、実コード全体の品質判定も結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 48 後の total SCORE は 6110 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 49 後の total SCORE は 6250 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 次フェーズへ進める場合は、lawful criterion の necessity / minimality、
 selected support-defect localization の generic theorem、
-または parametrized loss-aware commutator atlas を狙う。threshold 7000 には未達であるため、次 cycle へ進む。
+parametrized atlas transition maps、
+または multi-route non-singleton correction systems を狙う。threshold 7000 には未達であるため、次 cycle へ進む。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 49 として、baseline loss-aware cells と staged correction cells を同じ finite atlas に載せる Lean research artifact を追加しました。staged correction cells は全 stage で visible flatness を保ち、protected support empty / source-ref exact / exact restoration locus が `allBranches` に一致することを証明しています。

tracking Issue は score 7000 まで継続するため、この PR では close しません。

## 証明した定理

- `paramCell_exact_iff_visible_empty`
- `stagedCell_visibleTupleFlat`
- `stagedCell_supportEmpty_iff_allBranches`
- `stagedCell_sourceRefExact_iff_allBranches`
- `baseline_visibleLawDeletion_is_visibleLawLoss`
- `baseline_tableLawDeletion_is_protectedSupportLoss`
- `stagedCell_protectedSupportLoss_of_not_allBranches`
- `stagedCell_allBranches_is_exactRestoration`
- `stagedCell_exactRestoration_iff_allBranches`
- `parametrizedLossAwareAtlas_has_all_modes`
- `parametrizedLossAwareAtlas_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-parametrized-loss-aware-atlas.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/ParametrizedLossAwareAtlas.lean`
- [x] `lake env lean .tmp/parametrized_loss_aware_atlas_axioms.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue 継続のため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
