### PR TITLE
Cycle 50: parametrized atlas transition theorem を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -48,3 +48,4 @@ import Formal.AG.Research.QualitySurface.RouteDefectLocalRepairCalculusBridge
 import Formal.AG.Research.QualitySurface.SelectedRouteFamilyExactness
 import Formal.AG.Research.QualitySurface.ParametrizedSelectedCorrectionSystem
 import Formal.AG.Research.QualitySurface.ParametrizedLossAwareAtlas
+import Formal.AG.Research.QualitySurface.ParametrizedAtlasTransition

--- a/Formal/AG/Research/QualitySurface/ParametrizedAtlasTransition.lean
+++ b/Formal/AG/Research/QualitySurface/ParametrizedAtlasTransition.lean
@@ -1,0 +1,194 @@
+import Formal.AG.Research.QualitySurface.ParametrizedLossAwareAtlas
+
+/-!
+Cycle 50 evidence for `G-aat-quality-surface-01`.
+
+This file adds transition maps to the parametrized loss-aware atlas.  Along the
+concrete staged correction relation, source-ref exactness, protected-support
+emptiness, and exact restoration are upward closed.  Any pre-all stage can
+transition to the all-branches stage, crossing from protected-support loss to
+exact restoration without changing visible tuple flatness.
+
+The claim is relative to the concrete staged selected correction relation and
+the finite parametrized loss-aware atlas.  It does not assert arbitrary atlas
+transition maps, global repair planning, runtime patch synthesis, source
+extraction completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ParametrizedAtlasTransition
+
+open ParametrizedSelectedCorrectionSystem
+open ParametrizedLossAwareAtlas
+open ParametrizedLossAwareCell
+open RepairStage
+
+/-! ## Stage transitions inside the parametrized atlas -/
+
+/-- The staged atlas cell at a repair stage. -/
+def StageAtlasCell (stage : RepairStage) : ParametrizedLossAwareCell :=
+  stagedCorrectionCell stage
+
+/-- The concrete transition relation between staged atlas cells. -/
+def StageAtlasTransition (left right : RepairStage) : Prop :=
+  StageLe left right
+
+/-- Every staged atlas cell is visible-flat, independently of transition. -/
+theorem stageAtlasCell_visibleInvariant
+    (stage : RepairStage) :
+    ParamCellVisibleTupleFlat (StageAtlasCell stage) :=
+  stagedCell_visibleTupleFlat stage
+
+/-- Source-ref exactness is upward closed along staged atlas transitions. -/
+theorem stageTransition_sourceRefExact_upwardClosed
+    {left right : RepairStage}
+    (htransition : StageAtlasTransition left right)
+    (hexact : ParamCellSourceRefExact (StageAtlasCell left)) :
+    ParamCellSourceRefExact (StageAtlasCell right) := by
+  have hleftAll :
+      left = allBranches :=
+    (stagedCell_sourceRefExact_iff_allBranches left).mp hexact
+  subst hleftAll
+  cases right with
+  | uncorrected =>
+      cases htransition
+  | obligationOnly =>
+      cases htransition
+  | allBranches =>
+      exact (stagedCell_sourceRefExact_iff_allBranches allBranches).mpr rfl
+
+/-- Protected-support emptiness is upward closed along staged atlas transitions. -/
+theorem stageTransition_supportEmpty_upwardClosed
+    {left right : RepairStage}
+    (htransition : StageAtlasTransition left right)
+    (hempty : ParamCellProtectedRouteSupportEmpty (StageAtlasCell left)) :
+    ParamCellProtectedRouteSupportEmpty (StageAtlasCell right) := by
+  have hleftAll :
+      left = allBranches :=
+    (stagedCell_supportEmpty_iff_allBranches left).mp hempty
+  subst hleftAll
+  cases right with
+  | uncorrected =>
+      cases htransition
+  | obligationOnly =>
+      cases htransition
+  | allBranches =>
+      exact (stagedCell_supportEmpty_iff_allBranches allBranches).mpr rfl
+
+/-- Exact restoration is upward closed along staged atlas transitions. -/
+theorem stageTransition_exactRestoration_upwardClosed
+    {left right : RepairStage}
+    (htransition : StageAtlasTransition left right)
+    (hrestored : ParamExactRestorationCell (StageAtlasCell left)) :
+    ParamExactRestorationCell (StageAtlasCell right) := by
+  have hleftAll :
+      left = allBranches :=
+    (stagedCell_exactRestoration_iff_allBranches left).mp hrestored
+  subst hleftAll
+  cases right with
+  | uncorrected =>
+      cases htransition
+  | obligationOnly =>
+      cases htransition
+  | allBranches =>
+      exact stagedCell_allBranches_is_exactRestoration
+
+/-- Exact staged cells cannot transition to protected-support loss cells. -/
+theorem stageTransition_no_exact_to_protectedSupportLoss
+    {left right : RepairStage}
+    (htransition : StageAtlasTransition left right)
+    (hexact : ParamCellSourceRefExact (StageAtlasCell left)) :
+    ¬ ParamProtectedSupportLossCell (StageAtlasCell right) := by
+  intro hloss
+  exact hloss.2.2
+    (stageTransition_sourceRefExact_upwardClosed htransition hexact)
+
+/-! ## Loss-to-restoration transitions -/
+
+/-- A staged transition crosses from protected-support loss to exact restoration. -/
+def StageLossToRestorationTransition
+    (left right : RepairStage) : Prop :=
+  StageAtlasTransition left right ∧
+    ParamProtectedSupportLossCell (StageAtlasCell left) ∧
+    ParamExactRestorationCell (StageAtlasCell right)
+
+/-- Every pre-all stage transitions to all-branches. -/
+theorem stageTransition_to_allBranches_of_not_allBranches
+    {stage : RepairStage}
+    (hstage : stage ≠ allBranches) :
+    StageAtlasTransition stage allBranches := by
+  cases stage with
+  | uncorrected => trivial
+  | obligationOnly => trivial
+  | allBranches => exact False.elim (hstage rfl)
+
+/--
+Every pre-all staged cell can transition from protected-support loss to exact
+restoration at all-branches.
+-/
+theorem preAllStage_to_allBranches_lossToRestoration
+    {stage : RepairStage}
+    (hstage : stage ≠ allBranches) :
+    StageLossToRestorationTransition stage allBranches :=
+  ⟨stageTransition_to_allBranches_of_not_allBranches hstage,
+    stagedCell_protectedSupportLoss_of_not_allBranches hstage,
+    stagedCell_allBranches_is_exactRestoration⟩
+
+/-- The obligation-only stage crosses to exact restoration at all-branches. -/
+theorem obligationOnly_to_allBranches_lossToRestoration :
+    StageLossToRestorationTransition obligationOnly allBranches :=
+  preAllStage_to_allBranches_lossToRestoration (by intro h; cases h)
+
+/-- The uncorrected stage also crosses to exact restoration at all-branches. -/
+theorem uncorrected_to_allBranches_lossToRestoration :
+    StageLossToRestorationTransition uncorrected allBranches :=
+  preAllStage_to_allBranches_lossToRestoration (by intro h; cases h)
+
+/-! ## Theorem package -/
+
+/--
+Cycle-50 theorem package: stage transitions preserve visible flatness and make
+source-ref exactness, protected-support emptiness, and exact restoration
+upward closed.  Pre-all stages cross from protected-support loss to exact
+restoration at all-branches.
+-/
+theorem parametrizedAtlasTransition_package :
+    (∀ stage, ParamCellVisibleTupleFlat (StageAtlasCell stage)) ∧
+    (∀ {left right},
+      StageAtlasTransition left right ->
+        ParamCellSourceRefExact (StageAtlasCell left) ->
+          ParamCellSourceRefExact (StageAtlasCell right)) ∧
+    (∀ {left right},
+      StageAtlasTransition left right ->
+        ParamCellProtectedRouteSupportEmpty (StageAtlasCell left) ->
+          ParamCellProtectedRouteSupportEmpty (StageAtlasCell right)) ∧
+    (∀ {left right},
+      StageAtlasTransition left right ->
+        ParamExactRestorationCell (StageAtlasCell left) ->
+          ParamExactRestorationCell (StageAtlasCell right)) ∧
+    (∀ {left right},
+      StageAtlasTransition left right ->
+        ParamCellSourceRefExact (StageAtlasCell left) ->
+          ¬ ParamProtectedSupportLossCell (StageAtlasCell right)) ∧
+    (∀ {stage},
+      stage ≠ allBranches ->
+        StageLossToRestorationTransition stage allBranches) ∧
+    StageLossToRestorationTransition obligationOnly allBranches ∧
+    StageLossToRestorationTransition uncorrected allBranches := by
+  exact ⟨stageAtlasCell_visibleInvariant,
+    fun htransition hexact =>
+      stageTransition_sourceRefExact_upwardClosed htransition hexact,
+    fun htransition hempty =>
+      stageTransition_supportEmpty_upwardClosed htransition hempty,
+    fun htransition hrestored =>
+      stageTransition_exactRestoration_upwardClosed htransition hrestored,
+    fun htransition hexact =>
+      stageTransition_no_exact_to_protectedSupportLoss htransition hexact,
+    fun hstage => preAllStage_to_allBranches_lossToRestoration hstage,
+    obligationOnly_to_allBranches_lossToRestoration,
+    uncorrected_to_allBranches_lossToRestoration⟩
+
+end ParametrizedAtlasTransition
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-parametrized-atlas-transition.md
+++ b/research/ideas/g-aat-quality-surface-01-parametrized-atlas-transition.md
@@ -1,0 +1,108 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: transition / closure
+capability_category: certificate-transport / repair-potential / obstruction / traceability / invariance / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can list staged violations and fixes, but this theorem proves transition-level non-regression and loss-to-restoration crossing inside the parametrized atlas.
+origin: G-aat-quality-surface-01-cycle50
+tags: [quality-surface, atlas-transition, staged-correction, exact-locus, protected-support]
+created: 2026-06-21
+cycle: 50
+lean: proved-in-research
+---
+
+# Parametrized atlas transition theorem
+
+## 主張
+
+Cycle 49 の parametrized loss-aware atlas に stage transition を入れる。concrete staged correction relation に沿って source-ref exactness、protected-support emptiness、exact restoration は upward-closed であり、exact cell から protected-support loss cell へは遷移しない。さらに `allBranches` より前の stage は、`allBranches` へ遷移すると protected-support loss から exact restoration へ移る。
+
+## 候補種別
+
+`transition / closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean`
+- `Formal/AG/Research/QualitySurface/ParametrizedLossAwareAtlas.lean`
+
+## 非自明性
+
+Cycle 49 は stage ごとの atlas cell classification を固定した。Cycle 50 はその分類を transition-level に上げ、StageLe に沿う upward-closed 性質と loss-to-restoration crossing を theorem として束ねる。単なる locus 表ではなく、stage transition が exactness を後退させないことを明示する。
+
+## 数学的興味
+
+Quality Surface の repair trajectory は、点ごとの分類表だけでなく、transition に沿った non-regression / restoration crossing として読める。exactness と protected-support emptiness が upward-closed であることは、repair frontier を順序付き certificate transport として扱うための局所モデルになる。
+
+## GOAL への前進
+
+この候補は `certificate-transport`、`repair-potential`、`obstruction`、`traceability`、`invariance`、`quality-surface` を前進させる。Cycle 49 の open question だった parametrized atlas transition のうち、concrete `StageAtlasTransition` relation を進める。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は staged violations と fixes を列挙できるが、exactness / support-empty / restoration の transition-level upward closure や、pre-all stage から all-branches stage への protected-loss-to-restoration crossing を theorem として与えない。
+
+## SCORE 見込み
+
+- `score_reason`: parametrized atlas transition relation を進め、visible invariance、exact/support/restoration upward closure、no exact-to-loss regression、loss-to-restoration crossing witness を Lean で持つ。ただし Cycle 49 の locus theorem と concrete `StageLe` から自然に出る closure でもあるため、G2 判定に合わせて base70 とする。
+- `dullness_risk`: Cycle 49 の locus theorem を言い換えるだけだと弱い。transition relation `StageAtlasTransition`、non-regression theorem、loss-to-restoration transition witness を追加して transition-level の内容にする。
+- `proof_or_evidence_plan`: Lean file `ParametrizedAtlasTransition.lean` で proved-in-research。G2/G3/G4 監査後に report と Issue score を同期する。
+
+## CS / SWE への帰結
+
+repair stage view では、現在の cell classification だけでなく、stage transition が exactness を後退させないかを検査できる。ただしこれは tooling 実装 claim ではなく、concrete staged correction relation と finite parametrized atlas に相対化された theorem である。
+
+## 証明・根拠
+
+Lean file: `Formal/AG/Research/QualitySurface/ParametrizedAtlasTransition.lean`
+
+Proved declarations:
+
+- `StageAtlasCell`
+- `StageAtlasTransition`
+- `stageAtlasCell_visibleInvariant`
+- `stageTransition_sourceRefExact_upwardClosed`
+- `stageTransition_supportEmpty_upwardClosed`
+- `stageTransition_exactRestoration_upwardClosed`
+- `stageTransition_no_exact_to_protectedSupportLoss`
+- `StageLossToRestorationTransition`
+- `stageTransition_to_allBranches_of_not_allBranches`
+- `preAllStage_to_allBranches_lossToRestoration`
+- `obligationOnly_to_allBranches_lossToRestoration`
+- `uncorrected_to_allBranches_lossToRestoration`
+- `parametrizedAtlasTransition_package`
+
+Boundary:
+
+- concrete staged selected correction relation、finite parametrized loss-aware atlas に相対化する。
+- arbitrary atlas transition maps、baseline cell との transition、global repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+
+## 審判メモ
+
+- 厳密性: A は accept/base80。B/D/C は content accept だが base70 同期を要求。採用する base は 70。
+- 研究価値: Cycle 49 の staged locus theorem を concrete transition relation 上の upward closure / non-regression / loss-to-restoration crossing へ上げる。
+- repo 全体価値: parametrized atlas の cell-wise classification に transition-level reading を追加する。
+- ライバル比較: ADL / conformance checker との差分は、concrete `StageAtlasTransition` 上の non-regression と pre-all-to-allBranches crossing に限定する。
+
+## Verification
+
+- `lake env lean Formal/AG/Research/QualitySurface/ParametrizedAtlasTransition.lean`: pass
+- `lake build FormalAGResearch`: pass
+- forbidden-token scan for `sorry` / `admit` / `axiom` / `unsafe` / broad autoImplicit setting: pass
+- `.tmp/parametrized_atlas_transition_axioms.lean`: pass
+  - axiom-free: `stageAtlasCell_visibleInvariant`
+  - standard axioms only: transition upward-closure / crossing / package declarations depend only on `propext` / `Quot.sound`
+- G3 independent audit: pass; blocking findings none
+
+## 関連
+
+- Cycle 48: `Parametrized selected correction system`
+- Cycle 49: `Parametrized loss-aware atlas`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 50 候補として作成し、Lean 証明を追加。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 6250
+- total SCORE: 6390
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -54,8 +54,9 @@
   - certificate-transport / obstruction / repair-potential / traceability / quality-surface: 160
   - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
   - certificate-transport / obstruction / repair-potential / traceability / invariance / quality-surface: 140
+  - certificate-transport / repair-potential / obstruction / traceability / invariance / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 49
+  - proved-in-research: 50
 
 ## Phase synthesis
 
@@ -71,7 +72,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-49 件の Lean-proved research artifacts は、次の paper seed を形成している。
+50 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -114,8 +115,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 49 後の total SCORE は 6250 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 49 件持ち、
+Cycle 50 後の total SCORE は 6390 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 50 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2253,13 +2254,56 @@ repair stage parameter に沿って protected support と exact restoration locu
 主張は baseline cells + staged correction cells の finite atlas に限定され、任意の parametrized atlas や transition map までは主張しない。
 global repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、実コード全体の品質判定も結論しない。
 
+## Cycle 50: Parametrized atlas transition theorem
+
+```text
+candidate: Parametrized atlas transition theorem
+candidate_type: transition / closure
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: certificate-transport/repair-potential/obstruction/traceability/invariance/quality-surface
+goal_delta: Cycle 49 の staged atlas locus を concrete `StageAtlasTransition` relation 上の upward closure、non-regression、loss-to-restoration crossing として固定した。
+project_value_delta: parametrized atlas の cell-wise classification に transition-level reading を追加し、repair stage relation 上で exactness が後退しないことを Lean artifact とした。
+rival_delta: ADL / conformance checker は staged violation / fix candidate を列挙できるが、concrete stage transition 上の exactness non-regression と protected-loss-to-restoration crossing を theorem として与えない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch` は pass。transition theorem 系は標準 `propext` / `Quot.sound` のみに依存する。claim は concrete `StageAtlasTransition` relation に限定される。
+open_questions: generic selected support-defect localization、multi-route non-singleton correction systems、arbitrary atlas transition map theory。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ParametrizedAtlasTransition.lean` は、
+Cycle 49 の parametrized loss-aware atlas に concrete stage transition relation を追加する。
+`StageAtlasTransition left right` は Cycle 48 の `StageLe left right` に相対化された relation であり、
+任意の atlas transition map までは主張しない。
+
+Lean 証拠は次を固定する。
+
+- `stageAtlasCell_visibleInvariant`: staged atlas cell は stage に依らず visible-flat である。
+- `stageTransition_sourceRefExact_upwardClosed`: `StageAtlasTransition` に沿って source-ref exactness は upward-closed である。
+- `stageTransition_supportEmpty_upwardClosed`: protected-support emptiness も upward-closed である。
+- `stageTransition_exactRestoration_upwardClosed`: exact restoration cell であることも upward-closed である。
+- `stageTransition_no_exact_to_protectedSupportLoss`: exact staged cell から protected-support loss cell へは遷移しない。
+- `stageTransition_to_allBranches_of_not_allBranches`: pre-all stage は `allBranches` へ transition できる。
+- `preAllStage_to_allBranches_lossToRestoration`: pre-all stage から `allBranches` への transition は protected-support loss から exact restoration への crossing である。
+- `obligationOnly_to_allBranches_lossToRestoration` /
+  `uncorrected_to_allBranches_lossToRestoration`: concrete crossing witnesses。
+- `parametrizedAtlasTransition_package`: visible invariance、upward closure、non-regression、loss-to-restoration crossing を束ねる。
+
+この結果により、repair stage view は cell-wise classification だけでなく、
+transition relation 上の exactness non-regression と restoration crossing として読める。
+主張は concrete staged selected correction relation と finite parametrized loss-aware atlas に限定され、
+arbitrary atlas transition maps、baseline cell との transition、global repair planner、runtime patch synthesis、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 49 後の total SCORE は 6250 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 50 後の total SCORE は 6390 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 次フェーズへ進める場合は、lawful criterion の necessity / minimality、
 selected support-defect localization の generic theorem、
-parametrized atlas transition maps、
 または multi-route non-singleton correction systems を狙う。threshold 7000 には未達であるため、次 cycle へ進む。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 50 として、parametrized loss-aware atlas に concrete `StageAtlasTransition` relation を追加する Lean research artifact を追加しました。stage transition に沿う exactness / support-empty / exact restoration の upward closure、exact-to-protected-loss regression の禁止、pre-all stage から `allBranches` への loss-to-restoration crossing を証明しています。

tracking Issue は score 7000 まで継続するため、この PR では close しません。

## 証明した定理

- `stageAtlasCell_visibleInvariant`
- `stageTransition_sourceRefExact_upwardClosed`
- `stageTransition_supportEmpty_upwardClosed`
- `stageTransition_exactRestoration_upwardClosed`
- `stageTransition_no_exact_to_protectedSupportLoss`
- `stageTransition_to_allBranches_of_not_allBranches`
- `preAllStage_to_allBranches_lossToRestoration`
- `obligationOnly_to_allBranches_lossToRestoration`
- `uncorrected_to_allBranches_lossToRestoration`
- `parametrizedAtlasTransition_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-parametrized-atlas-transition.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/ParametrizedAtlasTransition.lean`
- [x] `lake env lean .tmp/parametrized_atlas_transition_axioms.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue 継続のため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
