### PR TITLE
研究: finite route scanを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -53,3 +53,4 @@ import Formal.AG.Research.QualitySurface.SelectedSupportDefectLocalization
 import Formal.AG.Research.QualitySurface.MultiRouteCorrectionSystem
 import Formal.AG.Research.QualitySurface.FiniteRouteFamilyExactLocus
 import Formal.AG.Research.QualitySurface.FailingSlotCertificate
+import Formal.AG.Research.QualitySurface.FiniteRouteScan

--- a/Formal/AG/Research/QualitySurface/FiniteRouteScan.lean
+++ b/Formal/AG/Research/QualitySurface/FiniteRouteScan.lean
@@ -1,0 +1,184 @@
+import Formal.AG.Research.QualitySurface.FailingSlotCertificate
+
+/-!
+Cycle 55 evidence for `G-aat-quality-surface-01`.
+
+This file turns the route-family exact locus into a finite scan when a supplied
+slot list covers the route-slot type.  The scan is relative to the supplied list:
+it does not enumerate an arbitrary type on its own, choose a canonical failing
+slot, synthesize repairs, validate ArchMap observations, or judge whole-codebase
+quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace FiniteRouteScan
+
+open SourceRefExactVisualizationCriterion
+open ParametrizedSelectedCorrectionSystem
+open MultiRouteCorrectionSystem
+open FiniteRouteFamilyExactLocus
+open FailingSlotCertificate
+open RepairStage
+open RouteSlot
+
+universe u
+
+/-! ## Finite scan for supplied route-slot lists -/
+
+/-- A supplied finite slot list covers every route slot. -/
+def SlotListCovers {Slot : Type u} (slots : List Slot) : Prop :=
+  ∀ slot, slot ∈ slots
+
+/-- All listed slots are at the all-branches stage. -/
+def ListedSlotsAllBranches {Slot : Type u}
+    (assignment : StageAssignment Slot) (slots : List Slot) : Prop :=
+  ∀ slot, slot ∈ slots -> assignment slot = allBranches
+
+/-- Boolean scan for whether every listed slot is at the all-branches stage. -/
+def listedAllBranchesScan {Slot : Type u}
+    (assignment : StageAssignment Slot) : List Slot -> Bool
+  | [] => true
+  | slot :: rest =>
+      decide (assignment slot = allBranches) &&
+        listedAllBranchesScan assignment rest
+
+/-- The boolean scan is true exactly when every listed slot is all-branches. -/
+theorem listedAllBranchesScan_eq_true_iff {Slot : Type u}
+    (assignment : StageAssignment Slot) :
+    ∀ slots,
+      listedAllBranchesScan assignment slots = true ↔
+        ListedSlotsAllBranches assignment slots
+  | [] => by
+      constructor
+      · intro _ slot hmem
+        cases hmem
+      · intro _
+        rfl
+  | slot :: rest => by
+      constructor
+      · intro hscan listedSlot hmem
+        have hscanPair :
+            decide (assignment slot = allBranches) = true ∧
+              listedAllBranchesScan assignment rest = true := by
+          simpa [listedAllBranchesScan] using hscan
+        have hhead : assignment slot = allBranches := by
+          exact of_decide_eq_true hscanPair.left
+        have htail :
+            ListedSlotsAllBranches assignment rest :=
+          (listedAllBranchesScan_eq_true_iff assignment rest).mp
+            hscanPair.right
+        cases hmem with
+        | head =>
+            exact hhead
+        | tail _ hlisted =>
+            exact htail listedSlot hlisted
+      · intro hall
+        have hhead : assignment slot = allBranches :=
+          hall slot (by simp)
+        have htail :
+            ListedSlotsAllBranches assignment rest := by
+          intro listedSlot hmem
+          exact hall listedSlot (by simp [hmem])
+        have htailScan :
+            listedAllBranchesScan assignment rest = true :=
+          (listedAllBranchesScan_eq_true_iff assignment rest).mpr htail
+        simp [listedAllBranchesScan, hhead, htailScan]
+
+/-- A supplied covering list turns family exactness into the finite scan. -/
+theorem assignmentFamilySourceRefExact_iff_listedScan {Slot : Type u}
+    (assignment : StageAssignment Slot)
+    (slots : List Slot)
+    (hcover : SlotListCovers slots) :
+    AssignmentFamilySourceRefExact assignment ↔
+      listedAllBranchesScan assignment slots = true := by
+  constructor
+  · intro hexact
+    apply (listedAllBranchesScan_eq_true_iff assignment slots).mpr
+    intro slot _hmem
+    exact (assignmentFamilySourceRefExact_iff_allBranches
+      assignment).mp hexact slot
+  · intro hscan
+    apply (assignmentFamilySourceRefExact_iff_allBranches assignment).mpr
+    intro slot
+    exact ((listedAllBranchesScan_eq_true_iff assignment slots).mp
+      hscan) slot (hcover slot)
+
+/--
+If a listed slot fails the scan, it produces the same failing-slot certificate
+used by the exactness obstruction interface.
+-/
+def listedFailingSlotCertificate {Slot : Type u}
+    {assignment : StageAssignment Slot}
+    {slots : List Slot}
+    {slot : Slot}
+    (_hmem : slot ∈ slots)
+    (hfail : assignment slot ≠ allBranches) :
+    FailingSlotWitness assignment where
+  slot := slot
+  fails := hfail
+
+/-! ## Concrete mixed route-slot scan -/
+
+/-- A supplied finite list of the two concrete route slots. -/
+def routeSlotScanOrder : List RouteSlot :=
+  [primary, secondary]
+
+/-- The supplied route-slot scan order covers the concrete route-slot type. -/
+theorem routeSlotScanOrder_covers :
+    SlotListCovers routeSlotScanOrder := by
+  intro slot
+  cases slot <;> simp [routeSlotScanOrder]
+
+/-- The mixed two-slot assignment fails the finite all-branches scan. -/
+theorem mixedRouteSlot_listedAllBranchesScan_false :
+    listedAllBranchesScan mixedRouteSlotAssignment routeSlotScanOrder = false := by
+  simp [listedAllBranchesScan, routeSlotScanOrder, mixedRouteSlotAssignment]
+
+/-- For the mixed two-slot assignment, family exactness is exactly the scan result. -/
+theorem mixedRouteSlot_familyExact_iff_listedScan :
+    AssignmentFamilySourceRefExact mixedRouteSlotAssignment ↔
+      listedAllBranchesScan mixedRouteSlotAssignment routeSlotScanOrder = true :=
+  assignmentFamilySourceRefExact_iff_listedScan
+    mixedRouteSlotAssignment routeSlotScanOrder routeSlotScanOrder_covers
+
+/-- The concrete scan exposes the secondary-slot failing certificate. -/
+def mixedRouteSlot_scanFailingCertificate :
+    FailingSlotWitness mixedRouteSlotAssignment :=
+  listedFailingSlotCertificate
+    (assignment := mixedRouteSlotAssignment)
+    (slots := routeSlotScanOrder)
+    (slot := secondary)
+    (by simp [routeSlotScanOrder])
+    mixedRouteSlotAssignment_secondary_fails
+
+/-- The scan-exposed certificate obstructs mixed route-family exactness. -/
+theorem mixedRouteSlot_scanCertificate_obstructs :
+    ¬ AssignmentFamilySourceRefExact mixedRouteSlotAssignment :=
+  failingSlotCertificate_obstructs_familyExact
+    mixedRouteSlot_scanFailingCertificate
+
+/-! ## Theorem package -/
+
+/--
+Cycle-55 theorem package: a supplied covering finite slot list computes the
+route-family exactness gate, and the mixed two-slot scan exposes the concrete
+secondary-slot failure certificate.
+-/
+theorem finiteRouteScan_package :
+    (∀ {Slot : Type u} (assignment : StageAssignment Slot)
+      (slots : List Slot), SlotListCovers slots ->
+        (AssignmentFamilySourceRefExact assignment ↔
+          listedAllBranchesScan assignment slots = true)) ∧
+    (listedAllBranchesScan mixedRouteSlotAssignment routeSlotScanOrder = false) ∧
+    (AssignmentFamilySourceRefExact mixedRouteSlotAssignment ↔
+      listedAllBranchesScan mixedRouteSlotAssignment routeSlotScanOrder = true) ∧
+    ¬ AssignmentFamilySourceRefExact mixedRouteSlotAssignment := by
+  exact ⟨assignmentFamilySourceRefExact_iff_listedScan,
+    mixedRouteSlot_listedAllBranchesScan_false,
+    mixedRouteSlot_familyExact_iff_listedScan,
+    mixedRouteSlot_scanCertificate_obstructs⟩
+
+end FiniteRouteScan
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-finite-route-scan.md
+++ b/research/ideas/g-aat-quality-surface-01-finite-route-scan.md
@@ -1,0 +1,112 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: computable finite scan / closure
+capability_category: computability / obstruction / certificate-transport / repair-potential / traceability / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checker can list failing routes, but this result proves that a supplied covering slot list computes the exactness gate and exposes the same failing certificate interface.
+origin: G-aat-quality-surface-01-cycle55
+tags: [quality-surface, route-family, finite-scan, computability, failing-slot]
+created: 2026-06-21
+cycle: 55
+lean: proved-in-research
+---
+
+# Finite route scan
+
+## 主張
+
+任意の staged route-slot assignment `Slot -> RepairStage` と supplied finite slot list `slots : List Slot` について、`slots` が全 slot を cover するなら、boolean scan `listedAllBranchesScan assignment slots` が `true` であることと family source-ref exactness は同値である。Concrete mixed two-slot assignment では supplied list `[primary, secondary]` が cover し、scan は `false` を返し、secondary slot の failing certificate を露出する。
+
+## 候補種別
+
+`computable finite scan / closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/FailingSlotCertificate.lean`
+- `Formal/AG/Research/QualitySurface/FiniteRouteFamilyExactLocus.lean`
+
+## 非自明性
+
+Cycle 53 は exact locus を任意 slot family 上の theorem として固定し、Cycle 54 は failure を certificate object にした。Cycle 55 は supplied finite list が cover する場合に限り、exactness gate を boolean scan で計算できる theorem に変換し、mixed two-slot example で false scan と failing certificate を同時に固定する。
+
+## 数学的興味
+
+Quality Surface の route-family exactness を、抽象的な `∀ slot` 命題から、cover certificate 付きの finite scan へ落とす。これは arbitrary type の自動列挙ではなく、supplied cover list に相対化した computability statement であり、reportable UI / finite evidence surface へ移す最小の型付き橋になる。
+
+## GOAL への前進
+
+この候補は `computability`、`obstruction`、`certificate-transport`、`repair-potential`、`traceability`、`quality-surface` を前進させる。Cycle 54 の open question だった computable finite scan instance を、supplied covering list に相対化して閉じる。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は failing route の一覧や status を表示できるが、cover list が exactness gate を計算すること、false scan が same certificate interface に接続することを theorem としては与えない。
+
+## SCORE 見込み
+
+- `score_reason`: supplied covering finite list、boolean scan true iff family exactness、mixed two-slot false scan、scan-exposed failing certificate を Lean で固定する。Cycle 54 の certificate interface を computable finite surface に接続するが、canonical enumeration や minimal failing slot までは主張しないため base70 とする。
+- `dullness_risk`: exact locus theorem を list scan に移しただけに見える危険がある。cover condition、boolean scan theorem、false concrete scan、certificate obstructionへの接続により computability frontier として採る。
+- `proof_or_evidence_plan`: Lean file `FiniteRouteScan.lean` で proved-in-research。G2/G3/G4 監査後に report と Issue score を同期する。
+
+## CS / SWE への帰結
+
+route family repair status は、ArchMap / observation layer などが supplied slot list を与えた場合、boolean scan と failing-slot certificate に落とせる。これは runtime patch synthesis や source extraction completeness ではなく、有限 evidence surface 上の exactness gate computation である。
+
+## 証明・根拠
+
+Lean file: `Formal/AG/Research/QualitySurface/FiniteRouteScan.lean`
+
+Proved declarations:
+
+- `SlotListCovers`
+- `ListedSlotsAllBranches`
+- `listedAllBranchesScan`
+- `listedAllBranchesScan_eq_true_iff`
+- `assignmentFamilySourceRefExact_iff_listedScan`
+- `listedFailingSlotCertificate`
+- `routeSlotScanOrder`
+- `routeSlotScanOrder_covers`
+- `mixedRouteSlot_listedAllBranchesScan_false`
+- `mixedRouteSlot_familyExact_iff_listedScan`
+- `mixedRouteSlot_scanFailingCertificate`
+- `mixedRouteSlot_scanCertificate_obstructs`
+- `finiteRouteScan_package`
+
+Boundary:
+
+- supplied finite slot list と、その cover proof に相対化する。Lean statement は arbitrary `Slot` を自動列挙しない。
+- canonical failing slot、minimal failing slot、arbitrary repair planner、runtime patch synthesis、source extraction completeness、ArchMap correctness、whole-codebase quality は主張しない。
+
+## 審判メモ
+
+- 厳密性: accept/base70。supplied cover list による exactness iff scan は厳密だが、Cycle 53 exact locus と list induction の合成でもある。generic false-scan-to-certificate、canonical/minimal failing slot、arbitrary enumeration は主張しない。
+- 研究価値: accept/base70。Cycle 54 の certificate interface を finite scan へ接続し、computability frontier と finite evidence gate を閉じる。
+- repo 全体価値: accept/base70。reportable finite evidence surface と paper seed の computability frontier を補い、将来の tooling/report/UI projection へ接続できる。
+- ライバル比較: accept/base70。ADL / conformance checker との差分は status 表示ではなく、cover-list scan true iff exactness と certificate theorem の接続に限定する。
+
+## Verification
+
+- `lake env lean Formal/AG/Research/QualitySurface/FiniteRouteScan.lean`: pass
+- `lake build FormalAGResearch`: pass
+- `lake build`: pass, with the pre-existing `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning only
+- forbidden-token scan for `sorry` / `admit` / `axiom` / `unsafe` / broad autoImplicit setting in the Lean file: pass
+- hidden / bidirectional Unicode scan and private/local path scan: pass
+- `.tmp/finite_route_scan_axioms.lean`: pass
+  - axiom-free: `listedFailingSlotCertificate`
+  - standard axioms only: scan/equivalence/package declarations depend only on `propext` / `Quot.sound`
+- G3 independent audit: pass
+  - axiom audit: no `sorryAx`; no nonstandard axioms; finite scan function and listed certificate constructor are axiom-free
+  - formalization quality audit: pass; `SlotListCovers` is a strong but explicit supplied-list assumption, and the Lean statement does not claim arbitrary enumeration, generic false-scan-to-certificate, canonical/minimal slot, or repair planning
+
+## 関連
+
+- Cycle 53: `Finite route-family exact locus`
+- Cycle 54: `Failing slot certificate`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 55 候補として作成し、Lean 証明を追加。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 6950
+- total SCORE: 7090
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -59,8 +59,9 @@
   - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
   - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
   - obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface: 140
+  - computability / obstruction / certificate-transport / repair-potential / traceability / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 54
+  - proved-in-research: 55
 
 ## Phase synthesis
 
@@ -76,7 +77,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-54 件の Lean-proved research artifacts は、次の paper seed を形成している。
+55 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -119,8 +120,8 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 54 後の total SCORE は 6950 であり、このフェーズの tracking Issue active threshold 7000 には未達である。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 54 件持ち、
+Cycle 55 後の total SCORE は 7090 であり、このフェーズの tracking Issue active threshold 7000 に到達している。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 55 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2468,12 +2469,59 @@ Quality Surface 上で運べる obstruction certificate として読める。
 finite enumeration、computable scan、arbitrary repair planner、runtime patch synthesis、
 source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 55: Finite route scan
+
+```text
+candidate: Finite route scan
+candidate_type: computable finite scan / closure
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: computability / obstruction / certificate-transport / repair-potential / traceability / quality-surface
+goal_delta: supplied covering slot list がある場合、route-family exactness gate を boolean scan として計算できることを固定した。
+project_value_delta: exact locus と failing certificate interface を finite evidence surface に接続し、reportable scan result と obstruction certificate を同じ Lean surface に置いた。
+rival_delta: ADL / conformance checker は failing route status を表示できるが、cover-list scan true iff family exactness と scan-exposed failing certificate theorem は与えない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch` は pass。finite scan declarations は標準 `propext` / `Quot.sound` のみに依存し、listed failing-slot certificate constructor は axiom-free。supplied cover list に相対化し、arbitrary type enumeration、canonical failing slot、minimality、repair planner は主張しない。
+open_questions: canonical/minimal failing slot under ordered scans、heterogeneous route interaction、UI/report projection design。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/FiniteRouteScan.lean` は、
+supplied finite slot list に対する route-family exactness scan を定義する。
+scan は各 listed slot が `allBranches` stage であるかを boolean として検査する。
+
+Lean 証拠は次を固定する。
+
+- `SlotListCovers`: supplied slot list が全 slot を cover する条件。
+- `ListedSlotsAllBranches` /
+  `listedAllBranchesScan`: listed slots の all-branches condition と boolean scan。
+- `listedAllBranchesScan_eq_true_iff`: scan が true であることは listed slots がすべて all-branches であることと同値。
+- `assignmentFamilySourceRefExact_iff_listedScan`: cover list の下で family source-ref exactness は scan result と同値。
+- `listedFailingSlotCertificate`: listed failing slot から Cycle 54 の failing certificate を作る。
+- `routeSlotScanOrder` /
+  `routeSlotScanOrder_covers`: concrete `primary` / `secondary` route-slot list は concrete route-slot type を cover する。
+- `mixedRouteSlot_listedAllBranchesScan_false`: mixed two-slot assignment の scan は false である。
+- `mixedRouteSlot_familyExact_iff_listedScan`: mixed assignment の family exactness は scan result と同値。
+- `mixedRouteSlot_scanFailingCertificate` /
+  `mixedRouteSlot_scanCertificate_obstructs`: scan-exposed secondary certificate は mixed family exactness を阻む。
+- `finiteRouteScan_package`: cover-list scan theorem、mixed false scan、mixed exactness iff scan、certificate obstruction を束ねる。
+
+この結果により、route-family exactness は supplied finite evidence surface の上では
+boolean scan として計算でき、その false result は failing-slot certificate に接続する。
+主張は supplied slot list と cover proof に相対化され、
+arbitrary type enumeration、canonical/minimal failing slot、arbitrary repair planner、runtime patch synthesis、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 54 後の total SCORE は 6950 である。
+次フェーズの tracking Issue active threshold は 7000 であり、cycle 55 後の total SCORE は 7090 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
-次フェーズへ進める場合は、lawful criterion の necessity / minimality、
-minimal failing slot theorem、
-または computable finite scan instance を狙う。threshold 7000 には未達であるため、次 cycle へ進む。
+threshold 7000 に到達したため、次は G6 phase boundary 判定を行う。
+次フェーズを立てる場合は、lawful criterion の necessity / minimality、
+canonical/minimal failing slot under ordered scans、
+または heterogeneous route interaction を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 55 として、supplied covering slot list に相対化した finite route scan を追加しました。`listedAllBranchesScan` が true であることと route-family source-ref exactness が同値になることを証明し、mixed two-slot assignment では scan が false になり、secondary slot の failing certificate に接続することを固定します。

G2 は四審判とも accept/base70、G4 SCORE 監査は base70 x 2.0、penalty 0、final +140 を confirm しました。report の total SCORE は 6950 から 7090 に更新し、active threshold 7000 に到達しています。

## 証明した定理

- `listedAllBranchesScan_eq_true_iff`
- `assignmentFamilySourceRefExact_iff_listedScan`
- `routeSlotScanOrder_covers`
- `mixedRouteSlot_listedAllBranchesScan_false`
- `mixedRouteSlot_familyExact_iff_listedScan`
- `mixedRouteSlot_scanCertificate_obstructs`
- `finiteRouteScan_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-finite-route-scan.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/FiniteRouteScan.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `.tmp/finite_route_scan_axioms.lean`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] private/local path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan on the new Lean file

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した（research tracking Issue のため close しない）
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
