### PR TITLE
研究: ordered scan first-failing slot を追加

### DIFF
--- a/Formal/AG/Research/QualitySurface/OrderedScanFirstFailingSlot.lean
+++ b/Formal/AG/Research/QualitySurface/OrderedScanFirstFailingSlot.lean
@@ -1,0 +1,260 @@
+import Formal.AG.Research.QualitySurface.FiniteRouteScan
+
+/-!
+Cycle 56 evidence for `G-aat-quality-surface-01`.
+
+This file refines the finite route scan into an ordered certificate selector.
+The first failing slot is canonical only relative to the supplied ordered slot
+list.  It does not enumerate an arbitrary type, prove global minimality,
+synthesize repairs, validate ArchMap observations, or judge whole-codebase
+quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace OrderedScanFirstFailingSlot
+
+open SourceRefExactVisualizationCriterion
+open ParametrizedSelectedCorrectionSystem
+open MultiRouteCorrectionSystem
+open FiniteRouteFamilyExactLocus
+open FailingSlotCertificate
+open FiniteRouteScan
+open RepairStage
+open RouteSlot
+
+universe u
+
+/-! ## Ordered first-failing-slot scan -/
+
+/-- The first listed slot that is not at the all-branches stage. -/
+def firstFailingSlot? {Slot : Type u}
+    (assignment : StageAssignment Slot) : List Slot -> Option Slot
+  | [] => none
+  | slot :: rest =>
+      if assignment slot = allBranches then
+        firstFailingSlot? assignment rest
+      else
+        some slot
+
+/-- A first failing slot returned by the ordered scan is a member of the supplied list. -/
+theorem firstFailingSlot?_some_mem {Slot : Type u}
+    (assignment : StageAssignment Slot) :
+    ∀ {slots : List Slot} {slot : Slot},
+      firstFailingSlot? assignment slots = some slot ->
+        slot ∈ slots
+  | [], _slot, hsome => by
+      cases hsome
+  | head :: rest, slot, hsome => by
+      by_cases hhead : assignment head = allBranches
+      · have htail :
+            firstFailingSlot? assignment rest = some slot := by
+          simpa [firstFailingSlot?, hhead] using hsome
+        exact List.mem_cons_of_mem head
+          (firstFailingSlot?_some_mem assignment htail)
+      · have hslot : slot = head := by
+          simpa [firstFailingSlot?, hhead] using hsome.symm
+        subst hslot
+        simp
+
+/-- A first failing slot returned by the ordered scan really fails all-branches. -/
+theorem firstFailingSlot?_some_fails {Slot : Type u}
+    (assignment : StageAssignment Slot) :
+    ∀ {slots : List Slot} {slot : Slot},
+      firstFailingSlot? assignment slots = some slot ->
+        assignment slot ≠ allBranches
+  | [], _slot, hsome => by
+      cases hsome
+  | head :: rest, slot, hsome => by
+      by_cases hhead : assignment head = allBranches
+      · have htail :
+            firstFailingSlot? assignment rest = some slot := by
+          simpa [firstFailingSlot?, hhead] using hsome
+        exact firstFailingSlot?_some_fails assignment htail
+      · have hslot : slot = head := by
+          simpa [firstFailingSlot?, hhead] using hsome.symm
+        subst hslot
+        exact hhead
+
+/-- The ordered scan returns none exactly when every listed slot is all-branches. -/
+theorem firstFailingSlot?_none_iff_listedAllBranches {Slot : Type u}
+    (assignment : StageAssignment Slot) :
+    ∀ slots,
+      firstFailingSlot? assignment slots = none ↔
+        ListedSlotsAllBranches assignment slots
+  | [] => by
+      constructor
+      · intro _ slot hmem
+        cases hmem
+      · intro _
+        rfl
+  | head :: rest => by
+      constructor
+      · intro hnone listedSlot hmem
+        by_cases hhead : assignment head = allBranches
+        · have htail :
+              firstFailingSlot? assignment rest = none := by
+            simpa [firstFailingSlot?, hhead] using hnone
+          cases hmem with
+          | head =>
+              exact hhead
+          | tail _ hlisted =>
+              exact ((firstFailingSlot?_none_iff_listedAllBranches
+                assignment rest).mp htail) listedSlot hlisted
+        · have hsome :
+              firstFailingSlot? assignment (head :: rest) = some head := by
+            simp [firstFailingSlot?, hhead]
+          rw [hsome] at hnone
+          cases hnone
+      · intro hall
+        have hhead : assignment head = allBranches := hall head (by simp)
+        have htail :
+            ListedSlotsAllBranches assignment rest := by
+          intro listedSlot hmem
+          exact hall listedSlot (by simp [hmem])
+        have htailNone :
+            firstFailingSlot? assignment rest = none :=
+          (firstFailingSlot?_none_iff_listedAllBranches assignment rest).mpr
+            htail
+        simp [firstFailingSlot?, hhead, htailNone]
+
+/-- A returned first failing slot gives a reportable failing-slot certificate. -/
+def firstFailingSlot?_failingCertificate {Slot : Type u}
+    {assignment : StageAssignment Slot}
+    {slots : List Slot}
+    {slot : Slot}
+    (hfirst : firstFailingSlot? assignment slots = some slot) :
+    FailingSlotWitness assignment where
+  slot := slot
+  fails := firstFailingSlot?_some_fails assignment hfirst
+
+/-! ## Prefix exactness relative to the supplied order -/
+
+/--
+Every listed slot before the returned target slot is all-branches.  This is an
+order-relative statement, not a global minimality claim.
+-/
+def PrefixBeforeFirstAllBranches {Slot : Type u} [DecidableEq Slot]
+    (assignment : StageAssignment Slot) (target : Slot) : List Slot -> Prop
+  | [] => True
+  | slot :: rest =>
+      if slot = target then
+        True
+      else
+        assignment slot = allBranches ∧
+          PrefixBeforeFirstAllBranches assignment target rest
+
+/-- The first-failing-slot scan carries prefix exactness for the supplied order. -/
+theorem firstFailingSlot?_some_prefixAllBranches {Slot : Type u}
+    [DecidableEq Slot]
+    (assignment : StageAssignment Slot) :
+    ∀ {slots : List Slot} {slot : Slot},
+      firstFailingSlot? assignment slots = some slot ->
+        PrefixBeforeFirstAllBranches assignment slot slots
+  | [], _slot, hsome => by
+      cases hsome
+  | head :: rest, slot, hsome => by
+      by_cases hhead : assignment head = allBranches
+      · have htail :
+            firstFailingSlot? assignment rest = some slot := by
+          simpa [firstFailingSlot?, hhead] using hsome
+        by_cases hslot : head = slot
+        · simp [PrefixBeforeFirstAllBranches, hslot]
+        · simp [PrefixBeforeFirstAllBranches, hslot, hhead,
+            firstFailingSlot?_some_prefixAllBranches assignment htail]
+      · have hslot : slot = head := by
+          simpa [firstFailingSlot?, hhead] using hsome.symm
+        subst hslot
+        simp [PrefixBeforeFirstAllBranches]
+
+/-- A returned first failing slot obstructs family source-ref exactness. -/
+theorem firstFailingSlot?_some_obstructs_familyExact {Slot : Type u}
+    {assignment : StageAssignment Slot}
+    {slots : List Slot}
+    {slot : Slot}
+    (hfirst : firstFailingSlot? assignment slots = some slot) :
+    ¬ AssignmentFamilySourceRefExact assignment :=
+  failingSlotCertificate_obstructs_familyExact
+    (firstFailingSlot?_failingCertificate hfirst)
+
+/-- On a covering slot list, family exactness is equivalent to no first failing slot. -/
+theorem assignmentFamilySourceRefExact_iff_firstFailingSlot?_none {Slot : Type u}
+    (assignment : StageAssignment Slot)
+    (slots : List Slot)
+    (hcover : SlotListCovers slots) :
+    AssignmentFamilySourceRefExact assignment ↔
+      firstFailingSlot? assignment slots = none := by
+  constructor
+  · intro hexact
+    apply (firstFailingSlot?_none_iff_listedAllBranches
+      assignment slots).mpr
+    intro slot _hmem
+    exact (assignmentFamilySourceRefExact_iff_allBranches
+      assignment).mp hexact slot
+  · intro hnone
+    apply (assignmentFamilySourceRefExact_iff_allBranches assignment).mpr
+    intro slot
+    exact ((firstFailingSlot?_none_iff_listedAllBranches
+      assignment slots).mp hnone) slot (hcover slot)
+
+/-! ## Concrete mixed route-slot order -/
+
+/-- The ordered scan selects the secondary slot for the mixed two-slot assignment. -/
+theorem mixedRouteSlot_firstFailingSlot?_secondary :
+    firstFailingSlot? mixedRouteSlotAssignment routeSlotScanOrder =
+      some secondary := by
+  simp [firstFailingSlot?, routeSlotScanOrder, mixedRouteSlotAssignment]
+
+/-- The selected secondary slot is the first-failing certificate for the mixed assignment. -/
+def mixedRouteSlot_firstFailingCertificate :
+    FailingSlotWitness mixedRouteSlotAssignment :=
+  firstFailingSlot?_failingCertificate
+    mixedRouteSlot_firstFailingSlot?_secondary
+
+/-- The ordered first-failing certificate obstructs mixed route-family exactness. -/
+theorem mixedRouteSlot_firstFailingCertificate_obstructs :
+    ¬ AssignmentFamilySourceRefExact mixedRouteSlotAssignment :=
+  failingSlotCertificate_obstructs_familyExact
+    mixedRouteSlot_firstFailingCertificate
+
+/-- In the concrete route order, the primary prefix is exact before the secondary failure. -/
+theorem mixedRouteSlot_firstFailing_prefixAllBranches :
+    PrefixBeforeFirstAllBranches
+      mixedRouteSlotAssignment secondary routeSlotScanOrder := by
+  exact firstFailingSlot?_some_prefixAllBranches
+    mixedRouteSlotAssignment mixedRouteSlot_firstFailingSlot?_secondary
+
+/-! ## Theorem package -/
+
+/--
+Cycle-56 theorem package: an ordered covering slot list turns family exactness
+into absence of a first failing slot, and a returned slot gives the reportable
+failing-slot certificate.
+-/
+theorem orderedScanFirstFailingSlot_package :
+    (∀ {Slot : Type u} (assignment : StageAssignment Slot)
+      (slots : List Slot), SlotListCovers slots ->
+        (AssignmentFamilySourceRefExact assignment ↔
+          firstFailingSlot? assignment slots = none)) ∧
+    (∀ {Slot : Type u} [DecidableEq Slot] {assignment : StageAssignment Slot}
+      {slots : List Slot} {slot : Slot},
+        firstFailingSlot? assignment slots = some slot ->
+          slot ∈ slots ∧
+            assignment slot ≠ allBranches ∧
+            PrefixBeforeFirstAllBranches assignment slot slots ∧
+            ¬ AssignmentFamilySourceRefExact assignment) ∧
+    (firstFailingSlot? mixedRouteSlotAssignment routeSlotScanOrder =
+      some secondary) ∧
+    ¬ AssignmentFamilySourceRefExact mixedRouteSlotAssignment := by
+  exact ⟨assignmentFamilySourceRefExact_iff_firstFailingSlot?_none,
+    fun hfirst =>
+      ⟨firstFailingSlot?_some_mem _ hfirst,
+        firstFailingSlot?_some_fails _ hfirst,
+        firstFailingSlot?_some_prefixAllBranches _ hfirst,
+        firstFailingSlot?_some_obstructs_familyExact hfirst⟩,
+    mixedRouteSlot_firstFailingSlot?_secondary,
+    mixedRouteSlot_firstFailingCertificate_obstructs⟩
+
+end OrderedScanFirstFailingSlot
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-ordered-scan-first-failing-slot.md
+++ b/research/ideas/g-aat-quality-surface-01-ordered-scan-first-failing-slot.md
@@ -1,0 +1,93 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: computability / canonical-certificate
+capability_category: computability / obstruction / certificate-transport / traceability / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance tools can report failing route entries, but do not turn a supplied ordered evidence surface into a first-failing-slot certificate theorem tied to family exactness.
+origin: cycle-56
+tags: [quality-surface, finite-scan, failing-slot, computability]
+created: 2026-06-21
+cycle: 56
+lean: Formal/AG/Research/QualitySurface/OrderedScanFirstFailingSlot.lean
+---
+
+# Ordered scan first-failing slot certificate
+
+## 主張
+
+Supplied ordered route-slot list `slots` と staged assignment `assignment` に相対化して、
+`firstFailingSlot? assignment slots` を定義する。この ordered scan が `none` を返すことは
+listed all-branches condition と同値であり、cover list の下では family source-ref exactness と同値である。
+また `some slot` を返す場合、その slot は list 上の failing-slot certificate を与え、
+その前方 prefix は all-branches であり、family exactness を阻む。
+
+## 候補種別
+
+`computability` / `closure`
+
+## 依拠
+
+- Cycle 53: `FiniteRouteFamilyExactLocus`
+- Cycle 54: `FailingSlotCertificate`
+- Cycle 55: `FiniteRouteScan`
+
+## 非自明性
+
+Cycle 55 は boolean scan と listed failing certificate を与えたが、false result からどの certificate を報告するかは固定していなかった。
+本候補は supplied order に相対化した first failing slot と prefix exactness を証明対象にし、scan result、certificate、family exactness obstruction を一つの interface に接続する。
+
+## 数学的興味
+
+Quality Surface の failure は単なる truth value ではなく、ordered evidence surface 上で reportable な obstruction certificate として返せる。
+これは canonicality を絶対的な最小性ではなく、declared scan order に相対化するため、claim boundary を守りながら計算可能な certificate selection を与える。
+
+## GOAL への前進
+
+`computability` と `obstruction` を進め、finite evidence surface から exactness failure certificate を選ぶ interface を追加する。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は failing component や failing route を表示できるが、declared ordered evidence surface、family exactness theorem、first-failing certificate obstruction を同じ証明対象としては束ねない。
+
+## SCORE 見込み
+
+- `score_reason`: ordered scan が failure certificate selection を固定し、Cycle 55 の open frontier `canonical/minimal failing slot under ordered scans` を claim-boundary 内で進める。G2 厳密性審判は、既存 exactness/certificate lemmas に近い list-recursive refinement であるため base 70 が妥当と判定した。
+- `dullness_risk`: absolute canonical / minimal failing slot と言うと過大主張になる。supplied ordered list に相対化し、global minimality は主張しない。
+- `proof_or_evidence_plan`: Lean で recursive scanner、none/listed-all-branches equivalence、some-to-certificate、cover-list exactness equivalence、concrete mixed route-slot witness を証明する。
+
+## CS / SWE への帰結
+
+有限 route-family check で false が出たとき、単なる fail flag ではなく ordered scan が返す reportable obstruction certificate を運べる。
+ただし ordered list と cover proof は入力 contract であり、任意コードベースの自動列挙や ArchMap completeness は主張しない。
+
+## 証明・根拠の見込み
+
+Lean file `OrderedScanFirstFailingSlot.lean` に置く。
+主要 declaration は `firstFailingSlot?_none_iff_listedAllBranches`、
+`firstFailingSlot?_failingCertificate`、
+`firstFailingSlot?_some_prefixAllBranches`、
+`assignmentFamilySourceRefExact_iff_firstFailingSlot?_none`、
+`mixedRouteSlot_firstFailingSlot?_secondary`、
+`orderedScanFirstFailingSlot_package`。
+
+## 審判メモ
+
+- 厳密性: accept; base 70. order-relative canonicity と prefix exactness は新規だが、Cycle 53-55 の exactness/certificate lemmas に近いため 80 までは上げない。
+- 研究価値: accepted; base 80. boolean scan を certificate selection に変え、finite route-family exactness section の reportable interface になる。
+- repo 全体価値: accept; base 80. research-to-tooling interface として有効だが、SFT / Website への直接効果は弱い。
+- ライバル比較: accept; base 80. ADL-style first failing entry display ではなく、scan result、prefix exactness、certificate、family exactness obstruction を theorem-backed に束ねる。
+- genius: not eligible. A/B/D は `genius_eligibility: no`、C は条件付き評価に留まったため、四者 yes を満たさず通常 SCORE として扱う。
+- resolved revise: G3 formalization audit が `orderedScanFirstFailingSlot_package` の weak existential certificate conjunct を指摘したため、package theorem を `slot ∈ slots`、`assignment slot ≠ allBranches`、prefix exactness、family exactness obstruction を直接返す形へ強化した。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-finite-route-scan.md`
+- `Formal/AG/Research/QualitySurface/FiniteRouteScan.lean`
+
+## 進捗ログ
+
+- 2026-06-21: cycle 56 candidate picked and Lean evidence added.

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 7090
+- total SCORE: 7230
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -60,8 +60,9 @@
   - repair-potential / obstruction / certificate-transport / traceability / invariance / quality-surface: 140
   - obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface: 140
   - computability / obstruction / certificate-transport / repair-potential / traceability / quality-surface: 140
+  - computability / obstruction / certificate-transport / traceability / quality-surface: 140
 - evidence portfolio:
-  - proved-in-research: 55
+  - proved-in-research: 56
 
 ## Phase synthesis
 
@@ -77,7 +78,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-55 件の Lean-proved research artifacts は、次の paper seed を形成している。
+56 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -120,8 +121,10 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 ### Phase result
 
-Cycle 55 後の total SCORE は 7090 であり、このフェーズの tracking Issue active threshold 7000 に到達している。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 55 件持ち、
+Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 56 後の total SCORE は 7230 である。
+現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 56 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2515,13 +2518,55 @@ boolean scan として計算でき、その false result は failing-slot certif
 arbitrary type enumeration、canonical/minimal failing slot、arbitrary repair planner、runtime patch synthesis、
 source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 
+## Cycle 56: Ordered scan first-failing slot certificate
+
+```text
+candidate: Ordered scan first-failing slot certificate
+candidate_type: computability / canonical-certificate
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: computability / obstruction / certificate-transport / traceability / quality-surface
+goal_delta: supplied ordered evidence surface に相対化して、boolean scan failure を first-failing-slot certificate、prefix exactness、family exactness obstruction へ接続した。
+project_value_delta: Cycle 55 の finite route scan を reportable obstruction selector へ強め、Quality Surface が fail flag ではなく certificate を返す interface を追加した。
+rival_delta: ADL / conformance checker は failing route entry を表示できるが、ordered scan result、prefix exactness、failing-slot certificate、family exactness obstruction を theorem package としては束ねない。
+formalization_quality: pass。`lake env lean` と `lake build FormalAGResearch` は pass。主要 declaration は標準 `propext` / `Quot.sound` の範囲に収まる。G3 formalization audit 後、package theorem は returned slot の membership、failure、prefix exactness、family obstruction を直接含む形へ強化した。主張は supplied ordered slot list と cover proof に相対化され、absolute global minimality、arbitrary type enumeration、repair planner、ArchMap correctness、source extraction completeness、whole-codebase quality は主張しない。
+open_questions: heterogeneous route interaction、route-family lawful criterion minimality、Quality Surface holonomy-obstruction correspondence の genius-target seed。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/OrderedScanFirstFailingSlot.lean` は、
+supplied ordered route-slot list に対して `firstFailingSlot?` を定義する。
+この scan は、最初に `allBranches` でない slot を `some slot` として返し、失敗がなければ `none` を返す。
+
+Lean 証拠は次を固定する。
+
+- `firstFailingSlot?_some_mem`: returned slot は supplied list の member である。
+- `firstFailingSlot?_some_fails`: returned slot は `allBranches` ではない。
+- `firstFailingSlot?_none_iff_listedAllBranches`: `none` は listed all-branches condition と同値である。
+- `firstFailingSlot?_failingCertificate`: returned slot は failing-slot certificate を与える。
+- `firstFailingSlot?_some_prefixAllBranches`: returned slot より前の prefix は all-branches である。
+- `firstFailingSlot?_some_obstructs_familyExact`: returned certificate は family exactness を阻む。
+- `assignmentFamilySourceRefExact_iff_firstFailingSlot?_none`: cover list の下で family exactness は first-failing scan が `none` を返すことと同値である。
+- `mixedRouteSlot_firstFailingSlot?_secondary`: concrete mixed route-slot order では secondary slot が first failing slot である。
+- `mixedRouteSlot_firstFailing_prefixAllBranches`: concrete order で secondary failure の前方 prefix は all-branches である。
+- `orderedScanFirstFailingSlot_package`: ordered scan exactness criterion、certificate construction、concrete mixed obstruction を束ねる。
+
+この結果により、Cycle 55 の boolean finite scan は、ordered evidence surface 上の reportable obstruction certificate selector へ強化される。
+ただし first / canonical / minimal は supplied list order に相対化した主張であり、
+arbitrary slot type の自動列挙、global minimal failing slot、runtime repair synthesis、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+genius scoring は適用しない。G2 で A/B/D は `genius_eligibility: no`、C は条件付き評価に留まり、四者 yes を満たしていない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 7000 であり、cycle 55 後の total SCORE は 7090 である。
+次フェーズの tracking Issue active threshold は 10000 であり、cycle 56 後の total SCORE は 7230 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
-threshold 7000 に到達したため、次は G6 phase boundary 判定を行う。
-次フェーズを立てる場合は、lawful criterion の necessity / minimality、
-canonical/minimal failing slot under ordered scans、
-または heterogeneous route interaction を狙う。
+threshold 10000 には未達であるため、次 cycle では lawful criterion の necessity / minimality、
+heterogeneous route interaction、または Quality Surface holonomy-obstruction correspondence の
+genius-target seed / support theorem を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 56 として、supplied ordered route-slot list に相対化した `firstFailingSlot?` を追加しました。Cycle 55 の boolean finite scan を、first-failing-slot certificate、prefix exactness、family exactness obstruction に接続します。

G4 SCORE 監査は base 70 x evidence 2.0、penalty 0、final +140 と判定しました。Cycle 56 後の total SCORE は 7230 / active threshold 10000 です。genius scoring は A/B/D が `no`、C が条件付きに留まったため適用しません。

## 証明した定理

- `firstFailingSlot?_some_mem`
- `firstFailingSlot?_some_fails`
- `firstFailingSlot?_none_iff_listedAllBranches`
- `firstFailingSlot?_failingCertificate`
- `firstFailingSlot?_some_prefixAllBranches`
- `firstFailingSlot?_some_obstructs_familyExact`
- `assignmentFamilySourceRefExact_iff_firstFailingSlot?_none`
- `mixedRouteSlot_firstFailingSlot?_secondary`
- `mixedRouteSlot_firstFailing_prefixAllBranches`
- `orderedScanFirstFailingSlot_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-ordered-scan-first-failing-slot.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/OrderedScanFirstFailingSlot.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `#print axioms` for main declarations: only standard `propext` / `Quot.sound`, no `sorryAx`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan for the new evidence file and candidate card

## チェックリスト

- [x] 対象 tracking Issue を `Refs #2348` として記載した（research-loop tracking Issue のため `Closes` は使わない）
- [x] Lean status を `proved-in-research` として明確にした
- [x] research report の SCORE / Lean status と候補カードを同期した
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
