### PR TITLE
Cycle 51: selected support-defect localization を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -49,3 +49,4 @@ import Formal.AG.Research.QualitySurface.SelectedRouteFamilyExactness
 import Formal.AG.Research.QualitySurface.ParametrizedSelectedCorrectionSystem
 import Formal.AG.Research.QualitySurface.ParametrizedLossAwareAtlas
 import Formal.AG.Research.QualitySurface.ParametrizedAtlasTransition
+import Formal.AG.Research.QualitySurface.SelectedSupportDefectLocalization

--- a/Formal/AG/Research/QualitySurface/SelectedSupportDefectLocalization.lean
+++ b/Formal/AG/Research/QualitySurface/SelectedSupportDefectLocalization.lean
@@ -1,0 +1,343 @@
+import Formal.AG.Research.QualitySurface.ParametrizedAtlasTransition
+
+/-!
+Cycle 51 evidence for `G-aat-quality-surface-01`.
+
+This file isolates selected support-defect localization as a generic
+certificate.  A localization covers every protected route defect by selected
+branches; under that cover, empty protected support is equivalent to agreement
+on all localized branches, and source-ref exactness is visible flatness plus
+localized branch agreement.  The generic criterion is instantiated for the
+visible route and for corrected selected routes.
+
+The claim is relative to supplied source-ref packets, selected protected
+components, and the explicit source-ref packet bridge.  It does not assert
+source extraction completeness, ArchMap correctness, global repair planning,
+runtime patch synthesis, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SelectedSupportDefectLocalization
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open SourceRefExactVisualizationCriterion
+open RouteDefectSupportTheory
+open ExactVisualizationCriterionMinimality
+open SelectedRouteDefectSupportHitting
+open SelectedRouteCorrectionExactness
+open SelectedRouteFamilyExactness
+open RouteDefectAtom
+open RouteDefectBranch
+open CorrectedRouteFamilyIndex
+
+/-! ## Generic route support localization -/
+
+/-- A branch localization that covers every protected route defect. -/
+structure RouteSupportLocalization
+    (left right : SourceRefPacket) where
+  Branch : Type
+  branchComponent : Branch -> SourceRefPacketProtectedComponent
+  covers :
+    ∀ component,
+      RouteDefectSupport left right component ->
+        ∃ branch, branchComponent branch = component
+
+/-- Agreement on every localized branch. -/
+def RouteLocalizationBranchesAgree
+    {left right : SourceRefPacket}
+    (localization : RouteSupportLocalization left right) : Prop :=
+  ∀ branch,
+    RouteComponentAgreement
+      left right (localization.branchComponent branch)
+
+/-- A localized branch carries a protected route defect. -/
+def LocalizedBranchDefect
+    {left right : SourceRefPacket}
+    (localization : RouteSupportLocalization left right)
+    (branch : localization.Branch) : Prop :=
+  RouteDefectSupport left right (localization.branchComponent branch)
+
+/--
+Under a support localization cover, empty protected support is equivalent to
+agreement on every localized branch.
+-/
+theorem routeSupportEmpty_iff_localizedBranches
+    {left right : SourceRefPacket}
+    (localization : RouteSupportLocalization left right) :
+    RouteDefectSupportEmpty left right ↔
+      RouteLocalizationBranchesAgree localization := by
+  constructor
+  · intro hempty branch
+    exact hempty (localization.branchComponent branch)
+  · intro hagree component
+    by_contra hcomponent
+    rcases localization.covers component hcomponent with ⟨branch, hbranch⟩
+    exact hcomponent (by
+      simpa [hbranch] using hagree branch)
+
+/--
+With a support localization cover, source-ref exactness is visible flatness plus
+agreement on every localized branch.
+-/
+theorem sourceRefExact_iff_visible_localizedBranches
+    {left right : SourceRefPacket}
+    (localization : RouteSupportLocalization left right) :
+    SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        left right ↔
+      TupleVisibleVisualizationEquivalent
+          SourceRefTupleBridge.endpointGridCertificate
+          SourceRefTupleBridge.endpointGridCertificate
+          left right ∧
+        RouteLocalizationBranchesAgree localization := by
+  have hsupport := routeSupportEmpty_iff_localizedBranches localization
+  constructor
+  · intro hexact
+    have hcriterion :=
+      (exactVisualization_iff_visible_emptyRouteSupport
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        left right).mp hexact
+    exact ⟨hcriterion.1, hsupport.mp hcriterion.2⟩
+  · intro hlocalized
+    exact (exactVisualization_iff_visible_emptyRouteSupport
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      left right).mpr
+      ⟨hlocalized.1, hsupport.mpr hlocalized.2⟩
+
+/-- Any localized branch defect obstructs source-ref exactness. -/
+theorem localizedBranchDefect_obstructs_sourceRefExact
+    {left right : SourceRefPacket}
+    (localization : RouteSupportLocalization left right)
+    (branch : localization.Branch)
+    (hdefect : LocalizedBranchDefect localization branch) :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      left right := by
+  intro hexact
+  have hempty :
+      RouteDefectSupportEmpty left right :=
+    (exactVisualization_requires_visible_and_emptyRouteSupport
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      hexact).2
+  exact hdefect (hempty (localization.branchComponent branch))
+
+/-! ## Concrete visible-route localization -/
+
+/-- Selected route-defect branches localize the visible repair/transport route support. -/
+def visibleRouteSupportLocalization :
+    RouteSupportLocalization visibleRouteLeft visibleRouteRight where
+  Branch := RouteDefectBranch
+  branchComponent := fun branch =>
+    routeDefectAtomComponent (routeDefectBranchAtom branch)
+  covers := by
+    intro component hdefect
+    cases component with
+    | obligation =>
+        exact ⟨obligationBranch, rfl⟩
+    | repairFrontier atom =>
+        cases atom with
+        | endpoint =>
+            exact False.elim
+              ((visibleRepairTransport_noRepairFrontierDefect_offStorage
+                CodeAtom.endpoint (by intro h; cases h)) hdefect)
+        | storage =>
+            exact ⟨storageRepairBranch, rfl⟩
+        | worker =>
+            exact False.elim
+              ((visibleRepairTransport_noRepairFrontierDefect_offStorage
+                CodeAtom.worker (by intro h; cases h)) hdefect)
+    | sourceRefTable atom =>
+        cases atom with
+        | endpoint =>
+            exact False.elim
+              ((visibleRepairTransport_noTableDefect_offStorage
+                CodeAtom.endpoint (by intro h; cases h)) hdefect)
+        | storage =>
+            exact ⟨storageTableBranch, rfl⟩
+        | worker =>
+            exact False.elim
+              ((visibleRepairTransport_noTableDefect_offStorage
+                CodeAtom.worker (by intro h; cases h)) hdefect)
+
+/-- The visible route source-ref exactness criterion localized to selected branches. -/
+theorem visibleRoute_exact_iff_visible_localizedBranches :
+    SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        visibleRouteLeft visibleRouteRight ↔
+      TupleVisibleVisualizationEquivalent
+          SourceRefTupleBridge.endpointGridCertificate
+          SourceRefTupleBridge.endpointGridCertificate
+          visibleRouteLeft visibleRouteRight ∧
+        RouteLocalizationBranchesAgree visibleRouteSupportLocalization :=
+  sourceRefExact_iff_visible_localizedBranches
+    visibleRouteSupportLocalization
+
+/-- The obligation branch is a localized visible-route defect. -/
+theorem visibleRoute_obligation_localizedDefect :
+    LocalizedBranchDefect
+      visibleRouteSupportLocalization obligationBranch :=
+  visibleRepairTransport_defectSupport_obligation
+
+/-- The visible route obligation localized defect obstructs source-ref exactness. -/
+theorem visibleRoute_obligationDefect_obstructs_sourceRefExact :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      visibleRouteLeft visibleRouteRight :=
+  localizedBranchDefect_obstructs_sourceRefExact
+    visibleRouteSupportLocalization obligationBranch
+    visibleRoute_obligation_localizedDefect
+
+/-! ## Concrete corrected-route localization -/
+
+/-- Selected route-defect branches localize every corrected selected route. -/
+def correctedRouteSupportLocalization
+    (correction : RouteDefectAtom -> Bool) :
+    RouteSupportLocalization
+      (correctedVisibleRouteLeft correction) visibleRouteRight where
+  Branch := RouteDefectBranch
+  branchComponent := fun branch =>
+    routeDefectAtomComponent (routeDefectBranchAtom branch)
+  covers := by
+    intro component hdefect
+    simpa [correctedRouteFamilyLeft, correctedRouteFamilyRight,
+      correctedRouteFamilyBranchComponent] using
+      (correctedRouteFamily_supportLocalized
+        correction corrected component hdefect)
+
+/-- Corrected route exactness localized to selected route-defect branches. -/
+theorem correctedRoute_exact_iff_visible_localizedBranches
+    (correction : RouteDefectAtom -> Bool) :
+    SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        (correctedVisibleRouteLeft correction) visibleRouteRight ↔
+      TupleVisibleVisualizationEquivalent
+          SourceRefTupleBridge.endpointGridCertificate
+          SourceRefTupleBridge.endpointGridCertificate
+          (correctedVisibleRouteLeft correction) visibleRouteRight ∧
+        RouteLocalizationBranchesAgree
+          (correctedRouteSupportLocalization correction) :=
+  sourceRefExact_iff_visible_localizedBranches
+    (correctedRouteSupportLocalization correction)
+
+/-- The all-hit correction agrees on every localized selected branch. -/
+theorem allRouteDefectCorrection_localizedBranchesAgree :
+    RouteLocalizationBranchesAgree
+      (correctedRouteSupportLocalization allRouteDefectCorrection) := by
+  intro branch
+  exact (correctedBranchAgreement_iff_hits
+    allRouteDefectCorrection branch).mpr
+    (allRouteDefectCorrection_hits_every_selectedRouteDefectSupport branch)
+
+/-- The obligation-only correction has a localized storage-repair defect. -/
+theorem obligationOnlyCorrection_storageRepair_localizedDefect :
+    LocalizedBranchDefect
+      (correctedRouteSupportLocalization obligationOnlyCorrection)
+      storageRepairBranch := by
+  intro hagree
+  exact obligationOnlyCorrection_misses_storageRepair
+    ((correctedBranchAgreement_iff_hits
+      obligationOnlyCorrection storageRepairBranch).mp hagree)
+
+/-- The localized storage-repair defect obstructs obligation-only exactness. -/
+theorem obligationOnlyCorrection_localizedDefect_obstructs_sourceRefExact :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight :=
+  localizedBranchDefect_obstructs_sourceRefExact
+    (correctedRouteSupportLocalization obligationOnlyCorrection)
+    storageRepairBranch
+    obligationOnlyCorrection_storageRepair_localizedDefect
+
+/-! ## Theorem package -/
+
+/--
+Cycle-51 theorem package: selected support-defect localization gives a generic
+route-level exactness criterion and branch-defect obstruction theorem, with
+visible-route and corrected-route concrete instances.
+-/
+theorem selectedSupportDefectLocalization_package :
+    (∀ {left right : SourceRefPacket}
+      (localization : RouteSupportLocalization left right),
+      RouteDefectSupportEmpty left right ↔
+        RouteLocalizationBranchesAgree localization) ∧
+    (∀ {left right : SourceRefPacket}
+      (localization : RouteSupportLocalization left right),
+      SourceRefExactVisualization
+          SourceRefTupleBridge.endpointGridCertificate
+          SourceRefTupleBridge.endpointGridCertificate
+          left right ↔
+        TupleVisibleVisualizationEquivalent
+            SourceRefTupleBridge.endpointGridCertificate
+            SourceRefTupleBridge.endpointGridCertificate
+            left right ∧
+          RouteLocalizationBranchesAgree localization) ∧
+    (∀ {left right : SourceRefPacket}
+      (localization : RouteSupportLocalization left right)
+      (branch : localization.Branch),
+      LocalizedBranchDefect localization branch ->
+        ¬ SourceRefExactVisualization
+          SourceRefTupleBridge.endpointGridCertificate
+          SourceRefTupleBridge.endpointGridCertificate
+          left right) ∧
+    (SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        visibleRouteLeft visibleRouteRight ↔
+      TupleVisibleVisualizationEquivalent
+          SourceRefTupleBridge.endpointGridCertificate
+          SourceRefTupleBridge.endpointGridCertificate
+          visibleRouteLeft visibleRouteRight ∧
+        RouteLocalizationBranchesAgree visibleRouteSupportLocalization) ∧
+    LocalizedBranchDefect
+      visibleRouteSupportLocalization obligationBranch ∧
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      visibleRouteLeft visibleRouteRight ∧
+    (∀ correction,
+      (SourceRefExactVisualization
+          SourceRefTupleBridge.endpointGridCertificate
+          SourceRefTupleBridge.endpointGridCertificate
+          (correctedVisibleRouteLeft correction) visibleRouteRight ↔
+        TupleVisibleVisualizationEquivalent
+            SourceRefTupleBridge.endpointGridCertificate
+            SourceRefTupleBridge.endpointGridCertificate
+            (correctedVisibleRouteLeft correction) visibleRouteRight ∧
+          RouteLocalizationBranchesAgree
+            (correctedRouteSupportLocalization correction))) ∧
+    RouteLocalizationBranchesAgree
+      (correctedRouteSupportLocalization allRouteDefectCorrection) ∧
+    LocalizedBranchDefect
+      (correctedRouteSupportLocalization obligationOnlyCorrection)
+      storageRepairBranch ∧
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (correctedVisibleRouteLeft obligationOnlyCorrection) visibleRouteRight := by
+  exact ⟨routeSupportEmpty_iff_localizedBranches,
+    sourceRefExact_iff_visible_localizedBranches,
+    fun localization branch hdefect =>
+      localizedBranchDefect_obstructs_sourceRefExact
+        localization branch hdefect,
+    visibleRoute_exact_iff_visible_localizedBranches,
+    visibleRoute_obligation_localizedDefect,
+    visibleRoute_obligationDefect_obstructs_sourceRefExact,
+    correctedRoute_exact_iff_visible_localizedBranches,
+    allRouteDefectCorrection_localizedBranchesAgree,
+    obligationOnlyCorrection_storageRepair_localizedDefect,
+    obligationOnlyCorrection_localizedDefect_obstructs_sourceRefExact⟩
+
+end SelectedSupportDefectLocalization
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-selected-support-defect-localization.md
+++ b/research/ideas/g-aat-quality-surface-01-selected-support-defect-localization.md
@@ -1,0 +1,111 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: localization / closure
+capability_category: obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can report component mismatches, but this theorem packages selected support-defect localization as a generic certificate with branch-level exactness and obstruction criteria.
+origin: G-aat-quality-surface-01-cycle51
+tags: [quality-surface, support-defect, localization, branch-obstruction, exactness]
+created: 2026-06-21
+cycle: 51
+lean: proved-in-research
+---
+
+# Selected support-defect localization
+
+## 主張
+
+selected branch localization が protected route defects を cover するなら、empty protected support は全 localized branch agreement に同値であり、source-ref exactness は visible tuple flatness と localized branch agreement に同値になる。さらに localized branch defect は source-ref exactness を阻む。generic theorem を visible route と corrected selected route の concrete localization に instantiation する。
+
+## 候補種別
+
+`localization / closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/SelectedRouteFamilyExactness.lean`
+- `Formal/AG/Research/QualitySurface/ParametrizedAtlasTransition.lean`
+
+## 非自明性
+
+Cycle 47 は family-level localization cover を持った。Cycle 51 は route-level localization certificate を `RouteSupportLocalization` として切り出し、empty support criterion、exactness criterion、branch-level obstruction theorem を generic に固定する。さらに visible route と corrected route の concrete localization を与えるため、単なる Cycle 47 の `∀ index` 再掲ではない。
+
+## 数学的興味
+
+support defect は「どの protected component が壊れたか」ではなく、「どの localized selected branch が exactness を阻むか」として読むことができる。localized branch defect が exactness obstruction になる定理により、branch-level obstruction geometry が route-level exactness criterion に接続される。
+
+## GOAL への前進
+
+この候補は `obstruction`、`certificate-transport`、`repair-potential`、`traceability`、`invariance`、`quality-surface` を前進させる。Next Frontier の `generic selected support-defect localization` を直接埋める。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は component mismatch を列挙できるが、その mismatch を selected branch localization certificate として束ね、branch defect が exactness obstruction になることを theorem として与えない。
+
+## SCORE 見込み
+
+- `score_reason`: generic `RouteSupportLocalization`、empty support iff localized branch agreement、source-ref exact iff visible plus localized branch agreement、branch-defect obstruction theorem、visible/corrected route instances を持つ。ただし中核 criterion は Cycle 47 の family localization と近いため、G2 の厳しめ判定に合わせて base70 とする。
+- `dullness_risk`: Cycle 47 の family theorem の再掲に留まる危険がある。route-level certificate structure、branch-level obstruction theorem、visible route instance、corrected route instance を含めて回避する。
+- `proof_or_evidence_plan`: Lean file `SelectedSupportDefectLocalization.lean` で proved-in-research。G2/G3/G4 監査後に report と Issue score を同期する。
+
+## CS / SWE への帰結
+
+diagnostic report の component mismatch は、selected branch localization certificate として読める。branch-level defect は exactness obstruction として扱えるため、repair planning ではなく obstruction explanation surface の theorem になる。
+
+## 証明・根拠
+
+Lean file: `Formal/AG/Research/QualitySurface/SelectedSupportDefectLocalization.lean`
+
+Proved declarations:
+
+- `RouteSupportLocalization`
+- `RouteLocalizationBranchesAgree`
+- `LocalizedBranchDefect`
+- `routeSupportEmpty_iff_localizedBranches`
+- `sourceRefExact_iff_visible_localizedBranches`
+- `localizedBranchDefect_obstructs_sourceRefExact`
+- `visibleRouteSupportLocalization`
+- `visibleRoute_exact_iff_visible_localizedBranches`
+- `visibleRoute_obligation_localizedDefect`
+- `visibleRoute_obligationDefect_obstructs_sourceRefExact`
+- `correctedRouteSupportLocalization`
+- `correctedRoute_exact_iff_visible_localizedBranches`
+- `allRouteDefectCorrection_localizedBranchesAgree`
+- `obligationOnlyCorrection_storageRepair_localizedDefect`
+- `obligationOnlyCorrection_localizedDefect_obstructs_sourceRefExact`
+- `selectedSupportDefectLocalization_package`
+
+Boundary:
+
+- supplied source-ref packets、selected protected components、explicit source-ref packet bridge に相対化する。
+- source extraction completeness、ArchMap correctness、global repair planning、runtime patch synthesis、whole-codebase quality は主張しない。
+
+## 審判メモ
+
+- 厳密性: A/C/D は accept/base80。B は accept/base70 とし、Cycle 47 の family localization と近いため G4/report は base70 に同期すべきと判定。採用する base は 70。
+- 研究価値: Cycle 47 を置き換えるのではなく、route-level localization certificate と branch-level obstruction theorem として切り出す。
+- repo 全体価値: visible route / corrected route の concrete localization instances を追加し、component mismatch を selected branch obstruction として読めるようにする。
+- ライバル比較: ADL / conformance checker との差分は、component mismatch list を selected branch localization certificate と exactness obstruction theorem に持ち上げる点に限定する。
+
+## Verification
+
+- `lake env lean Formal/AG/Research/QualitySurface/SelectedSupportDefectLocalization.lean`: pass
+- `lake build FormalAGResearch`: pass
+- forbidden-token scan for `sorry` / `admit` / `axiom` / `unsafe` / broad autoImplicit setting: pass
+- `.tmp/selected_support_defect_localization_axioms.lean`: pass
+  - axiom-free: `localizedBranchDefect_obstructs_sourceRefExact`, `visibleRoute_obligation_localizedDefect`, `visibleRoute_obligationDefect_obstructs_sourceRefExact`, `allRouteDefectCorrection_localizedBranchesAgree`, `obligationOnlyCorrection_storageRepair_localizedDefect`, `obligationOnlyCorrection_localizedDefect_obstructs_sourceRefExact`
+  - standard axioms only: generic cover criterion and package declarations depend only on `propext`, `Classical.choice`, `Quot.sound`
+- G3 independent audit: pass; blocking findings none
+
+## 関連
+
+- Cycle 47: `Selected route family exactness criterion`
+- Cycle 50: `Parametrized atlas transition theorem`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 51 候補として作成し、Lean 証明を追加。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 6390
+- total SCORE: 6530
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -55,8 +55,9 @@
   - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
   - certificate-transport / obstruction / repair-potential / traceability / invariance / quality-surface: 140
   - certificate-transport / repair-potential / obstruction / traceability / invariance / quality-surface: 140
+  - obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 50
+  - proved-in-research: 51
 
 ## Phase synthesis
 
@@ -72,7 +73,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-50 件の Lean-proved research artifacts は、次の paper seed を形成している。
+51 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -115,8 +116,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 50 後の total SCORE は 6390 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 50 件持ち、
+Cycle 51 後の total SCORE は 6530 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 51 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2298,12 +2299,56 @@ transition relation 上の exactness non-regression と restoration crossing と
 arbitrary atlas transition maps、baseline cell との transition、global repair planner、runtime patch synthesis、
 source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 51: Selected support-defect localization
+
+```text
+candidate: Selected support-defect localization
+candidate_type: localization / closure
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: obstruction/certificate-transport/repair-potential/traceability/invariance/quality-surface
+goal_delta: selected support-defect localization を route-level certificate として切り出し、localized branch agreement criterion と branch-level obstruction theorem を Lean で固定した。
+project_value_delta: Cycle 47 の family localization を置き換えるのではなく、visible route / corrected route の concrete instances を持つ route-level support-defect certificate surface を追加した。
+rival_delta: ADL / conformance checker は component mismatch を列挙できるが、selected branch localization certificate と branch defect exactness obstruction theorem としては与えない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch` は pass。generic cover criterion 系は標準 `propext` / `Classical.choice` / `Quot.sound` に依存し、branch obstruction と concrete defect witnesses は axiom-free。
+open_questions: multi-route non-singleton correction systems、minimality of localization covers、paper-level lawful criterion synthesis。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SelectedSupportDefectLocalization.lean` は、
+selected support-defect localization を `RouteSupportLocalization` として定義する。
+localization は protected route defect を selected branch component の像で cover する certificate である。
+
+Lean 証拠は次を固定する。
+
+- `routeSupportEmpty_iff_localizedBranches`: localization cover の下で、empty protected support は全 localized branch agreement と同値である。
+- `sourceRefExact_iff_visible_localizedBranches`: source-ref exactness は visible tuple flatness と localized branch agreement に同値である。
+- `localizedBranchDefect_obstructs_sourceRefExact`: localized branch defect は source-ref exactness を阻む。
+- `visibleRouteSupportLocalization`: visible repair/transport route の defects を selected route-defect branches で localize する。
+- `visibleRoute_exact_iff_visible_localizedBranches`: visible route の exactness criterion を localized branches で読む。
+- `visibleRoute_obligation_localizedDefect` /
+  `visibleRoute_obligationDefect_obstructs_sourceRefExact`: obligation branch defect が visible route exactness を阻む。
+- `correctedRouteSupportLocalization`: corrected selected route の protected defects を selected route-defect branches で localize する。
+- `correctedRoute_exact_iff_visible_localizedBranches`: corrected route exactness を localized branch agreement で読む。
+- `allRouteDefectCorrection_localizedBranchesAgree`: all-hit correction はすべての localized branches に agreement を与える。
+- `obligationOnlyCorrection_storageRepair_localizedDefect` /
+  `obligationOnlyCorrection_localizedDefect_obstructs_sourceRefExact`: obligation-only correction の storage-repair localized defect が exactness を阻む。
+- `selectedSupportDefectLocalization_package`: generic criterion、branch obstruction、visible/corrected concrete instances を束ねる。
+
+この結果により、component mismatch list は selected branch localization certificate として読める。
+Cycle 47 の family localization theorem を置き換えるのではなく、route-level certificate と branch-level obstruction theorem として切り出した成果である。
+主張は supplied source-ref packets、selected protected components、explicit source-ref packet bridge に相対化され、
+source extraction completeness、ArchMap correctness、global repair planning、runtime patch synthesis、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 50 後の total SCORE は 6390 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 51 後の total SCORE は 6530 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 次フェーズへ進める場合は、lawful criterion の necessity / minimality、
-selected support-defect localization の generic theorem、
 または multi-route non-singleton correction systems を狙う。threshold 7000 には未達であるため、次 cycle へ進む。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 51 として、selected support-defect localization を route-level certificate として切り出す Lean research artifact を追加しました。empty support / exactness の localized branch criterion と、localized branch defect が source-ref exactness を阻む obstruction theorem を証明し、visible route と corrected route に具体化しています。

tracking Issue は score 7000 まで継続するため、この PR では close しません。

## 証明した定理

- `routeSupportEmpty_iff_localizedBranches`
- `sourceRefExact_iff_visible_localizedBranches`
- `localizedBranchDefect_obstructs_sourceRefExact`
- `visibleRoute_exact_iff_visible_localizedBranches`
- `visibleRoute_obligation_localizedDefect`
- `visibleRoute_obligationDefect_obstructs_sourceRefExact`
- `correctedRoute_exact_iff_visible_localizedBranches`
- `allRouteDefectCorrection_localizedBranchesAgree`
- `obligationOnlyCorrection_storageRepair_localizedDefect`
- `obligationOnlyCorrection_localizedDefect_obstructs_sourceRefExact`
- `selectedSupportDefectLocalization_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-selected-support-defect-localization.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SelectedSupportDefectLocalization.lean`
- [x] `lake env lean .tmp/selected_support_defect_localization_axioms.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue 継続のため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
