### PR TITLE
研究: failing slot certificateを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -52,3 +52,4 @@ import Formal.AG.Research.QualitySurface.ParametrizedAtlasTransition
 import Formal.AG.Research.QualitySurface.SelectedSupportDefectLocalization
 import Formal.AG.Research.QualitySurface.MultiRouteCorrectionSystem
 import Formal.AG.Research.QualitySurface.FiniteRouteFamilyExactLocus
+import Formal.AG.Research.QualitySurface.FailingSlotCertificate

--- a/Formal/AG/Research/QualitySurface/FailingSlotCertificate.lean
+++ b/Formal/AG/Research/QualitySurface/FailingSlotCertificate.lean
@@ -1,0 +1,128 @@
+import Formal.AG.Research.QualitySurface.FiniteRouteFamilyExactLocus
+
+/-!
+Cycle 54 evidence for `G-aat-quality-surface-01`.
+
+This file turns failing route slots into explicit certificates.  For any
+staged route-slot family, failure of family source-ref exactness is equivalent
+to the existence of a failing-slot certificate.  Conversely, absence of such a
+certificate is equivalent to family exactness.
+
+The claim is relative to supplied route slots, staged selected correction
+semantics, and the explicit source-ref packet bridge.  It does not assert a
+computable scan, arbitrary repair planning, runtime patch synthesis, source
+extraction completeness, ArchMap correctness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace FailingSlotCertificate
+
+open SourceRefExactVisualizationCriterion
+open ParametrizedSelectedCorrectionSystem
+open MultiRouteCorrectionSystem
+open FiniteRouteFamilyExactLocus
+open RepairStage
+open RouteSlot
+
+universe u
+
+/-! ## Failing-slot certificates -/
+
+/-- A certificate that a staged route-slot family has a failing slot. -/
+structure FailingSlotWitness {Slot : Type u}
+    (assignment : StageAssignment Slot) where
+  slot : Slot
+  fails : assignment slot ≠ allBranches
+
+/-- A failing-slot certificate obstructs family source-ref exactness. -/
+theorem failingSlotCertificate_obstructs_familyExact {Slot : Type u}
+    {assignment : StageAssignment Slot}
+    (certificate : FailingSlotWitness assignment) :
+    ¬ AssignmentFamilySourceRefExact assignment :=
+  failingSlot_obstructs_assignmentFamilyExact
+    assignment certificate.slot certificate.fails
+
+/-- Family exactness failure is equivalent to the existence of a failing-slot certificate. -/
+theorem not_familyExact_iff_exists_failingSlotCertificate {Slot : Type u}
+    (assignment : StageAssignment Slot) :
+    ¬ AssignmentFamilySourceRefExact assignment ↔
+      ∃ _certificate : FailingSlotWitness assignment, True := by
+  classical
+  constructor
+  · intro hnotExact
+    by_contra hnoCertificate
+    have hall : AssignmentAllBranches assignment := by
+      intro slot
+      by_contra hslot
+      exact hnoCertificate ⟨⟨slot, hslot⟩, trivial⟩
+    exact hnotExact
+      ((assignmentFamilySourceRefExact_iff_allBranches assignment).mpr hall)
+  · intro hcertificate
+    rcases hcertificate with ⟨certificate, _htrivial⟩
+    exact failingSlotCertificate_obstructs_familyExact certificate
+
+/-- Family exactness is equivalent to absence of failing-slot certificates. -/
+theorem familyExact_iff_no_failingSlotCertificate {Slot : Type u}
+    (assignment : StageAssignment Slot) :
+    AssignmentFamilySourceRefExact assignment ↔
+      ¬ ∃ _certificate : FailingSlotWitness assignment, True := by
+  classical
+  constructor
+  · intro hexact hcertificate
+    exact ((not_familyExact_iff_exists_failingSlotCertificate
+      assignment).mpr hcertificate) hexact
+  · intro hnoCertificate
+    by_contra hnotExact
+    exact hnoCertificate
+      ((not_familyExact_iff_exists_failingSlotCertificate
+        assignment).mp hnotExact)
+
+/-! ## Mixed assignment certificate -/
+
+/-- The secondary route is the failing-slot certificate for the mixed assignment. -/
+def mixedRouteSlotFailingCertificate :
+    FailingSlotWitness mixedRouteSlotAssignment where
+  slot := secondary
+  fails := mixedRouteSlotAssignment_secondary_fails
+
+/-- The mixed assignment failure is explained by its failing-slot certificate. -/
+theorem mixedRouteSlotFailingCertificate_obstructs :
+    ¬ AssignmentFamilySourceRefExact mixedRouteSlotAssignment :=
+  failingSlotCertificate_obstructs_familyExact
+    mixedRouteSlotFailingCertificate
+
+/-- The mixed assignment has a failing-slot certificate exactly as expected. -/
+theorem mixedRouteSlot_exists_failingSlotCertificate :
+    ∃ _certificate : FailingSlotWitness mixedRouteSlotAssignment, True :=
+  ⟨mixedRouteSlotFailingCertificate, trivial⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-54 theorem package: family exactness failure is equivalent to an explicit
+failing-slot certificate, and the mixed route-slot assignment carries such a
+certificate at its secondary slot.
+-/
+theorem failingSlotCertificate_package :
+    (∀ {Slot : Type u} (assignment : StageAssignment Slot),
+      ¬ AssignmentFamilySourceRefExact assignment ↔
+        ∃ _certificate : FailingSlotWitness assignment, True) ∧
+    (∀ {Slot : Type u} (assignment : StageAssignment Slot),
+      AssignmentFamilySourceRefExact assignment ↔
+        ¬ ∃ _certificate : FailingSlotWitness assignment, True) ∧
+    (∀ {Slot : Type u} {assignment : StageAssignment Slot}
+      (_certificate : FailingSlotWitness assignment),
+      ¬ AssignmentFamilySourceRefExact assignment) ∧
+    ¬ AssignmentFamilySourceRefExact mixedRouteSlotAssignment ∧
+    (∃ _certificate : FailingSlotWitness mixedRouteSlotAssignment, True) := by
+  exact ⟨not_familyExact_iff_exists_failingSlotCertificate,
+    familyExact_iff_no_failingSlotCertificate,
+    fun certificate =>
+      failingSlotCertificate_obstructs_familyExact certificate,
+    mixedRouteSlotFailingCertificate_obstructs,
+    mixedRouteSlot_exists_failingSlotCertificate⟩
+
+end FailingSlotCertificate
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-failing-slot-certificate.md
+++ b/research/ideas/g-aat-quality-surface-01-failing-slot-certificate.md
@@ -1,0 +1,105 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: obstruction-certificate / closure
+capability_category: obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can mark failing route slots, but this result packages family exactness failure as an explicit certificate object with obstruction and no-certificate exactness theorems.
+origin: G-aat-quality-surface-01-cycle54
+tags: [quality-surface, route-family, exact-locus, failing-slot, certificate]
+created: 2026-06-21
+cycle: 54
+lean: proved-in-research
+---
+
+# Failing slot certificate
+
+## 主張
+
+任意の staged route-slot assignment `Slot -> RepairStage` について、family source-ref exactness の失敗は、ある slot と `allBranches` でない証拠からなる明示的な `FailingSlotWitness` の存在と同値である。逆に、そのような certificate が存在しなければ family exactness が成り立つ。Cycle 52 の mixed route-slot assignment には secondary slot の failing certificate が具体的に存在する。
+
+## 候補種別
+
+`obstruction-certificate / closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/FiniteRouteFamilyExactLocus.lean`
+- `Formal/AG/Research/QualitySurface/MultiRouteCorrectionSystem.lean`
+
+## 非自明性
+
+Cycle 53 は arbitrary staged route family の exact locus と failing-slot obstruction を固定した。Cycle 54 は failure を単なる否定命題として残さず、slot と stage failure を持つ certificate object に変換し、exactness failure / no-certificate exactness / concrete mixed witness を同じ theorem package に束ねる。これにより、family-level failure を reportable な obstruction certificate として扱える。
+
+## 数学的興味
+
+exact locus の補集合を「どこかが失敗している」という古典的な論理形から、AAT Quality Surface の certificate tuple に載せられる明示 witness へ変換する。これは minimal failing slot theorem や computable finite scan instance へ進むための、failure mode の型付き界面である。
+
+## GOAL への前進
+
+この候補は `obstruction`、`certificate-transport`、`repair-potential`、`traceability`、`invariance`、`quality-surface` を前進させる。family exactness の failure を route slot certificate として取り出し、quality surface 上で obstruction を局所化して運べる形にする。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は route ごとの failing status を表示できるが、family exactness の否定を certificate object と obstruction theorem、no-certificate exactness theorem、concrete mixed witness として同じ Lean surface に固定しない。
+
+## SCORE 見込み
+
+- `score_reason`: arbitrary route-slot assignment で failure iff certificate、exactness iff no certificate、certificate obstruction、mixed route-slot concrete certificate を Lean で固定する。Cycle 53 の failing-slot obstruction を certificate interface へ上げる成果なので base70 とする。
+- `dullness_risk`: Cycle 53 の否定命題を構造体に包むだけに見える危険がある。逆向きの no-certificate exactness、mixed witness、theorem package により failure mode を次の computable scan / minimal witness へ接続する。
+- `proof_or_evidence_plan`: Lean file `FailingSlotCertificate.lean` で proved-in-research。G2/G3/G4 監査後に report と Issue score を同期する。
+
+## CS / SWE への帰結
+
+route family repair status が失敗したとき、その失敗は単なる boolean false ではなく、どの route slot が required correction stage に入っていないかを持つ certificate として扱える。有限 scan や UI 表示へ移す場合は、ArchMap / observation layer が slot family を供給することに相対化する。
+
+## 証明・根拠
+
+Lean file: `Formal/AG/Research/QualitySurface/FailingSlotCertificate.lean`
+
+Proved declarations:
+
+- `FailingSlotWitness`
+- `failingSlotCertificate_obstructs_familyExact`
+- `not_familyExact_iff_exists_failingSlotCertificate`
+- `familyExact_iff_no_failingSlotCertificate`
+- `mixedRouteSlotFailingCertificate`
+- `mixedRouteSlotFailingCertificate_obstructs`
+- `mixedRouteSlot_exists_failingSlotCertificate`
+- `failingSlotCertificate_package`
+
+Boundary:
+
+- supplied route slots、staged selected correction semantics、explicit source-ref packet bridge に相対化する。Lean statement は `Slot : Type u` 全般であり、finite enumeration / computable scan は主張しない。
+- arbitrary repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+
+## 審判メモ
+
+- 厳密性: accept/base70。Cycle 53 の exact locus と failing-slot theorem から直接に出る面はあるが、typed certificate、no-certificate exactness、mixed concrete package により単なる rename ではない。claim boundary は `Formal/AG/Research` の route-slot family に限定する。
+- 研究価値: accept/base70。Cycle 53 の exact locus を failure certificate interface へ上げる。minimality / computable scan までは出ていないため base80 にはしない。
+- repo 全体価値: accept/base70。reportable obstruction certificate として route-family failure を固定し、paper seed と次 frontier へ接続する。
+- ライバル比較: accept/base70。ADL / conformance checker との差分は failing status 表示ではなく、certificate object と no-certificate exactness theorem に限定する。
+
+## Verification
+
+- `lake env lean Formal/AG/Research/QualitySurface/FailingSlotCertificate.lean`: pass
+- `lake build FormalAGResearch`: pass
+- forbidden-token scan for `sorry` / `admit` / `axiom` / `unsafe` / broad autoImplicit setting in the Lean file: pass
+- `.tmp/failing_slot_certificate_axioms.lean`: pass
+  - axiom-free: `mixedRouteSlotFailingCertificate`, `mixedRouteSlot_exists_failingSlotCertificate`
+  - standard axioms only: certificate obstruction / failure equivalence / no-certificate exactness / package declarations depend only on `propext` / `Classical.choice` / `Quot.sound`
+- G3 independent audit: pass
+  - axiom audit: no `sorryAx`; only allowed standard axioms; concrete mixed witness existence axiom-free
+  - formalization quality audit: pass; `FailingSlotWitness` is a reusable typed obstruction certificate, and `∃ _, True` is acceptable because the certificate data lives in the witness object
+
+## 関連
+
+- Cycle 52: `Multi-route correction system`
+- Cycle 53: `Finite route-family exact locus`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 54 候補として作成し、Lean 証明を追加。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 6810
+- total SCORE: 6950
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -58,8 +58,9 @@
   - obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface: 140
   - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
   - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
+  - obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 53
+  - proved-in-research: 54
 
 ## Phase synthesis
 
@@ -75,7 +76,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-53 件の Lean-proved research artifacts は、次の paper seed を形成している。
+54 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -118,8 +119,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 53 後の total SCORE は 6810 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 53 件持ち、
+Cycle 54 後の total SCORE は 6950 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 54 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2427,9 +2428,49 @@ Lean 証拠は次を固定する。
 主張は supplied route slots、staged selected correction semantics、explicit source-ref packet bridge に相対化され、
 arbitrary repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 54: Failing slot certificate
+
+```text
+candidate: Failing slot certificate
+candidate_type: obstruction-certificate / closure
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface
+goal_delta: Cycle 53 の family exactness failure を、slot と stage failure を持つ explicit certificate object として取り出せることを固定した。
+project_value_delta: route-family failure を boolean ではなく reportable obstruction certificate として扱う interface を作り、minimal failing slot theorem と computable finite scan instance への bridge を作った。
+rival_delta: ADL / conformance checker は per-route failing status を表示できるが、family exactness failure iff certificate と no-certificate exactness theorem は与えない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch` は pass。generic certificate declarations は標準 `propext` / `Classical.choice` / `Quot.sound` のみに依存し、mixed witness existence は axiom-free。Lean statement は `Slot : Type u` 全般であり、finite enumeration や computable scan は主張しない。
+open_questions: minimal failing slot theorem、computable finite scan instance、heterogeneous route interaction。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/FailingSlotCertificate.lean` は、
+staged assignment `Slot -> RepairStage` に対して failing slot certificate `FailingSlotWitness` を定義する。
+certificate は failing slot と、その slot が `allBranches` stage でない証拠を持つ。
+
+Lean 証拠は次を固定する。
+
+- `failingSlotCertificate_obstructs_familyExact`: failing-slot certificate は family source-ref exactness を阻む。
+- `not_familyExact_iff_exists_failingSlotCertificate`: family exactness failure は failing-slot certificate の存在と同値である。
+- `familyExact_iff_no_failingSlotCertificate`: family exactness は failing-slot certificate が存在しないことと同値である。
+- `mixedRouteSlotFailingCertificate`: mixed route-slot assignment の secondary slot は concrete failing-slot certificate である。
+- `mixedRouteSlotFailingCertificate_obstructs` /
+  `mixedRouteSlot_exists_failingSlotCertificate`: mixed assignment failure はこの certificate で説明される。
+- `failingSlotCertificate_package`: failure/certificate equivalence、no-certificate exactness、certificate obstruction、mixed witness を束ねる。
+
+この結果により、route family exactness の失敗は単なる否定命題ではなく、
+Quality Surface 上で運べる obstruction certificate として読める。
+主張は supplied route slots、staged selected correction semantics、explicit source-ref packet bridge に相対化され、
+finite enumeration、computable scan、arbitrary repair planner、runtime patch synthesis、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 53 後の total SCORE は 6810 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 54 後の total SCORE は 6950 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 54 として、route-family exactness failure を明示的な `FailingSlotWitness` certificate として扱う Lean artifact を追加しました。Cycle 53 の exact locus / failing-slot obstruction を、failure iff certificate、no-certificate exactness、mixed route-slot concrete witness の theorem package に束ねます。

G2 は四審判とも accept/base70、G4 SCORE 監査は base70 x 2.0、penalty 0、final +140 を confirm しました。report の total SCORE は 6810 から 6950 に更新しています。

## 証明した定理

- `failingSlotCertificate_obstructs_familyExact`
- `not_familyExact_iff_exists_failingSlotCertificate`
- `familyExact_iff_no_failingSlotCertificate`
- `mixedRouteSlotFailingCertificate_obstructs`
- `mixedRouteSlot_exists_failingSlotCertificate`
- `failingSlotCertificate_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-failing-slot-certificate.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/FailingSlotCertificate.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `.tmp/failing_slot_certificate_axioms.lean`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] private/local path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan on the new Lean file

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した（research tracking Issue のため close しない）
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
