### PR TITLE
Cycle 53: route family exact locus を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -51,3 +51,4 @@ import Formal.AG.Research.QualitySurface.ParametrizedLossAwareAtlas
 import Formal.AG.Research.QualitySurface.ParametrizedAtlasTransition
 import Formal.AG.Research.QualitySurface.SelectedSupportDefectLocalization
 import Formal.AG.Research.QualitySurface.MultiRouteCorrectionSystem
+import Formal.AG.Research.QualitySurface.FiniteRouteFamilyExactLocus

--- a/Formal/AG/Research/QualitySurface/FiniteRouteFamilyExactLocus.lean
+++ b/Formal/AG/Research/QualitySurface/FiniteRouteFamilyExactLocus.lean
@@ -1,0 +1,174 @@
+import Formal.AG.Research.QualitySurface.MultiRouteCorrectionSystem
+
+/-!
+Cycle 53 evidence for `G-aat-quality-surface-01`.
+
+This file generalizes the two-route staged correction family to an arbitrary
+route-slot family.  A staged assignment is family source-ref exact exactly when
+every route slot is at the all-branches stage.  Exactness is upward closed
+under pointwise stage order, and any failing slot obstructs family exactness.
+
+The claim is relative to supplied route slots, staged selected correction
+semantics, and the explicit source-ref packet bridge.  It does not assert an
+arbitrary repair planner, runtime patch synthesis, source extraction
+completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace FiniteRouteFamilyExactLocus
+
+open CodebaseTracePacket
+open SourceRefExactVisualizationCriterion
+open RouteDefectSupportTheory
+open SelectedRouteDefectSupportHitting
+open SelectedRouteFamilyExactness
+open ParametrizedSelectedCorrectionSystem
+open ParametrizedLossAwareAtlas
+open MultiRouteCorrectionSystem
+open RepairStage
+open RouteSlot
+
+universe u
+
+/-! ## Arbitrary route-slot staged assignments -/
+
+/-- A staged selected correction assignment over a route-slot family. -/
+abbrev StageAssignment (Slot : Type u) :=
+  Slot -> RepairStage
+
+/-- Left packets for a staged route-slot family. -/
+def assignmentFamilyLeft {Slot : Type u}
+    (assignment : StageAssignment Slot) : Slot -> SourceRefPacket :=
+  fun slot => correctedVisibleRouteLeft (stagedCorrection (assignment slot))
+
+/-- Right packets for a staged route-slot family. -/
+def assignmentFamilyRight {Slot : Type u} : Slot -> SourceRefPacket :=
+  fun _slot => visibleRouteRight
+
+/-- Source-ref exactness of a staged route-slot family. -/
+def AssignmentFamilySourceRefExact {Slot : Type u}
+    (assignment : StageAssignment Slot) : Prop :=
+  FamilySourceRefExact
+    (assignmentFamilyLeft assignment) assignmentFamilyRight
+
+/-- Every route slot is at the all-branches stage. -/
+def AssignmentAllBranches {Slot : Type u}
+    (assignment : StageAssignment Slot) : Prop :=
+  ∀ slot, assignment slot = allBranches
+
+/-- A staged route-slot family is exact exactly when every slot is all-branches. -/
+theorem assignmentFamilySourceRefExact_iff_allBranches {Slot : Type u}
+    (assignment : StageAssignment Slot) :
+    AssignmentFamilySourceRefExact assignment ↔
+      AssignmentAllBranches assignment := by
+  constructor
+  · intro hexact slot
+    exact (stagedCorrection_exact_iff_allBranches
+      (assignment slot)).mp (by
+        simpa [AssignmentFamilySourceRefExact, assignmentFamilyLeft,
+          assignmentFamilyRight, CorrectionSourceRefExact] using hexact slot)
+  · intro hall slot
+    simpa [AssignmentFamilySourceRefExact, assignmentFamilyLeft,
+      assignmentFamilyRight, CorrectionSourceRefExact, hall slot]
+      using stagedCorrection_allBranches_exact
+
+/-! ## Pointwise stage order -/
+
+/-- Pointwise stage order on staged route-slot assignments. -/
+def AssignmentLe {Slot : Type u}
+    (left right : StageAssignment Slot) : Prop :=
+  ∀ slot, StageLe (left slot) (right slot)
+
+/-- Family exactness is upward closed under pointwise stage order. -/
+theorem assignmentFamilySourceRefExact_upwardClosed {Slot : Type u}
+    {left right : StageAssignment Slot}
+    (hle : AssignmentLe left right)
+    (hexact : AssignmentFamilySourceRefExact left) :
+    AssignmentFamilySourceRefExact right := by
+  have hallLeft :=
+    (assignmentFamilySourceRefExact_iff_allBranches left).mp hexact
+  apply (assignmentFamilySourceRefExact_iff_allBranches right).mpr
+  intro slot
+  exact stageLe_allBranches_right (by
+    simpa [hallLeft slot] using hle slot)
+
+/-- A failing slot obstructs exactness of the whole route-slot family. -/
+theorem failingSlot_obstructs_assignmentFamilyExact {Slot : Type u}
+    (assignment : StageAssignment Slot)
+    (slot : Slot)
+    (hslot : assignment slot ≠ allBranches) :
+    ¬ AssignmentFamilySourceRefExact assignment := by
+  intro hexact
+  have hall :=
+    (assignmentFamilySourceRefExact_iff_allBranches assignment).mp hexact
+  exact hslot (hall slot)
+
+/-! ## Concrete mixed finite assignment as an instance -/
+
+/-- The mixed two-slot assignment from Cycle 52 as an arbitrary-family instance. -/
+def mixedRouteSlotAssignment : StageAssignment RouteSlot
+  | primary => allBranches
+  | secondary => obligationOnly
+
+/-- The mixed assignment has an exact primary slot. -/
+theorem mixedRouteSlotAssignment_primary_sourceRefExact :
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (assignmentFamilyLeft mixedRouteSlotAssignment primary)
+      (assignmentFamilyRight primary) := by
+  simpa [assignmentFamilyLeft, assignmentFamilyRight,
+    mixedRouteSlotAssignment, CorrectionSourceRefExact]
+    using stagedCorrection_allBranches_exact
+
+/-- The secondary slot is a failing slot in the mixed assignment. -/
+theorem mixedRouteSlotAssignment_secondary_fails :
+    mixedRouteSlotAssignment secondary ≠ allBranches := by
+  intro hstage
+  cases hstage
+
+/-- The mixed assignment is not family exact. -/
+theorem mixedRouteSlotAssignment_not_familyExact :
+    ¬ AssignmentFamilySourceRefExact mixedRouteSlotAssignment :=
+  failingSlot_obstructs_assignmentFamilyExact
+    mixedRouteSlotAssignment secondary
+    mixedRouteSlotAssignment_secondary_fails
+
+/-! ## Theorem package -/
+
+/--
+Cycle-53 theorem package: arbitrary staged route-slot families are exact
+exactly when every slot is all-branches; exactness is upward closed under
+pointwise stage order; any failing slot obstructs family exactness.
+-/
+theorem finiteRouteFamilyExactLocus_package :
+    (∀ {Slot : Type u} (assignment : StageAssignment Slot),
+      AssignmentFamilySourceRefExact assignment ↔
+        AssignmentAllBranches assignment) ∧
+    (∀ {Slot : Type u} {left right : StageAssignment Slot},
+      AssignmentLe left right ->
+        AssignmentFamilySourceRefExact left ->
+          AssignmentFamilySourceRefExact right) ∧
+    (∀ {Slot : Type u} (assignment : StageAssignment Slot) (slot : Slot),
+      assignment slot ≠ allBranches ->
+        ¬ AssignmentFamilySourceRefExact assignment) ∧
+    SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      (assignmentFamilyLeft mixedRouteSlotAssignment primary)
+      (assignmentFamilyRight primary) ∧
+    mixedRouteSlotAssignment secondary ≠ allBranches ∧
+    ¬ AssignmentFamilySourceRefExact mixedRouteSlotAssignment := by
+  exact ⟨assignmentFamilySourceRefExact_iff_allBranches,
+    fun hle hexact =>
+      assignmentFamilySourceRefExact_upwardClosed hle hexact,
+    fun assignment slot hslot =>
+      failingSlot_obstructs_assignmentFamilyExact assignment slot hslot,
+    mixedRouteSlotAssignment_primary_sourceRefExact,
+    mixedRouteSlotAssignment_secondary_fails,
+    mixedRouteSlotAssignment_not_familyExact⟩
+
+end FiniteRouteFamilyExactLocus
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-finite-route-family-exact-locus.md
+++ b/research/ideas/g-aat-quality-surface-01-finite-route-family-exact-locus.md
@@ -1,0 +1,108 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: family-exact-locus / closure
+capability_category: repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can show per-route fixed status, but this theorem proves the exact locus and failing-slot obstruction for arbitrary staged route-slot families.
+origin: G-aat-quality-surface-01-cycle53
+tags: [quality-surface, route-family, exact-locus, failing-slot, staged-correction]
+created: 2026-06-21
+cycle: 53
+lean: proved-in-research
+---
+
+# Finite route-family exact locus
+
+## 主張
+
+任意の route slot family `Slot -> RepairStage` について、family source-ref exactness はすべての slot が `allBranches` stage にあることと同値である。pointwise stage order に沿って family exactness は upward-closed であり、任意の failing slot は family exactness を阻む。Cycle 52 の mixed pair はこの arbitrary family theorem の concrete instance になる。
+
+## 候補種別
+
+`family-exact-locus / closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/MultiRouteCorrectionSystem.lean`
+- `Formal/AG/Research/QualitySurface/SelectedRouteFamilyExactness.lean`
+
+## 非自明性
+
+Cycle 52 は two-slot finite witness だった。Cycle 53 は route slot type を任意にし、exact locus、pointwise upward closure、failing-slot obstruction を一括して証明する。これにより non-singleton の finite witness から arbitrary staged route-slot family の theorem へ進む。
+
+## 数学的興味
+
+family exactness は slot ごとの exactness を単に眺めるのではなく、全 slot の stage assignment が `allBranches` fiber に入る exact locus として読める。failing slot theorem は、family exactness failure を局所化するための次の minimality theorem の土台になる。
+
+## GOAL への前進
+
+この候補は `repair-potential`、`obstruction`、`certificate-transport`、`traceability`、`invariance`、`quality-surface` を前進させる。Cycle 52 の open question だった arbitrary finite non-singleton family exact locus を直接進める。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は route ごとの fixed status を表示できるが、arbitrary staged route-slot family の exact locus と failing-slot obstruction theorem は与えない。
+
+## SCORE 見込み
+
+- `score_reason`: arbitrary route-slot assignment、exact locus iff all slots all-branches、pointwise upward closure、failing-slot obstruction、mixed assignment instance を Lean で持つ。ただし既存 staged correction exactness と `FamilySourceRefExact` の pointwise 性から自然に出る面も強いため、G2 の厳しめ判定に合わせて base70 とする。
+- `dullness_risk`: Cycle 52 の two-slot theorem の単純拡張に見える危険がある。任意 `Slot`、pointwise order、failing-slot obstruction theorem を加え、次の minimal failing slot theorem への接続を作る。
+- `proof_or_evidence_plan`: Lean file `FiniteRouteFamilyExactLocus.lean` で proved-in-research。G2/G3/G4 監査後に report と Issue score を同期する。
+
+## CS / SWE への帰結
+
+route family repair status は、per-route green check の一覧ではなく、全 slot が required correction stage に入ったかを判定する exact locus になる。任意の failing slot は family exactness failure の witness になる。
+
+## 証明・根拠
+
+Lean file: `Formal/AG/Research/QualitySurface/FiniteRouteFamilyExactLocus.lean`
+
+Proved declarations:
+
+- `StageAssignment`
+- `assignmentFamilyLeft`
+- `assignmentFamilyRight`
+- `AssignmentFamilySourceRefExact`
+- `AssignmentAllBranches`
+- `assignmentFamilySourceRefExact_iff_allBranches`
+- `AssignmentLe`
+- `assignmentFamilySourceRefExact_upwardClosed`
+- `failingSlot_obstructs_assignmentFamilyExact`
+- `mixedRouteSlotAssignment`
+- `mixedRouteSlotAssignment_primary_sourceRefExact`
+- `mixedRouteSlotAssignment_secondary_fails`
+- `mixedRouteSlotAssignment_not_familyExact`
+- `finiteRouteFamilyExactLocus_package`
+
+Boundary:
+
+- supplied route slots、staged selected correction semantics、explicit source-ref packet bridge に相対化する。Lean statement は `Slot : Type u` 全般であり、finite family を含むが finite enumeration / computable scan は主張しない。
+- arbitrary repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+
+## 審判メモ
+
+- 厳密性: A/B/C は accept/base80。D は content accept だが score 同期 revise/base70。採用する base は 70。
+- 研究価値: Cycle 52 の two-slot witness を `Slot -> RepairStage` の general family exact locus へ上げる。
+- repo 全体価値: failing slot が family exactness failure の witness になる theorem を追加する。
+- ライバル比較: ADL / conformance checker との差分は per-route fixed status ではなく family exact locus と failing-slot obstruction theorem に限定する。
+
+## Verification
+
+- `lake env lean Formal/AG/Research/QualitySurface/FiniteRouteFamilyExactLocus.lean`: pass
+- `lake build FormalAGResearch`: pass
+- forbidden-token scan for `sorry` / `admit` / `axiom` / `unsafe` / broad autoImplicit setting: pass
+- `.tmp/finite_route_family_exact_locus_axioms.lean`: pass
+  - axiom-free: `mixedRouteSlotAssignment_secondary_fails`
+  - standard axioms only: exact-locus / upward-closure / failing-slot declarations and package depend only on `propext` / `Quot.sound`
+- G3 independent audit: pass; blocking findings none
+
+## 関連
+
+- Cycle 52: `Multi-route correction system`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 53 候補として作成し、Lean 証明を追加。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 6670
+- total SCORE: 6810
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -57,8 +57,9 @@
   - certificate-transport / repair-potential / obstruction / traceability / invariance / quality-surface: 140
   - obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface: 140
   - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
+  - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 52
+  - proved-in-research: 53
 
 ## Phase synthesis
 
@@ -74,7 +75,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-52 件の Lean-proved research artifacts は、次の paper seed を形成している。
+53 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -117,8 +118,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 52 後の total SCORE は 6670 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 52 件持ち、
+Cycle 53 後の total SCORE は 6810 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 53 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2386,12 +2387,52 @@ Lean 証拠は次を固定する。
 異種 route 間の相互作用、arbitrary multi-route planners、runtime patch synthesis、
 source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 53: Finite route-family exact locus
+
+```text
+candidate: Finite route-family exact locus
+candidate_type: family-exact-locus / closure
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: repair-potential/obstruction/certificate-transport/traceability/invariance/quality-surface
+goal_delta: Cycle 52 の two-slot witness を `Slot -> RepairStage` の route-slot family exact locus theorem へ上げ、failing slot obstruction を固定した。
+project_value_delta: family exactness failure を任意 slot の failing-stage witness で説明できる theorem surface を追加し、minimal failing slot theorem の準備を作った。
+rival_delta: ADL / conformance checker は per-route fixed status を表示できるが、family exact locus と failing-slot obstruction theorem は与えない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch` は pass。exact-locus / upward-closure / failing-slot declarations は標準 `propext` / `Quot.sound` のみに依存する。Lean statement は `Slot : Type u` 全般であり、finite enumeration や computable scan は主張しない。
+open_questions: minimal failing slot theorem、heterogeneous route interaction、computable finite scan instance。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/FiniteRouteFamilyExactLocus.lean` は、
+staged assignment `Slot -> RepairStage` に対する route-slot family exact locus を定義する。
+Lean statement は `Slot : Type u` 全般であり、finite family を含むが、finite enumeration や computable scan までは主張しない。
+
+Lean 証拠は次を固定する。
+
+- `assignmentFamilySourceRefExact_iff_allBranches`: staged route-slot family が source-ref exact であることは、すべての slot が `allBranches` stage にあることと同値である。
+- `AssignmentLe` /
+  `assignmentFamilySourceRefExact_upwardClosed`: pointwise stage order に沿って family exactness は upward-closed である。
+- `failingSlot_obstructs_assignmentFamilyExact`: 任意の failing slot は family exactness を阻む。
+- `mixedRouteSlotAssignment_primary_sourceRefExact`: mixed assignment の primary slot は exact である。
+- `mixedRouteSlotAssignment_secondary_fails` /
+  `mixedRouteSlotAssignment_not_familyExact`: secondary slot の failure が mixed assignment の family exactness を阻む。
+- `finiteRouteFamilyExactLocus_package`: exact locus、upward closure、failing-slot obstruction、mixed assignment instance を束ねる。
+
+この結果により、route family の修復状態は per-route fixed status ではなく、
+全 slot が required stage に入る exact locus として読める。
+主張は supplied route slots、staged selected correction semantics、explicit source-ref packet bridge に相対化され、
+arbitrary repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 52 後の total SCORE は 6670 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 53 後の total SCORE は 6810 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 次フェーズへ進める場合は、lawful criterion の necessity / minimality、
-arbitrary finite non-singleton family exact locus、
-または minimal failing slot theorem を狙う。threshold 7000 には未達であるため、次 cycle へ進む。
+minimal failing slot theorem、
+または computable finite scan instance を狙う。threshold 7000 には未達であるため、次 cycle へ進む。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 53 として、staged route-slot family の exact locus theorem を追加しました。`Slot -> RepairStage` の assignment について、family exactness が全 slot の `allBranches` と同値であること、pointwise order で upward-closed であること、任意の failing slot が family exactness を阻むことを証明しています。

tracking Issue は score 7000 まで継続するため、この PR では close しません。

## 証明した定理

- `assignmentFamilySourceRefExact_iff_allBranches`
- `assignmentFamilySourceRefExact_upwardClosed`
- `failingSlot_obstructs_assignmentFamilyExact`
- `mixedRouteSlotAssignment_primary_sourceRefExact`
- `mixedRouteSlotAssignment_secondary_fails`
- `mixedRouteSlotAssignment_not_familyExact`
- `finiteRouteFamilyExactLocus_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-finite-route-family-exact-locus.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/FiniteRouteFamilyExactLocus.lean`
- [x] `lake env lean .tmp/finite_route_family_exact_locus_axioms.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue 継続のため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
