### PR TITLE
Cycle 52: multi-route correction system を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -50,3 +50,4 @@ import Formal.AG.Research.QualitySurface.ParametrizedSelectedCorrectionSystem
 import Formal.AG.Research.QualitySurface.ParametrizedLossAwareAtlas
 import Formal.AG.Research.QualitySurface.ParametrizedAtlasTransition
 import Formal.AG.Research.QualitySurface.SelectedSupportDefectLocalization
+import Formal.AG.Research.QualitySurface.MultiRouteCorrectionSystem

--- a/Formal/AG/Research/QualitySurface/MultiRouteCorrectionSystem.lean
+++ b/Formal/AG/Research/QualitySurface/MultiRouteCorrectionSystem.lean
@@ -1,0 +1,201 @@
+import Formal.AG.Research.QualitySurface.SelectedSupportDefectLocalization
+
+/-!
+Cycle 52 evidence for `G-aat-quality-surface-01`.
+
+This file builds a non-singleton selected correction system with two route
+slots.  A two-route staged family is source-ref exact exactly when both route
+slots are at the all-branches stage.  Exactness is upward closed under
+componentwise stage order, and a mixed family shows that one exact route does
+not make the whole family exact.
+
+The claim is relative to the selected two-slot route family, staged selected
+correction semantics, and the explicit source-ref packet bridge.  It does not
+assert arbitrary multi-route planners, runtime patch synthesis, source
+extraction completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace MultiRouteCorrectionSystem
+
+open CodebaseTracePacket
+open SourceRefExactVisualizationCriterion
+open RouteDefectSupportTheory
+open SelectedRouteDefectSupportHitting
+open SelectedRouteCorrectionExactness
+open SelectedRouteFamilyExactness
+open ParametrizedSelectedCorrectionSystem
+open ParametrizedLossAwareAtlas
+open ParametrizedLossAwareCell
+open RepairStage
+
+/-! ## Two-route staged correction families -/
+
+/-- Two selected route slots in a non-singleton correction family. -/
+inductive RouteSlot where
+  | primary
+  | secondary
+  deriving DecidableEq, Fintype
+
+open RouteSlot
+
+/-- A staged correction assignment for two route slots. -/
+structure StagePair where
+  primaryStage : RepairStage
+  secondaryStage : RepairStage
+  deriving DecidableEq
+
+/-- Read a pair assignment at a route slot. -/
+def StagePair.stage (pair : StagePair) : RouteSlot -> RepairStage
+  | primary => pair.primaryStage
+  | secondary => pair.secondaryStage
+
+/-- Left packets of the two-route staged correction family. -/
+def pairFamilyLeft (pair : StagePair) : RouteSlot -> SourceRefPacket :=
+  fun slot => correctedVisibleRouteLeft (stagedCorrection (pair.stage slot))
+
+/-- Right packets of the two-route staged correction family. -/
+def pairFamilyRight : RouteSlot -> SourceRefPacket :=
+  fun _slot => visibleRouteRight
+
+/-- Source-ref exactness of the whole two-route family. -/
+def PairFamilySourceRefExact (pair : StagePair) : Prop :=
+  FamilySourceRefExact (pairFamilyLeft pair) pairFamilyRight
+
+/-- Both route slots are at the all-branches stage. -/
+def PairAllBranches (pair : StagePair) : Prop :=
+  pair.primaryStage = allBranches ∧
+    pair.secondaryStage = allBranches
+
+/-- The two-route family is exact exactly when both slots are all-branches. -/
+theorem pairFamilySourceRefExact_iff_allBranches
+    (pair : StagePair) :
+    PairFamilySourceRefExact pair ↔
+      PairAllBranches pair := by
+  constructor
+  · intro hexact
+    exact ⟨(stagedCorrection_exact_iff_allBranches
+        pair.primaryStage).mp (by
+          simpa [pairFamilyLeft, pairFamilyRight, StagePair.stage,
+            CorrectionSourceRefExact] using hexact primary),
+      (stagedCorrection_exact_iff_allBranches
+        pair.secondaryStage).mp (by
+          simpa [pairFamilyLeft, pairFamilyRight, StagePair.stage,
+            CorrectionSourceRefExact] using hexact secondary)⟩
+  · intro hall slot
+    cases slot with
+    | primary =>
+        simpa [PairFamilySourceRefExact, pairFamilyLeft, pairFamilyRight,
+          StagePair.stage, hall.1] using stagedCorrection_allBranches_exact
+    | secondary =>
+        simpa [PairFamilySourceRefExact, pairFamilyLeft, pairFamilyRight,
+          StagePair.stage, hall.2] using stagedCorrection_allBranches_exact
+
+/-! ## Componentwise stage order -/
+
+/-- Componentwise stage order for two-route correction families. -/
+def StagePairLe (left right : StagePair) : Prop :=
+  StageLe left.primaryStage right.primaryStage ∧
+    StageLe left.secondaryStage right.secondaryStage
+
+/-- If all-branches is below a stage, that stage is all-branches. -/
+theorem stageLe_allBranches_right
+    {stage : RepairStage}
+    (hle : StageLe allBranches stage) :
+    stage = allBranches := by
+  cases stage with
+  | uncorrected =>
+      cases hle
+  | obligationOnly =>
+      cases hle
+  | allBranches =>
+      rfl
+
+/-- Two-route family exactness is upward closed under componentwise stage order. -/
+theorem pairFamilySourceRefExact_upwardClosed
+    {left right : StagePair}
+    (hle : StagePairLe left right)
+    (hexact : PairFamilySourceRefExact left) :
+    PairFamilySourceRefExact right := by
+  have hallLeft :=
+    (pairFamilySourceRefExact_iff_allBranches left).mp hexact
+  apply (pairFamilySourceRefExact_iff_allBranches right).mpr
+  exact ⟨stageLe_allBranches_right (by
+      simpa [hallLeft.1] using hle.1),
+    stageLe_allBranches_right (by
+      simpa [hallLeft.2] using hle.2)⟩
+
+/-! ## Concrete all-hit and mixed two-route families -/
+
+/-- Both slots are restored. -/
+def allBranchesPair : StagePair where
+  primaryStage := allBranches
+  secondaryStage := allBranches
+
+/-- Only the primary slot is restored; the secondary slot is obligation-only. -/
+def mixedPair : StagePair where
+  primaryStage := allBranches
+  secondaryStage := obligationOnly
+
+/-- The all-branches pair is family exact. -/
+theorem allBranchesPair_sourceRefExact :
+    PairFamilySourceRefExact allBranchesPair :=
+  (pairFamilySourceRefExact_iff_allBranches allBranchesPair).mpr
+    ⟨rfl, rfl⟩
+
+/-- The mixed pair has an exact primary route. -/
+theorem mixedPair_primary_sourceRefExact :
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (pairFamilyLeft mixedPair primary) (pairFamilyRight primary) := by
+  simpa [pairFamilyLeft, pairFamilyRight, mixedPair, StagePair.stage]
+    using stagedCorrection_allBranches_exact
+
+/-- The mixed pair has a protected-support-loss secondary route. -/
+theorem mixedPair_secondary_protectedSupportLoss :
+    ParamProtectedSupportLossCell (stagedCorrectionCell obligationOnly) :=
+  stagedCell_protectedSupportLoss_of_not_allBranches (by intro h; cases h)
+
+/-- One exact route does not make the two-route family exact. -/
+theorem mixedPair_not_familySourceRefExact :
+    ¬ PairFamilySourceRefExact mixedPair := by
+  intro hexact
+  have hall :=
+    (pairFamilySourceRefExact_iff_allBranches mixedPair).mp hexact
+  cases hall.2
+
+/-! ## Theorem package -/
+
+/--
+Cycle-52 theorem package: a non-singleton staged correction family is exact
+exactly when every route slot is all-branches; exactness is upward closed under
+componentwise stage order; a mixed pair witnesses that a single exact route is
+not enough for family exactness.
+-/
+theorem multiRouteCorrectionSystem_package :
+    (∀ pair,
+      PairFamilySourceRefExact pair ↔
+        PairAllBranches pair) ∧
+    (∀ {left right},
+      StagePairLe left right ->
+        PairFamilySourceRefExact left ->
+          PairFamilySourceRefExact right) ∧
+    PairFamilySourceRefExact allBranchesPair ∧
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (pairFamilyLeft mixedPair primary) (pairFamilyRight primary) ∧
+    ParamProtectedSupportLossCell (stagedCorrectionCell obligationOnly) ∧
+    ¬ PairFamilySourceRefExact mixedPair := by
+  exact ⟨pairFamilySourceRefExact_iff_allBranches,
+    fun hle hexact => pairFamilySourceRefExact_upwardClosed hle hexact,
+    allBranchesPair_sourceRefExact,
+    mixedPair_primary_sourceRefExact,
+    mixedPair_secondary_protectedSupportLoss,
+    mixedPair_not_familySourceRefExact⟩
+
+end MultiRouteCorrectionSystem
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-multi-route-correction-system.md
+++ b/research/ideas/g-aat-quality-surface-01-multi-route-correction-system.md
@@ -1,0 +1,113 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: multi-route / closure
+capability_category: repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can mark individual routes as fixed, but this theorem proves that family exactness for a non-singleton staged correction system requires every route slot to reach all-branches.
+origin: G-aat-quality-surface-01-cycle52
+tags: [quality-surface, multi-route, correction-system, exact-locus, family-exactness]
+created: 2026-06-21
+cycle: 52
+lean: proved-in-research
+---
+
+# Multi-route correction system
+
+## 主張
+
+二つの selected route slot を持つ staged correction family を定義する。この non-singleton family は、両 slot が `allBranches` stage にあるとき、かつそのときに限って family source-ref exact である。componentwise stage order に沿って family exactness は upward-closed であり、片方の route が exact でも mixed family 全体は exact ではない。
+
+## 候補種別
+
+`multi-route / closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/SelectedRouteFamilyExactness.lean`
+- `Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean`
+- `Formal/AG/Research/QualitySurface/SelectedSupportDefectLocalization.lean`
+
+## 非自明性
+
+Cycle 48 は単一 staged correction system、Cycle 51 は route-level localization を扱った。Cycle 52 は route slot を二つに増やし、family exactness が各 slot の exactness の合成であるだけでなく、全 slot が all-hit stage に到達する必要があることを finite non-singleton witness として示す。mixed pair は「一つの route が exact」という局所成功が family exactness には足りないことを固定する。
+
+## 数学的興味
+
+quality surface の repair trajectory は、単一 route の exactness ではなく selected route family 全体の exactness locus として読む必要がある。componentwise stage order で exactness が upward-closed になることは、multi-route repair frontier を certificate geometry として扱う最小モデルになる。
+
+## GOAL への前進
+
+この候補は `repair-potential`、`obstruction`、`certificate-transport`、`traceability`、`invariance`、`quality-surface` を前進させる。Next Frontier の `multi-route non-singleton correction systems` を直接進める。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は route ごとの violation / fixed 状態を表示できるが、non-singleton family exactness がすべての route slot の all-hit stage を要求する theorem としては与えない。
+
+## SCORE 見込み
+
+- `score_reason`: non-singleton route family、family exactness iff both slots all-branches、componentwise upward closure、mixed pair counterexample を Lean で持つ。ただし同じ staged correction route schema を二つの slot に置いた finite witness で、任意 finite non-singleton theorem までは出ていないため、G2 判定に合わせて base70 とする。
+- `dullness_risk`: 単に `∀ slot` の包装だと弱い。`StagePairLe`、`pairFamilySourceRefExact_upwardClosed`、`mixedPair_primary_sourceRefExact`、`mixedPair_not_familySourceRefExact` を含め、局所 exact と family exact の分離を入れる。
+- `proof_or_evidence_plan`: Lean file `MultiRouteCorrectionSystem.lean` で proved-in-research。G2/G3/G4 監査後に report と Issue score を同期する。
+
+## CS / SWE への帰結
+
+multi-route repair dashboard では、一つの route が exact でも family exact とは限らない。全 selected route slot が required correction stage に到達したときだけ family exactness が成立する、という certificate-level gate になる。
+
+## 証明・根拠
+
+Lean file: `Formal/AG/Research/QualitySurface/MultiRouteCorrectionSystem.lean`
+
+Proved declarations:
+
+- `RouteSlot`
+- `StagePair`
+- `StagePair.stage`
+- `pairFamilyLeft`
+- `pairFamilyRight`
+- `PairFamilySourceRefExact`
+- `PairAllBranches`
+- `pairFamilySourceRefExact_iff_allBranches`
+- `StagePairLe`
+- `stageLe_allBranches_right`
+- `pairFamilySourceRefExact_upwardClosed`
+- `allBranchesPair`
+- `mixedPair`
+- `allBranchesPair_sourceRefExact`
+- `mixedPair_primary_sourceRefExact`
+- `mixedPair_secondary_protectedSupportLoss`
+- `mixedPair_not_familySourceRefExact`
+- `multiRouteCorrectionSystem_package`
+
+Boundary:
+
+- selected two-slot route family、staged selected correction semantics、explicit source-ref packet bridge に相対化する。
+- 異種 route 間の相互作用、arbitrary multi-route planners、runtime patch synthesis、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+
+## 審判メモ
+
+- 厳密性: A/C は accept/base80。B は accept/base70、D は score 同期 revise/base70。採用する base は 70。
+- 研究価値: 同じ staged correction route schema を二つの slot に置いた non-singleton family exactness witness として扱う。
+- repo 全体価値: single-route exactness と family exactnessを分離し、mixed pair により局所 exact では family exact にならないことを固定する。
+- ライバル比較: ADL / conformance checker との差分は per-route fixed 表示ではなく certificate-level family exactness gate を theorem 化する点に限定する。
+
+## Verification
+
+- `lake env lean Formal/AG/Research/QualitySurface/MultiRouteCorrectionSystem.lean`: pass
+- `lake build FormalAGResearch`: pass
+- forbidden-token scan for `sorry` / `admit` / `axiom` / `unsafe` / broad autoImplicit setting: pass
+- `.tmp/multi_route_correction_system_axioms.lean`: pass
+  - standard axioms only: package and supporting declarations depend only on `propext` / `Quot.sound`
+- G3 independent audit: pass; blocking findings none
+
+## 関連
+
+- Cycle 48: `Parametrized selected correction system`
+- Cycle 51: `Selected support-defect localization`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 52 候補として作成し、Lean 証明を追加。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 6530
+- total SCORE: 6670
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -56,8 +56,9 @@
   - certificate-transport / obstruction / repair-potential / traceability / invariance / quality-surface: 140
   - certificate-transport / repair-potential / obstruction / traceability / invariance / quality-surface: 140
   - obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface: 140
+  - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 51
+  - proved-in-research: 52
 
 ## Phase synthesis
 
@@ -73,7 +74,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-51 件の Lean-proved research artifacts は、次の paper seed を形成している。
+52 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -116,8 +117,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 51 後の total SCORE は 6530 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 51 件持ち、
+Cycle 52 後の total SCORE は 6670 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 52 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2344,11 +2345,53 @@ Cycle 47 の family localization theorem を置き換えるのではなく、rou
 主張は supplied source-ref packets、selected protected components、explicit source-ref packet bridge に相対化され、
 source extraction completeness、ArchMap correctness、global repair planning、runtime patch synthesis、実コード全体の品質判定は結論しない。
 
+## Cycle 52: Multi-route correction system
+
+```text
+candidate: Multi-route correction system
+candidate_type: multi-route / closure
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: repair-potential/obstruction/certificate-transport/traceability/invariance/quality-surface
+goal_delta: 同じ staged correction route schema を二つの slot に置いた non-singleton family を定義し、family exactness が両 slot の all-branches stage を要求することを固定した。
+project_value_delta: single-route exactness と family exactness を分離し、mixed pair により一つの route が exact でも family exactness には足りないことを Lean finite witness とした。
+rival_delta: ADL / conformance checker は per-route fixed 表示を出せるが、non-singleton family exactness の all-slot gate を theorem としては与えない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch` は pass。package と supporting declarations は標準 `propext` / `Quot.sound` のみに依存する。claim は同じ staged route schema の two-slot finite witness に限定される。
+open_questions: arbitrary finite non-singleton family exact locus、minimal failing slot theorem、heterogeneous route interaction。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/MultiRouteCorrectionSystem.lean` は、
+`primary` / `secondary` の二つの `RouteSlot` を持つ staged correction family を定義する。
+各 slot は同じ staged selected correction route schema を持つが、stage assignment は `StagePair` で別々に与える。
+
+Lean 証拠は次を固定する。
+
+- `pairFamilySourceRefExact_iff_allBranches`: two-route family が source-ref exact であることは、primary / secondary の両 slot が `allBranches` stage にあることと同値である。
+- `StagePairLe` /
+  `pairFamilySourceRefExact_upwardClosed`: componentwise stage order に沿って family exactness は upward-closed である。
+- `allBranchesPair_sourceRefExact`: 両 slot が `allBranches` の pair は family exact である。
+- `mixedPair_primary_sourceRefExact`: mixed pair では primary route は exact である。
+- `mixedPair_secondary_protectedSupportLoss`: mixed pair の secondary route は protected-support loss である。
+- `mixedPair_not_familySourceRefExact`: mixed pair は family exact ではない。
+- `multiRouteCorrectionSystem_package`: exact locus、upward closure、all-hit pair、mixed-pair separation を束ねる。
+
+この結果により、single-route exactness と family exactness が分離される。
+一つの route slot が exact でも、selected route family 全体の exactness gate は全 slot の required stage を要求する。
+主張は同じ staged correction route schema を two slot に置いた finite witness であり、
+異種 route 間の相互作用、arbitrary multi-route planners、runtime patch synthesis、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 51 後の total SCORE は 6530 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 52 後の total SCORE は 6670 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 次フェーズへ進める場合は、lawful criterion の necessity / minimality、
-または multi-route non-singleton correction systems を狙う。threshold 7000 には未達であるため、次 cycle へ進む。
+arbitrary finite non-singleton family exact locus、
+または minimal failing slot theorem を狙う。threshold 7000 には未達であるため、次 cycle へ進む。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 52 として、二つの route slot を持つ staged correction family の Lean research artifact を追加しました。family exactness が両 slot の `allBranches` を要求すること、componentwise stage order で upward-closed であること、mixed pair では primary route が exact でも family exact ではないことを証明しています。

tracking Issue は score 7000 まで継続するため、この PR では close しません。

## 証明した定理

- `pairFamilySourceRefExact_iff_allBranches`
- `stageLe_allBranches_right`
- `pairFamilySourceRefExact_upwardClosed`
- `allBranchesPair_sourceRefExact`
- `mixedPair_primary_sourceRefExact`
- `mixedPair_secondary_protectedSupportLoss`
- `mixedPair_not_familySourceRefExact`
- `multiRouteCorrectionSystem_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-multi-route-correction-system.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/MultiRouteCorrectionSystem.lean`
- [x] `lake env lean .tmp/multi_route_correction_system_axioms.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue 継続のため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
