### PR TITLE
研究: heterogeneous route bridge obstruction を追加

### DIFF
--- a/Formal/AG/Research/QualitySurface/HeterogeneousRouteInteraction.lean
+++ b/Formal/AG/Research/QualitySurface/HeterogeneousRouteInteraction.lean
@@ -1,0 +1,297 @@
+import Formal.AG.Research.QualitySurface.OrderedScanFirstFailingSlot
+
+/-!
+Cycle 57 evidence for `G-aat-quality-surface-01`.
+
+This file separates local route exactness from cross-route interaction
+exactness.  The result is relative to a supplied heterogeneous state and a
+declared bridge certificate with support, trace, and repair-frontier
+components.  It does not synthesize repairs, validate ArchMap observations,
+enumerate arbitrary route systems, or judge whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace HeterogeneousRouteInteraction
+
+open SourceRefExactVisualizationCriterion
+open ParametrizedSelectedCorrectionSystem
+open MultiRouteCorrectionSystem
+open FiniteRouteFamilyExactLocus
+open FiniteRouteScan
+open OrderedScanFirstFailingSlot
+open RepairStage
+open RouteSlot
+
+/-! ## Heterogeneous route states -/
+
+/-- Components of the supplied cross-route bridge certificate. -/
+inductive BridgeComponent where
+  | support
+  | trace
+  | repairFrontier
+  deriving DecidableEq, Fintype
+
+open BridgeComponent
+
+/-- A supplied bridge certificate linking the heterogeneous route surfaces. -/
+structure BridgeCertificate where
+  supportPreserved : Bool
+  tracePreserved : Bool
+  repairFrontierPreserved : Bool
+  deriving DecidableEq
+
+/-- Read one component of the bridge certificate. -/
+def BridgeCertificate.component
+    (bridge : BridgeCertificate) : BridgeComponent -> Bool
+  | support => bridge.supportPreserved
+  | trace => bridge.tracePreserved
+  | repairFrontier => bridge.repairFrontierPreserved
+
+/-- The bridge certificate is fully aligned. -/
+def BridgeCertificate.Aligned
+    (bridge : BridgeCertificate) : Prop :=
+  bridge.supportPreserved = true ∧
+    bridge.tracePreserved = true ∧
+    bridge.repairFrontierPreserved = true
+
+/-- A concrete bridge obstruction certificate. -/
+structure BridgeObstruction
+    (bridge : BridgeCertificate) where
+  component : BridgeComponent
+  fails : bridge.component component = false
+
+/-- A bridge has at least one explicit obstruction certificate. -/
+def HasBridgeObstruction
+    (bridge : BridgeCertificate) : Prop :=
+  ∃ _obstruction : BridgeObstruction bridge, True
+
+/--
+A heterogeneous state carries two different local exactness surfaces:
+one selected-correction route stage and one finite route-family scan
+assignment.  `bridge` records the supplied cross-route bridge certificate.
+-/
+structure HeterogeneousRouteState where
+  selectedStage : RepairStage
+  scanAssignment : StageAssignment RouteSlot
+  bridge : BridgeCertificate
+
+/-- Local exactness of the selected correction route. -/
+def SelectedRouteLocalExact
+    (state : HeterogeneousRouteState) : Prop :=
+  CorrectionSourceRefExact (stagedCorrection state.selectedStage)
+
+/-- Local exactness of the finite scanned route-family surface. -/
+def ScanRouteLocalExact
+    (state : HeterogeneousRouteState) : Prop :=
+  AssignmentFamilySourceRefExact state.scanAssignment
+
+/-- Product of the two local exactness readings. -/
+def ProductLocalExact
+    (state : HeterogeneousRouteState) : Prop :=
+  SelectedRouteLocalExact state ∧ ScanRouteLocalExact state
+
+/-- The supplied cross-route bridge law is aligned. -/
+def BridgeAligned
+    (state : HeterogeneousRouteState) : Prop :=
+  state.bridge.Aligned
+
+/--
+Heterogeneous interaction exactness: local exactness product plus the bridge
+law.  This is intentionally stronger than per-route green status.
+-/
+def InteractionExact
+    (state : HeterogeneousRouteState) : Prop :=
+  ProductLocalExact state ∧ BridgeAligned state
+
+/-! ## Concrete product-exact but interaction-obstructed witness -/
+
+/-- Constant all-branches assignment for the scanned route-family surface. -/
+def allBranchesScanAssignment : StageAssignment RouteSlot :=
+  fun _slot => allBranches
+
+/-- The all-branches scan assignment is locally exact. -/
+theorem allBranchesScanAssignment_exact :
+    AssignmentFamilySourceRefExact allBranchesScanAssignment :=
+  (assignmentFamilySourceRefExact_iff_allBranches
+    allBranchesScanAssignment).mpr (by
+      intro slot
+      rfl)
+
+/-- A bridge certificate with a trace handoff obstruction. -/
+def traceBrokenBridge : BridgeCertificate where
+  supportPreserved := true
+  tracePreserved := false
+  repairFrontierPreserved := true
+
+/-- The trace handoff component fails in `traceBrokenBridge`. -/
+def traceBrokenBridgeObstruction :
+    BridgeObstruction traceBrokenBridge where
+  component := trace
+  fails := rfl
+
+/-- A fully aligned bridge certificate. -/
+def alignedBridge : BridgeCertificate where
+  supportPreserved := true
+  tracePreserved := true
+  repairFrontierPreserved := true
+
+/-- A fully aligned bridge has no failed component. -/
+theorem alignedBridge_aligned :
+    alignedBridge.Aligned :=
+  ⟨rfl, rfl, rfl⟩
+
+/-- A bridge obstruction rules out bridge alignment. -/
+theorem bridgeObstruction_not_aligned
+    {bridge : BridgeCertificate}
+    (obstruction : BridgeObstruction bridge) :
+    ¬ bridge.Aligned := by
+  intro haligned
+  rcases obstruction with ⟨component, hfail⟩
+  rcases haligned with ⟨hsupport, htrace, hrepair⟩
+  cases component with
+  | support =>
+      simp [BridgeCertificate.component, hsupport] at hfail
+  | trace =>
+      simp [BridgeCertificate.component, htrace] at hfail
+  | repairFrontier =>
+      simp [BridgeCertificate.component, hrepair] at hfail
+
+/-- A bridge obstruction rules out heterogeneous interaction exactness. -/
+theorem bridgeObstruction_obstructs_interactionExact
+    {state : HeterogeneousRouteState}
+    (obstruction : BridgeObstruction state.bridge) :
+    ¬ InteractionExact state := by
+  intro hexact
+  exact bridgeObstruction_not_aligned obstruction hexact.2
+
+def productExactBridgeBrokenState : HeterogeneousRouteState where
+  selectedStage := allBranches
+  scanAssignment := allBranchesScanAssignment
+  bridge := traceBrokenBridge
+
+/-- The selected-correction local route is exact in the bridge-broken state. -/
+theorem productExactBridgeBroken_selectedLocalExact :
+    SelectedRouteLocalExact productExactBridgeBrokenState := by
+  simpa [SelectedRouteLocalExact, productExactBridgeBrokenState]
+    using stagedCorrection_allBranches_exact
+
+/-- The scanned route-family local surface is exact in the bridge-broken state. -/
+theorem productExactBridgeBroken_scanLocalExact :
+    ScanRouteLocalExact productExactBridgeBrokenState := by
+  simpa [ScanRouteLocalExact, productExactBridgeBrokenState]
+    using allBranchesScanAssignment_exact
+
+/-- The bridge-broken state satisfies the product of local exactness readings. -/
+theorem productExactBridgeBroken_productLocalExact :
+    ProductLocalExact productExactBridgeBrokenState :=
+  ⟨productExactBridgeBroken_selectedLocalExact,
+    productExactBridgeBroken_scanLocalExact⟩
+
+/-- The bridge-broken state carries a trace handoff obstruction. -/
+def productExactBridgeBroken_traceObstruction :
+    BridgeObstruction productExactBridgeBrokenState.bridge :=
+  traceBrokenBridgeObstruction
+
+/-- The bridge-broken state does not satisfy the cross-route bridge law. -/
+theorem productExactBridgeBroken_not_bridgeAligned :
+    ¬ BridgeAligned productExactBridgeBrokenState :=
+  bridgeObstruction_not_aligned productExactBridgeBroken_traceObstruction
+
+/--
+Per-route local exactness product does not imply heterogeneous interaction
+exactness.
+-/
+theorem heterogeneousProductExact_not_interactionExact :
+    ProductLocalExact productExactBridgeBrokenState ∧
+      ¬ InteractionExact productExactBridgeBrokenState := by
+  constructor
+  · exact productExactBridgeBroken_productLocalExact
+  · intro hinteraction
+    exact productExactBridgeBroken_not_bridgeAligned hinteraction.2
+
+/-! ## Positive bridge-aligned comparator -/
+
+/-- Same local exactness surfaces, but with the cross-route bridge aligned. -/
+def bridgeAlignedInteractionState : HeterogeneousRouteState where
+  selectedStage := allBranches
+  scanAssignment := allBranchesScanAssignment
+  bridge := alignedBridge
+
+/-- The bridge-aligned comparator is interaction exact. -/
+theorem bridgeAlignedInteractionState_interactionExact :
+    InteractionExact bridgeAlignedInteractionState := by
+  constructor
+  · constructor
+    · simpa [SelectedRouteLocalExact, bridgeAlignedInteractionState]
+        using stagedCorrection_allBranches_exact
+    · simpa [ScanRouteLocalExact, bridgeAlignedInteractionState]
+        using allBranchesScanAssignment_exact
+  · exact alignedBridge_aligned
+
+/-- Interaction exactness remembers the local exactness product. -/
+theorem heterogeneousInteractionExact_implies_productLocalExact
+    {state : HeterogeneousRouteState}
+    (hexact : InteractionExact state) :
+      ProductLocalExact state :=
+  hexact.1
+
+/-- Interaction exactness remembers the bridge law. -/
+theorem heterogeneousInteractionExact_implies_bridgeAligned
+    {state : HeterogeneousRouteState}
+    (hexact : InteractionExact state) :
+      BridgeAligned state :=
+  hexact.2
+
+/--
+Two states can have the same local exactness product while differing on
+heterogeneous interaction exactness.
+-/
+theorem sameLocalProduct_differentInteractionExactness :
+    ProductLocalExact productExactBridgeBrokenState ∧
+      ProductLocalExact bridgeAlignedInteractionState ∧
+      HasBridgeObstruction productExactBridgeBrokenState.bridge ∧
+      ¬ InteractionExact productExactBridgeBrokenState ∧
+      InteractionExact bridgeAlignedInteractionState := by
+  exact ⟨productExactBridgeBroken_productLocalExact,
+    bridgeAlignedInteractionState_interactionExact.1,
+    ⟨productExactBridgeBroken_traceObstruction, trivial⟩,
+    heterogeneousProductExact_not_interactionExact.2,
+    bridgeAlignedInteractionState_interactionExact⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-57 theorem package: heterogeneous interaction exactness strictly
+strengthens the product of local route exactness surfaces by requiring a
+cross-route bridge law.
+-/
+theorem heterogeneousRouteInteraction_package :
+    ProductLocalExact productExactBridgeBrokenState ∧
+      HasBridgeObstruction productExactBridgeBrokenState.bridge ∧
+      ¬ InteractionExact productExactBridgeBrokenState ∧
+      InteractionExact bridgeAlignedInteractionState ∧
+      (∀ {state : HeterogeneousRouteState},
+        InteractionExact state -> ProductLocalExact state) ∧
+      (∀ {state : HeterogeneousRouteState},
+        InteractionExact state -> BridgeAligned state) ∧
+      (∀ {state : HeterogeneousRouteState},
+        BridgeObstruction state.bridge -> ¬ InteractionExact state) ∧
+      (ProductLocalExact productExactBridgeBrokenState ∧
+        ProductLocalExact bridgeAlignedInteractionState ∧
+        HasBridgeObstruction productExactBridgeBrokenState.bridge ∧
+        ¬ InteractionExact productExactBridgeBrokenState ∧
+        InteractionExact bridgeAlignedInteractionState) := by
+  exact ⟨productExactBridgeBroken_productLocalExact,
+    ⟨productExactBridgeBroken_traceObstruction, trivial⟩,
+    heterogeneousProductExact_not_interactionExact.2,
+    bridgeAlignedInteractionState_interactionExact,
+    fun hexact => heterogeneousInteractionExact_implies_productLocalExact hexact,
+    fun hexact => heterogeneousInteractionExact_implies_bridgeAligned hexact,
+    fun obstruction =>
+      bridgeObstruction_obstructs_interactionExact obstruction,
+    sameLocalProduct_differentInteractionExactness⟩
+
+end HeterogeneousRouteInteraction
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-heterogeneous-route-interaction-curvature.md
+++ b/research/ideas/g-aat-quality-surface-01-heterogeneous-route-interaction-curvature.md
@@ -1,0 +1,95 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: orientation / heterogeneous-interaction
+capability_category: profile-curvature / certificate-transport / obstruction / repair-potential / traceability / quality-surface
+expected_base_score: 80
+expected_evidence_multiplier: 2.0
+expected_final_score: 160
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance tools can list per-route exactness and cross-route constraints, but this candidate turns support / trace / repair-frontier bridge failure into an obstruction certificate tied to interaction exactness.
+origin: cycle-57
+tags: [quality-surface, heterogeneous-route, interaction, curvature]
+created: 2026-06-21
+cycle: 57
+lean: Formal/AG/Research/QualitySurface/HeterogeneousRouteInteraction.lean
+---
+
+# Heterogeneous route bridge obstruction
+
+## 主張
+
+selected correction route の local exactness と、finite scan route-family の local exactness を別々に満たしても、
+support / trace / repair-frontier からなる cross-route bridge certificate が落ちれば heterogeneous interaction exactness は成り立たない。
+したがって heterogeneous route family の exact locus は、local exactness の product だけでは読めない。
+
+## 候補種別
+
+`orientation`
+
+## 依拠
+
+- Cycle 48: parametrized selected correction system
+- Cycle 53-56: finite route-family exact locus、finite scan、ordered first-failing selector
+
+## 非自明性
+
+Cycle 52-56 は homogeneous staged route family と scan surface を扱った。
+本候補は selected correction route と route-family scan という異なる exactness notion を同じ state に載せ、
+local exactness product と cross-route bridge obstruction certificate を分離する。
+
+## 数学的興味
+
+Quality Surface 上の route family は、per-route green status の product だけではない。
+別 route の correction / scan surface を接続する bridge certificate の trace handoff component が落ちると、
+local exactness は保たれていても interaction cell は obstructed になる。
+
+## GOAL への前進
+
+heterogeneous route interaction frontier を開き、certificate transport と obstruction を product exactness から分離する。
+
+## ライバルに対する有効性
+
+ADL / conformance checker は route ごとの pass/fail や cross-route constraint violation を表示できるが、
+AAT 側ではその failure を support / trace / repair-frontier component を持つ bridge obstruction certificate として
+interaction exactness に接続する。
+
+## SCORE 見込み
+
+- `score_reason`: homogeneous route-family scan から heterogeneous interaction exactness へ進み、product-locus view を有限 witness で壊す。ただし bridge certificate はまだ supplied evidence contract であり derived invariant ではないため、G2 revise 後は base 80 を見込む。
+- `dullness_risk`: bridge law を任意 Bool として置くだけなら dull。revise により support / trace / repair-frontier component を持つ bridge certificate と obstruction object にした。
+- `proof_or_evidence_plan`: Lean で heterogeneous state、selected local exactness、scan local exactness、bridge certificate、bridge obstruction、interaction exactness、product-local-exact but not interaction-exact witness、bridge-aligned positive witness を証明する。
+
+## CS / SWE への帰結
+
+複数 route の dashboard がすべて green でも、route 間の handoff / bridge law が落ちれば interaction としては exact でない、という certificate-level explanation を持てる。
+ただし bridge law は supplied evidence contract であり、runtime repair synthesis や source extraction completeness は主張しない。
+
+## 証明・根拠の見込み
+
+Lean file `HeterogeneousRouteInteraction.lean` に置く。
+主要 declaration は `heterogeneousProductExact_not_interactionExact`、
+`heterogeneousInteractionExact_implies_productLocalExact`、
+`bridgeObstruction_obstructs_interactionExact`、
+`heterogeneousInteractionExact_implies_bridgeAligned`、
+`bridgeAlignedInteractionState_interactionExact`、
+`sameLocalProduct_differentInteractionExactness`、
+`heterogeneousRouteInteraction_package`。
+
+## 審判メモ
+
+- 厳密性: accept after one revise; base 80. First G2 A rejected the naked Bool bridge as too definitional. Revised to a support / trace / repair-frontier `BridgeCertificate` with explicit `BridgeObstruction`.
+- 研究価値: accept; base 80. Product-local-exactness と heterogeneous interaction exactness の分離は frontier を進めるが、bridge はまだ supplied contract なので base 90 ではない。
+- repo 全体価値: accept; base 80. Future tooling / website surface として有効だが、bridge law は supplied evidence contract として扱う必要がある。
+- ライバル比較: accept after one revise; base 80. First G2 D noted that ADL can also express cross-route constraints. Revised to make the advantage the certificate-bearing bridge obstruction, not merely an extra Boolean check.
+- G3: `lake env lean` and `lake build FormalAGResearch` pass. `BridgeCertificate` / `BridgeObstruction` / concrete trace obstruction are axiom-free; package and local exactness witnesses inherit standard `propext` / `Quot.sound` from imported exactness infrastructure.
+- genius: not eligible. All G2 judges treated this as a normal orientation / obstruction result, not a 1000-point breakthrough.
+
+## 関連
+
+- `Formal/AG/Research/QualitySurface/ParametrizedSelectedCorrectionSystem.lean`
+- `Formal/AG/Research/QualitySurface/OrderedScanFirstFailingSlot.lean`
+
+## 進捗ログ
+
+- 2026-06-21: cycle 57 candidate picked for G2/G3.

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 7230
+- total SCORE: 7390
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -61,8 +61,9 @@
   - obstruction / certificate-transport / repair-potential / traceability / invariance / quality-surface: 140
   - computability / obstruction / certificate-transport / repair-potential / traceability / quality-surface: 140
   - computability / obstruction / certificate-transport / traceability / quality-surface: 140
+  - profile-curvature / certificate-transport / obstruction / repair-potential / traceability / quality-surface: 160
 - evidence portfolio:
-  - proved-in-research: 56
+  - proved-in-research: 57
 
 ## Phase synthesis
 
@@ -78,7 +79,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-56 件の Lean-proved research artifacts は、次の paper seed を形成している。
+57 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -122,9 +123,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 56 後の total SCORE は 7230 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 57 後の total SCORE は 7390 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 56 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 57 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2561,12 +2562,57 @@ arbitrary slot type の自動列挙、global minimal failing slot、runtime repa
 source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 genius scoring は適用しない。G2 で A/B/D は `genius_eligibility: no`、C は条件付き評価に留まり、四者 yes を満たしていない。
 
+## Cycle 57: Heterogeneous route bridge obstruction
+
+```text
+candidate: Heterogeneous route bridge obstruction
+candidate_type: orientation / heterogeneous-interaction
+evidence_stage: proved-in-research
+base_score: 80
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 160
+category: profile-curvature / certificate-transport / obstruction / repair-potential / traceability / quality-surface
+goal_delta: selected correction route と finite scan route-family がどちらも local exact でも、support / trace / repair-frontier bridge certificate の trace obstruction が heterogeneous interaction exactness を阻むことを固定した。
+project_value_delta: Cycle 52-56 の homogeneous route-family / scan frontier を、local exactness product では読めない heterogeneous interaction cell へ拡張した。
+rival_delta: ADL / conformance checker は cross-route constraint violation を表示できるが、AAT 側ではその failure を support / trace / repair-frontier component を持つ bridge obstruction certificate として interaction exactness に接続する。
+formalization_quality: pass。`lake env lean` と `lake build FormalAGResearch` は pass。`BridgeCertificate` / `BridgeObstruction` / concrete trace obstruction は axiom-free。package と product-local exactness witnesses は imported exactness infrastructure 由来の標準 `propext` / `Quot.sound` を継承する。bridge certificate は supplied evidence contract であり、derived invariant、runtime repair synthesis、global route enumeration、ArchMap correctness、source extraction completeness、whole-codebase quality は主張しない。
+open_questions: bridge certificate を source-ref handoff / tuple transport / lawful repair-transport commutator から導出する theorem、route-family lawful criterion minimality、Quality Surface holonomy-obstruction correspondence の support theorem。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/HeterogeneousRouteInteraction.lean` は、
+selected correction route の local exactness と finite scan route-family の local exactness を同じ
+heterogeneous state に載せる。さらに cross-route bridge certificate を
+support / trace / repair-frontier の三成分として持たせる。
+
+Lean 証拠は次を固定する。
+
+- `BridgeCertificate`: support、trace、repair-frontier の bridge component を持つ supplied certificate。
+- `BridgeObstruction`: どの bridge component が失敗したかを持つ obstruction certificate。
+- `bridgeObstruction_not_aligned`: bridge obstruction は bridge alignment を阻む。
+- `bridgeObstruction_obstructs_interactionExact`: bridge obstruction は heterogeneous interaction exactness を阻む。
+- `productExactBridgeBroken_productLocalExact`: selected route と scan route-family の local exactness product は成り立つ。
+- `productExactBridgeBroken_traceObstruction`: その同じ state は trace handoff obstruction を持つ。
+- `heterogeneousProductExact_not_interactionExact`: local exactness product は heterogeneous interaction exactness を含意しない。
+- `bridgeAlignedInteractionState_interactionExact`: bridge-aligned comparator は interaction exact である。
+- `sameLocalProduct_differentInteractionExactness`: 同じ local exactness product を持つ二つの state が interaction exactness では分かれる。
+- `heterogeneousRouteInteraction_package`: product exactness、bridge obstruction、positive comparator、projection theorem を束ねる。
+
+この結果により、Quality Surface の route-family exactness は per-route green status の product だけではなく、
+support / trace / repair-frontier bridge certificate を含む interaction cell として読む必要がある。
+ただし bridge certificate は supplied evidence contract であり、
+任意 route system の列挙、bridge law の自動導出、runtime repair synthesis、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+genius scoring は適用しない。G2 四審判は通常 SCORE として accept し、base 80 とした。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 10000 であり、cycle 56 後の total SCORE は 7230 である。
+次フェーズの tracking Issue active threshold は 10000 であり、cycle 57 後の total SCORE は 7390 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 threshold 10000 には未達であるため、次 cycle では lawful criterion の necessity / minimality、
-heterogeneous route interaction、または Quality Surface holonomy-obstruction correspondence の
+bridge certificate を source-ref handoff から導出する theorem、または Quality Surface holonomy-obstruction correspondence の
 genius-target seed / support theorem を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 57 の研究成果として、heterogeneous route bridge obstruction を Lean research artifact として追加します。selected correction route と finite scan route-family の local exactness product が成立しても、support / trace / repair-frontier を持つ cross-route bridge certificate に obstruction があれば heterogeneous interaction exactness は成立しない、という分離を固定します。

Tracking Issue は score 10000 まで継続するため、この PR では close しません。

## 証明した定理

- `allBranchesScanAssignment_exact`
- `alignedBridge_aligned`
- `bridgeObstruction_not_aligned`
- `bridgeObstruction_obstructs_interactionExact`
- `productExactBridgeBroken_selectedLocalExact`
- `productExactBridgeBroken_scanLocalExact`
- `productExactBridgeBroken_productLocalExact`
- `productExactBridgeBroken_not_bridgeAligned`
- `heterogeneousProductExact_not_interactionExact`
- `bridgeAlignedInteractionState_interactionExact`
- `heterogeneousInteractionExact_implies_productLocalExact`
- `heterogeneousInteractionExact_implies_bridgeAligned`
- `sameLocalProduct_differentInteractionExactness`
- `heterogeneousRouteInteraction_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-heterogeneous-route-interaction-curvature.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/HeterogeneousRouteInteraction.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking issue 継続のため意図的に `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない