### PR TITLE
研究: route holonomy obstruction support を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -54,3 +54,4 @@ import Formal.AG.Research.QualitySurface.MultiRouteCorrectionSystem
 import Formal.AG.Research.QualitySurface.FiniteRouteFamilyExactLocus
 import Formal.AG.Research.QualitySurface.FailingSlotCertificate
 import Formal.AG.Research.QualitySurface.FiniteRouteScan
+import Formal.AG.Research.QualitySurface.RouteHolonomyObstructionSupport

--- a/Formal/AG/Research/QualitySurface/RouteHolonomyObstructionSupport.lean
+++ b/Formal/AG/Research/QualitySurface/RouteHolonomyObstructionSupport.lean
@@ -1,0 +1,429 @@
+import Formal.AG.Research.QualitySurface.HeterogeneousRouteInteraction
+
+/-!
+Cycle 58 evidence for `G-aat-quality-surface-01`.
+
+This file packages a finite selected route atlas as a closed-route holonomy
+surface.  Holonomy support is read from the supplied bridge certificate
+components, but atlas interaction exactness is defined separately as
+interaction exactness on every listed loop.  The result is relative to the
+selected finite atlas and supplied loop order.  It does not enumerate arbitrary
+route systems, prove global canonical minimality, synthesize repairs, validate
+ArchMap observations, or judge whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace RouteHolonomyObstructionSupport
+
+open HeterogeneousRouteInteraction
+open BridgeComponent
+
+/-! ## Selected closed-route atlas -/
+
+/-- Names for the selected closed-route loops in the finite atlas. -/
+inductive RouteLoopName where
+  | stable
+  | handoff
+  deriving DecidableEq
+
+open RouteLoopName
+
+/--
+A selected closed-route loop carries a heterogeneous route state.  The loop
+name is report-facing data; exactness is read from the state.
+-/
+structure RouteLoop where
+  name : RouteLoopName
+  state : HeterogeneousRouteState
+
+/-- A finite route atlas with its supplied loop order. -/
+structure RouteAtlas where
+  loops : List RouteLoop
+
+/-! ## Holonomy support -/
+
+/-- Holonomy support records which bridge component fails on a route loop. -/
+def HolonomySupport
+    (loop : RouteLoop) (component : BridgeComponent) : Prop :=
+  loop.state.bridge.component component = false
+
+/-- A route loop has some protected holonomy support. -/
+def HasHolonomySupport
+    (loop : RouteLoop) : Prop :=
+  ∃ component, HolonomySupport loop component
+
+/-- A route loop is holonomy-clear when every bridge component is preserved. -/
+def LoopHolonomyClear
+    (loop : RouteLoop) : Prop :=
+  ∀ component, loop.state.bridge.component component = true
+
+/-- Boolean clearance used by the supplied ordered scan. -/
+def loopHolonomyClearBool
+    (loop : RouteLoop) : Bool :=
+  loop.state.bridge.supportPreserved &&
+    loop.state.bridge.tracePreserved &&
+    loop.state.bridge.repairFrontierPreserved
+
+/-- Holonomy clearance is the same bridge alignment law used by interaction exactness. -/
+theorem bridgeHolonomyClear_iff_bridgeAligned
+    (loop : RouteLoop) :
+    LoopHolonomyClear loop ↔ BridgeAligned loop.state := by
+  constructor
+  · intro hclear
+    exact ⟨hclear support, hclear trace, hclear repairFrontier⟩
+  · intro haligned component
+    rcases haligned with ⟨hsupport, htrace, hrepair⟩
+    cases component with
+    | support =>
+        simpa [LoopHolonomyClear, BridgeCertificate.component] using hsupport
+    | trace =>
+        simpa [LoopHolonomyClear, BridgeCertificate.component] using htrace
+    | repairFrontier =>
+        simpa [LoopHolonomyClear, BridgeCertificate.component] using hrepair
+
+/-- The boolean scan predicate agrees with propositional holonomy clearance. -/
+theorem loopHolonomyClearBool_eq_true_iff
+    (loop : RouteLoop) :
+    loopHolonomyClearBool loop = true ↔ LoopHolonomyClear loop := by
+  constructor
+  · intro hclear component
+    cases component with
+    | support =>
+        cases hsupport : loop.state.bridge.supportPreserved <;>
+          simp [loopHolonomyClearBool, BridgeCertificate.component,
+            hsupport] at hclear ⊢
+    | trace =>
+        cases hsupport : loop.state.bridge.supportPreserved <;>
+          cases htrace : loop.state.bridge.tracePreserved <;>
+            simp [loopHolonomyClearBool, BridgeCertificate.component,
+              hsupport, htrace] at hclear ⊢
+    | repairFrontier =>
+        cases hsupport : loop.state.bridge.supportPreserved <;>
+          cases htrace : loop.state.bridge.tracePreserved <;>
+            cases hrepair : loop.state.bridge.repairFrontierPreserved <;>
+              simp [loopHolonomyClearBool, BridgeCertificate.component,
+                hsupport, htrace, hrepair] at hclear ⊢
+  · intro hclear
+    have hsupport : loop.state.bridge.supportPreserved = true := by
+      simpa [BridgeCertificate.component] using hclear support
+    have htrace : loop.state.bridge.tracePreserved = true := by
+      simpa [BridgeCertificate.component] using hclear trace
+    have hrepair :
+        loop.state.bridge.repairFrontierPreserved = true := by
+      simpa [BridgeCertificate.component] using hclear repairFrontier
+    simp [loopHolonomyClearBool, hsupport, htrace, hrepair]
+
+/-- A false boolean clearance exposes a nonempty holonomy support. -/
+theorem hasHolonomySupport_of_clearBool_false
+    {loop : RouteLoop}
+    (hclear : loopHolonomyClearBool loop = false) :
+    HasHolonomySupport loop := by
+  cases hsupport : loop.state.bridge.supportPreserved
+  · exact ⟨support, by
+      simp [HolonomySupport, BridgeCertificate.component, hsupport]⟩
+  · cases htrace : loop.state.bridge.tracePreserved
+    · exact ⟨trace, by
+        simp [HolonomySupport, BridgeCertificate.component, htrace]⟩
+    · cases hrepair : loop.state.bridge.repairFrontierPreserved
+      · exact ⟨repairFrontier, by
+          simp [HolonomySupport, BridgeCertificate.component, hrepair]⟩
+      · simp [loopHolonomyClearBool, hsupport, htrace, hrepair] at hclear
+
+/-- Holonomy support is a bridge obstruction certificate. -/
+def bridgeObstruction_of_holonomySupport
+    {loop : RouteLoop}
+    {component : BridgeComponent}
+    (hsupport : HolonomySupport loop component) :
+    BridgeObstruction loop.state.bridge where
+  component := component
+  fails := hsupport
+
+/-! ## Atlas exactness and holonomy vanishing -/
+
+/-- Every listed loop is locally exact before reading closed-route holonomy. -/
+def AtlasLocalExact
+    (atlas : RouteAtlas) : Prop :=
+  ∀ loop, loop ∈ atlas.loops -> ProductLocalExact loop.state
+
+/-- All listed loop holonomy supports vanish. -/
+def AtlasHolonomyVanishes
+    (atlas : RouteAtlas) : Prop :=
+  ∀ loop, loop ∈ atlas.loops -> LoopHolonomyClear loop
+
+/-- Atlas-level interaction exactness is interaction exactness on every listed loop. -/
+def RouteAtlasInteractionExact
+    (atlas : RouteAtlas) : Prop :=
+  ∀ loop, loop ∈ atlas.loops -> InteractionExact loop.state
+
+/--
+With local exactness fixed, loop holonomy clearance is equivalent to
+interaction exactness for that loop.
+-/
+theorem routeLoopHolonomyClear_iff_interactionExact_of_local
+    {loop : RouteLoop}
+    (hlocal : ProductLocalExact loop.state) :
+    LoopHolonomyClear loop ↔ InteractionExact loop.state := by
+  constructor
+  · intro hclear
+    exact ⟨hlocal, (bridgeHolonomyClear_iff_bridgeAligned loop).mp hclear⟩
+  · intro hexact
+    exact (bridgeHolonomyClear_iff_bridgeAligned loop).mpr hexact.2
+
+/--
+Atlas interaction exactness is equivalent to local exactness plus vanishing
+holonomy support on every listed loop.
+-/
+theorem routeAtlasInteractionExact_iff_localAndHolonomyClear
+    (atlas : RouteAtlas) :
+    RouteAtlasInteractionExact atlas ↔
+      AtlasLocalExact atlas ∧ AtlasHolonomyVanishes atlas := by
+  constructor
+  · intro hexact
+    constructor
+    · intro loop hmem
+      exact (hexact loop hmem).1
+    · intro loop hmem
+      exact (bridgeHolonomyClear_iff_bridgeAligned loop).mpr
+        (hexact loop hmem).2
+  · intro hpair loop hmem
+    exact ((routeLoopHolonomyClear_iff_interactionExact_of_local
+      (hpair.1 loop hmem)).mp (hpair.2 loop hmem))
+
+/-! ## Ordered first obstructing loop -/
+
+/-- The first listed loop whose closed-route holonomy support is nonempty. -/
+def firstObstructingLoop? : List RouteLoop -> Option RouteLoop
+  | [] => none
+  | loop :: rest =>
+      if loopHolonomyClearBool loop = true then
+        firstObstructingLoop? rest
+      else
+        some loop
+
+/-- The first obstructing loop is a member of the supplied loop order. -/
+theorem firstObstructingLoop?_some_mem :
+    ∀ {loops : List RouteLoop} {loop : RouteLoop},
+      firstObstructingLoop? loops = some loop ->
+        loop ∈ loops
+  | [], _loop, hsome => by
+      cases hsome
+  | head :: rest, loop, hsome => by
+      by_cases hhead : loopHolonomyClearBool head = true
+      · have htail :
+            firstObstructingLoop? rest = some loop := by
+          simpa [firstObstructingLoop?, hhead] using hsome
+        exact List.mem_cons_of_mem head
+          (firstObstructingLoop?_some_mem htail)
+      · have hloop : loop = head := by
+          simpa [firstObstructingLoop?, hhead] using hsome.symm
+        subst hloop
+        simp
+
+/-- A returned loop has nonempty holonomy support. -/
+theorem firstObstructingLoop?_some_nonemptySupport :
+    ∀ {loops : List RouteLoop} {loop : RouteLoop},
+      firstObstructingLoop? loops = some loop ->
+        HasHolonomySupport loop
+  | [], _loop, hsome => by
+      cases hsome
+  | head :: rest, loop, hsome => by
+      by_cases hhead : loopHolonomyClearBool head = true
+      · have htail :
+            firstObstructingLoop? rest = some loop := by
+          simpa [firstObstructingLoop?, hhead] using hsome
+        exact firstObstructingLoop?_some_nonemptySupport htail
+      · have hloop : loop = head := by
+          simpa [firstObstructingLoop?, hhead] using hsome.symm
+        have hfalse : loopHolonomyClearBool head = false := by
+          cases hbool : loopHolonomyClearBool head
+          · rfl
+          · exact False.elim (hhead hbool)
+        simpa [hloop] using hasHolonomySupport_of_clearBool_false hfalse
+
+/-- A returned loop carries an explicit bridge obstruction certificate. -/
+theorem firstObstructingLoop?_some_bridgeObstruction
+    {loops : List RouteLoop}
+    {loop : RouteLoop}
+    (hfirst : firstObstructingLoop? loops = some loop) :
+    ∃ _obstruction : BridgeObstruction loop.state.bridge, True := by
+  rcases firstObstructingLoop?_some_nonemptySupport hfirst with
+    ⟨component, hsupport⟩
+  exact ⟨bridgeObstruction_of_holonomySupport hsupport, trivial⟩
+
+/-- A returned first obstruction rules out atlas interaction exactness. -/
+theorem firstObstructingLoop?_some_obstructs_atlasInteractionExact
+    {loops : List RouteLoop}
+    {loop : RouteLoop}
+    (hfirst : firstObstructingLoop? loops = some loop) :
+    ¬ RouteAtlasInteractionExact { loops := loops } := by
+  intro hexact
+  rcases firstObstructingLoop?_some_bridgeObstruction hfirst with
+    ⟨obstruction, _⟩
+  exact bridgeObstruction_obstructs_interactionExact obstruction
+    (hexact loop (firstObstructingLoop?_some_mem hfirst))
+
+/-- No first obstruction is equivalent to vanishing holonomy on the supplied order. -/
+theorem firstObstructingLoop?_none_iff_holonomyVanishes :
+    ∀ loops : List RouteLoop,
+      firstObstructingLoop? loops = none ↔
+        AtlasHolonomyVanishes { loops := loops }
+  | [] => by
+      constructor
+      · intro _ loop hmem
+        cases hmem
+      · intro _
+        rfl
+  | head :: rest => by
+      constructor
+      · intro hnone loop hmem
+        by_cases hhead : loopHolonomyClearBool head = true
+        · have htail :
+              firstObstructingLoop? rest = none := by
+            simpa [firstObstructingLoop?, hhead] using hnone
+          cases hmem with
+          | head =>
+              exact (loopHolonomyClearBool_eq_true_iff head).mp hhead
+          | tail _ hlisted =>
+              exact ((firstObstructingLoop?_none_iff_holonomyVanishes
+                rest).mp htail) loop hlisted
+        · have hsome :
+              firstObstructingLoop? (head :: rest) = some head := by
+            simp [firstObstructingLoop?, hhead]
+          rw [hsome] at hnone
+          cases hnone
+      · intro hvans
+        have hhead : loopHolonomyClearBool head = true :=
+          (loopHolonomyClearBool_eq_true_iff head).mpr
+            (hvans head (by simp))
+        have htail :
+            firstObstructingLoop? rest = none :=
+          (firstObstructingLoop?_none_iff_holonomyVanishes rest).mpr
+            (by
+              intro loop hmem
+              exact hvans loop (by simp [hmem]))
+        simp [firstObstructingLoop?, hhead, htail]
+
+/-! ## Concrete mixed and aligned atlases -/
+
+/-- A holonomy-clear loop carrying the bridge-aligned comparator state. -/
+def alignedLoop : RouteLoop where
+  name := stable
+  state := bridgeAlignedInteractionState
+
+/-- A loop whose trace handoff bridge component is obstructed. -/
+def bridgeBrokenLoop : RouteLoop where
+  name := handoff
+  state := productExactBridgeBrokenState
+
+@[simp] theorem alignedLoop_clearBool :
+    loopHolonomyClearBool alignedLoop = true :=
+  rfl
+
+@[simp] theorem bridgeBrokenLoop_clearBool :
+    loopHolonomyClearBool bridgeBrokenLoop = false :=
+  rfl
+
+/-- The selected mixed atlas has one aligned loop followed by one obstructed loop. -/
+def mixedHolonomyAtlas : RouteAtlas where
+  loops := [alignedLoop, bridgeBrokenLoop]
+
+/-- The positive comparator atlas has only the aligned loop. -/
+def alignedHolonomyAtlas : RouteAtlas where
+  loops := [alignedLoop]
+
+/-- The mixed atlas is locally exact on every listed loop. -/
+theorem mixedHolonomyAtlas_localExact :
+    AtlasLocalExact mixedHolonomyAtlas := by
+  intro loop hmem
+  simp [mixedHolonomyAtlas] at hmem
+  rcases hmem with hloop | hloop
+  · subst hloop
+    exact bridgeAlignedInteractionState_interactionExact.1
+  · subst hloop
+    exact productExactBridgeBroken_productLocalExact
+
+/-- The mixed atlas has nonempty holonomy support on its handoff loop. -/
+theorem mixedHolonomyAtlas_handoff_nonemptySupport :
+    HasHolonomySupport bridgeBrokenLoop :=
+  hasHolonomySupport_of_clearBool_false bridgeBrokenLoop_clearBool
+
+/-- The ordered scan selects the handoff loop as the first obstruction. -/
+theorem mixedHolonomyAtlas_firstObstructingLoop :
+    firstObstructingLoop? mixedHolonomyAtlas.loops =
+      some bridgeBrokenLoop := by
+  simp [mixedHolonomyAtlas, firstObstructingLoop?]
+
+/-- The first obstruction in the mixed atlas carries a bridge obstruction certificate. -/
+theorem mixedHolonomyAtlas_firstObstructionCertificate :
+    ∃ _obstruction : BridgeObstruction bridgeBrokenLoop.state.bridge, True :=
+  firstObstructingLoop?_some_bridgeObstruction
+    mixedHolonomyAtlas_firstObstructingLoop
+
+/-- The mixed atlas is locally exact but not interaction exact. -/
+theorem mixedHolonomyAtlas_not_interactionExact :
+    AtlasLocalExact mixedHolonomyAtlas ∧
+      ¬ RouteAtlasInteractionExact mixedHolonomyAtlas := by
+  exact ⟨mixedHolonomyAtlas_localExact,
+    firstObstructingLoop?_some_obstructs_atlasInteractionExact
+      mixedHolonomyAtlas_firstObstructingLoop⟩
+
+/-- The aligned comparator atlas is interaction exact. -/
+theorem alignedHolonomyAtlas_interactionExact :
+    RouteAtlasInteractionExact alignedHolonomyAtlas := by
+  intro loop hmem
+  simp [alignedHolonomyAtlas] at hmem
+  subst hmem
+  exact bridgeAlignedInteractionState_interactionExact
+
+/-- The aligned comparator has vanishing holonomy. -/
+theorem alignedHolonomyAtlas_holonomyVanishes :
+    AtlasHolonomyVanishes alignedHolonomyAtlas :=
+  (routeAtlasInteractionExact_iff_localAndHolonomyClear
+    alignedHolonomyAtlas).mp alignedHolonomyAtlas_interactionExact |>.2
+
+/-! ## Theorem package -/
+
+/--
+Cycle-58 theorem package: a finite selected route atlas has interaction
+exactness exactly when local exactness and closed-route holonomy vanishing both
+hold; a nonzero holonomy support yields a first obstructing loop and bridge
+obstruction certificate.
+-/
+theorem routeAtlasHolonomyObstruction_package :
+    RouteAtlasInteractionExact alignedHolonomyAtlas ∧
+      AtlasLocalExact mixedHolonomyAtlas ∧
+      HasHolonomySupport bridgeBrokenLoop ∧
+      firstObstructingLoop? mixedHolonomyAtlas.loops =
+        some bridgeBrokenLoop ∧
+      (∃ _obstruction : BridgeObstruction bridgeBrokenLoop.state.bridge, True) ∧
+      ¬ RouteAtlasInteractionExact mixedHolonomyAtlas ∧
+      (∀ atlas : RouteAtlas,
+        RouteAtlasInteractionExact atlas ↔
+          AtlasLocalExact atlas ∧ AtlasHolonomyVanishes atlas) ∧
+      (∀ loops loop,
+        firstObstructingLoop? loops = some loop ->
+          loop ∈ loops ∧
+            HasHolonomySupport loop ∧
+            (∃ _obstruction : BridgeObstruction loop.state.bridge, True) ∧
+            ¬ RouteAtlasInteractionExact { loops := loops }) ∧
+      (∀ loops,
+        firstObstructingLoop? loops = none ↔
+          AtlasHolonomyVanishes { loops := loops }) := by
+  exact ⟨alignedHolonomyAtlas_interactionExact,
+    mixedHolonomyAtlas_localExact,
+    mixedHolonomyAtlas_handoff_nonemptySupport,
+    mixedHolonomyAtlas_firstObstructingLoop,
+    mixedHolonomyAtlas_firstObstructionCertificate,
+    mixedHolonomyAtlas_not_interactionExact.2,
+    routeAtlasInteractionExact_iff_localAndHolonomyClear,
+    fun loops loop hfirst =>
+      ⟨firstObstructingLoop?_some_mem hfirst,
+        firstObstructingLoop?_some_nonemptySupport hfirst,
+        firstObstructingLoop?_some_bridgeObstruction hfirst,
+        firstObstructingLoop?_some_obstructs_atlasInteractionExact hfirst⟩,
+    firstObstructingLoop?_none_iff_holonomyVanishes⟩
+
+end RouteHolonomyObstructionSupport
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-finite-route-holonomy-obstruction-support.md
+++ b/research/ideas/g-aat-quality-surface-01-finite-route-holonomy-obstruction-support.md
@@ -1,0 +1,128 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: profile-curvature / certificate-transport / obstruction / traceability / computability / repair-potential / quality-surface
+expected_base_score: 78
+expected_evidence_multiplier: 2.0
+expected_final_score: 156
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance tools can report route failures or cross-view inconsistencies, but this candidate packages closed-route holonomy support, first obstructing loop selection, and bridge obstruction certificates as one finite AAT theorem surface.
+origin: cycle-58
+tags: [quality-surface, holonomy, obstruction, route-atlas, bridge]
+created: 2026-06-21
+cycle: 58
+lean: Formal/AG/Research/QualitySurface/RouteHolonomyObstructionSupport.lean
+---
+
+# Finite route holonomy obstruction support theorem
+
+## 主張
+
+supplied finite route atlas 上で、closed route / loop cell ごとの protected bridge component defect を holonomy support として読み、
+local exactness product とは別に定義した `LoopHolonomyClear` が all selected loops で成り立つことと、
+atlas の heterogeneous interaction exactness が一致することを示す。
+holonomy support が非空なら、ordered scan は first obstructing loop を返し、その loop は support / trace / repair-frontier 成分を持つ
+bridge obstruction certificate を与える。
+
+この主張は selected finite atlas、supplied loop order、existing local exactness product、supplied bridge certificate に相対化する。
+arbitrary route system enumeration、global canonical minimality、runtime repair synthesis、ArchMap correctness、
+source extraction completeness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- Cycle 55: finite route scan
+- Cycle 56: ordered scan first-failing slot certificate
+- Cycle 57: heterogeneous route bridge obstruction
+- GOAL frontier: Quality Surface holonomy-obstruction correspondence
+
+## 非自明性
+
+直近の scan / first-failing selector / heterogeneous bridge obstruction を単に並べるのではなく、
+`RouteLoop`、`HolonomySupport`、`LoopHolonomyClear`、`RouteAtlasInteractionExact` を分離し、
+closed-route holonomy support の vanishing criterion と nonzero support certificate を同じ finite atlas statement に圧縮する。
+local exactness product が green でも、closed-route protected component holonomy が残ると interaction exactness は失敗する。
+
+## 数学的興味
+
+Quality Surface の curvature / holonomy を dashboard の失敗 flag ではなく、support / trace / repair-frontier component を持つ
+obstruction certificate として読む。この cycle では `genius-target` や 1000 点 unlock ではなく、
+finite selected atlas に相対化した通常 SCORE の unification theorem を狙う。
+
+## GOAL への前進
+
+profile curvature、certificate transport、obstruction、traceability、computability を、finite route atlas 上の
+holonomy support vanishing criterion と first obstruction selector へ統合する。
+
+## ライバルに対する有効性
+
+ADL / architecture conformance checker は route failure、cross-view inconsistency、constraint violation を表示できる。
+この候補は、その表示面の上に、closed route transport の protected holonomy support と bridge obstruction certificate を置き、
+zero-holonomy / nonzero-obstruction の finite theorem package として AAT 側に固定する。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 55-57 の computable scan、ordered first-failing selector、heterogeneous bridge obstruction を、holonomy-obstruction support theorem に統合する。ただし直近三 cycle の自然な合成でもあるため、G2 A の strict base 78 を保守的な入力値にする。
+- `dullness_risk`: `holonomy` と呼ぶだけで既存 bridge failure を言い換えるなら reject。closed route atlas、vanishing criterion、first obstructing loop certificate、positive aligned comparator を含める。
+- `proof_or_evidence_plan`: Lean で `RouteLoop`、`HolonomySupport`、`LoopHolonomyClear`、`RouteAtlasInteractionExact` を分離して定義した。finite two-loop atlas、atlas local exactness、first obstructing loop selector、nonzero holonomy support obstruction、all-clear aligned comparator、package theorem は `RouteHolonomyObstructionSupport.lean` で証明済み。
+
+## CS / SWE への帰結
+
+すべての local route status が green に見えても、closed route / cross-route handoff の protected holonomy support が残る場合、
+Quality Surface は first obstructing loop と bridge obstruction component を reportable reason として返せる。
+これは runtime patch synthesis や source extraction completeness ではなく、supplied evidence surface 上の finite diagnostic theorem である。
+
+## 証明・根拠の見込み
+
+Lean file `RouteHolonomyObstructionSupport.lean` に置く。
+主要 declaration の候補は次である。`HolonomySupport` は bridge component defect を読むが、
+`RouteAtlasInteractionExact` は listed loop ごとの `InteractionExact` として別に定義し、
+local exactness product と all-loop holonomy clearance との関係は theorem として証明する。
+
+- `RouteLoop`
+- `HolonomySupport`
+- `LoopHolonomyClear`
+- `RouteAtlasInteractionExact`
+- `bridgeHolonomyClear_iff_bridgeAligned`
+- `loopHolonomyClearBool_eq_true_iff`
+- `hasHolonomySupport_of_clearBool_false`
+- `bridgeObstruction_of_holonomySupport`
+- `routeLoopHolonomyClear_iff_interactionExact_of_local`
+- `routeAtlasInteractionExact_iff_localAndHolonomyClear`
+- `firstObstructingLoop?_none_iff_holonomyVanishes`
+- `firstObstructingLoop?_some_mem`
+- `firstObstructingLoop?_some_nonemptySupport`
+- `firstObstructingLoop?_some_bridgeObstruction`
+- `firstObstructingLoop?_some_obstructs_atlasInteractionExact`
+- `mixedHolonomyAtlas_firstObstructingLoop`
+- `mixedHolonomyAtlas_firstObstructionCertificate`
+- `mixedHolonomyAtlas_not_interactionExact`
+- `alignedHolonomyAtlas_interactionExact`
+- `alignedHolonomyAtlas_holonomyVanishes`
+- `routeAtlasHolonomyObstruction_package`
+
+## 審判メモ
+
+- G3: `lake env lean Formal/AG/Research/QualitySurface/RouteHolonomyObstructionSupport.lean`、`lake build FormalAGResearch`、full `lake build` は pass。full build のみ既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` warning を再生した。
+- G3 axiom audit: `bridgeHolonomyClear_iff_bridgeAligned`、`bridgeObstruction_of_holonomySupport`、`routeLoopHolonomyClear_iff_interactionExact_of_local`、`routeAtlasInteractionExact_iff_localAndHolonomyClear` は axiom-free。boolean / scan selector family は `propext`、mixed / aligned atlas evidence と package theorem は existing exactness infrastructure 由来の `propext` / `Quot.sound` を継承する。`sorryAx`、nonstandard axiom、`Classical.choice` はない。
+- G3 formalization quality: pass。`RouteLoop` / `HolonomySupport` / `LoopHolonomyClear` / `RouteAtlasInteractionExact` は分離され、mixed atlas は local exact かつ not interaction exact、aligned comparator は interaction exact として固定された。
+- 研究価値: G2 B は accept、base 88。base 95 は高すぎ、強い中間定理として評価。
+- repo 全体価値: G2 C は accept、base 85。vanishing criterion、nonzero support certificate、positive aligned comparator が必要。
+- ライバル比較: G2 D は accept、base 90。ADL の failure display を finite certificate geometry に変換する点を評価。
+- 厳密性: G2 A は初回 revise 後 accept、base 78。`holonomy` の名前替えリスクを下げるため、`RouteLoop` / `HolonomySupport` / `LoopHolonomyClear` / `RouteAtlasInteractionExact` の分離、local exact product + nonzero closed-route support witness、aligned comparator、first obstruction の membership / nonempty support / component / obstruction を要求し、修正版 card と Lean statement はそれを満たした。
+- genius: この cycle では `genius_potential: no` として扱う。open genius target はなく、1000 点 unlock は主張しない。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-finite-route-scan.md`
+- `research/ideas/g-aat-quality-surface-01-ordered-scan-first-failing-slot.md`
+- `research/ideas/g-aat-quality-surface-01-heterogeneous-route-interaction-curvature.md`
+
+## 進捗ログ
+
+- 2026-06-21: cycle 58 G1 候補 pool から G2 審判対象として作成。
+- 2026-06-21: G2 revise 解消、G3 Lean 証拠固定。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 7390
+- total SCORE: 7546
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -62,8 +62,9 @@
   - computability / obstruction / certificate-transport / repair-potential / traceability / quality-surface: 140
   - computability / obstruction / certificate-transport / traceability / quality-surface: 140
   - profile-curvature / certificate-transport / obstruction / repair-potential / traceability / quality-surface: 160
+  - profile-curvature / certificate-transport / obstruction / traceability / computability / repair-potential / quality-surface: 156
 - evidence portfolio:
-  - proved-in-research: 57
+  - proved-in-research: 58
 
 ## Phase synthesis
 
@@ -79,7 +80,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-57 件の Lean-proved research artifacts は、次の paper seed を形成している。
+58 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -123,9 +124,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 57 後の total SCORE は 7390 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 58 後の total SCORE は 7546 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 57 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 58 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 
@@ -2607,12 +2608,59 @@ support / trace / repair-frontier bridge certificate を含む interaction cell 
 source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 genius scoring は適用しない。G2 四審判は通常 SCORE として accept し、base 80 とした。
 
+## Cycle 58: Finite route holonomy obstruction support theorem
+
+```text
+candidate: Finite route holonomy obstruction support theorem
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 78
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 156
+category: profile-curvature / certificate-transport / obstruction / traceability / computability / repair-potential / quality-surface
+goal_delta: Cycle 55-57 の finite scan、ordered first-failing selector、heterogeneous bridge obstruction を、selected finite route atlas 上の holonomy support vanishing criterion と first obstruction certificate に統合した。
+project_value_delta: local exactness product が green でも closed-route protected holonomy support が残ると atlas interaction exactness が壊れることを Lean finite witness として固定した。
+rival_delta: ADL / conformance checker は route failure や cross-view inconsistency を表示できるが、closed-route holonomy support、first obstructing loop、support / trace / repair-frontier bridge obstruction certificate を一つの finite certificate geometry としては束ねない。
+formalization_quality: pass。`lake env lean`、`lake build FormalAGResearch`、full `lake build` は pass。core equivalence / bridge obstruction constructors は axiom-free。boolean clearance / selector family は `propext`、mixed / aligned atlas evidence と package theorem は既存 exactness infrastructure 由来の `propext` / `Quot.sound` を継承する。`sorryAx`、nonstandard axiom、`Classical.choice` はない。
+open_questions: source-ref handoff から bridge certificate を導出する theorem、heterogeneous bridge law minimality matrix、finite holonomy-obstruction correspondence の broader theorem program。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/RouteHolonomyObstructionSupport.lean` は、
+selected finite route atlas を closed-route holonomy surface として読む。
+各 `RouteLoop` は heterogeneous route state を持ち、`HolonomySupport` は bridge certificate の
+support / trace / repair-frontier component defect を読む。一方で `RouteAtlasInteractionExact` は
+listed loop ごとの `InteractionExact` として別に定義され、local exactness product と holonomy clearance の関係は theorem として証明される。
+
+Lean 証拠は次を固定する。
+
+- `bridgeHolonomyClear_iff_bridgeAligned`: loop holonomy clearance は bridge alignment と同値である。
+- `routeLoopHolonomyClear_iff_interactionExact_of_local`: local exactness product の下で、loop holonomy clearance は interaction exactness と同値である。
+- `routeAtlasInteractionExact_iff_localAndHolonomyClear`: atlas interaction exactness は atlas local exactness と all-loop holonomy vanishing の組と同値である。
+- `firstObstructingLoop?_some_mem`: ordered selector が返す loop は supplied loop order の member である。
+- `firstObstructingLoop?_some_nonemptySupport`: returned loop は nonempty holonomy support を持つ。
+- `firstObstructingLoop?_some_bridgeObstruction`: returned loop は explicit bridge obstruction certificate を持つ。
+- `firstObstructingLoop?_some_obstructs_atlasInteractionExact`: returned first obstruction は atlas interaction exactness を阻む。
+- `firstObstructingLoop?_none_iff_holonomyVanishes`: no first obstruction は supplied loop order 上の holonomy vanishing と同値である。
+- `mixedHolonomyAtlas_not_interactionExact`: mixed atlas は locally exact だが interaction exact ではない。
+- `alignedHolonomyAtlas_interactionExact`: aligned comparator atlas は interaction exact である。
+- `routeAtlasHolonomyObstruction_package`: aligned comparator、mixed nonzero support、first obstruction certificate、vanishing criterion を束ねる。
+
+この結果により、Quality Surface の route / bridge interaction は per-route green status ではなく、
+closed route 上の protected holonomy support と first obstruction certificate として読める。
+ただし主張は selected finite atlas、supplied loop order、supplied bridge certificate に相対化され、
+arbitrary route system enumeration、global canonical minimality、runtime repair synthesis、
+source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
+genius scoring は適用しない。G2 四審判は通常 SCORE として accept し、strict base 78 を G4 入力値とした。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 10000 であり、cycle 57 後の total SCORE は 7390 である。
+次フェーズの tracking Issue active threshold は 10000 であり、cycle 58 後の total SCORE は 7546 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 threshold 10000 には未達であるため、次 cycle では lawful criterion の necessity / minimality、
-bridge certificate を source-ref handoff から導出する theorem、または Quality Surface holonomy-obstruction correspondence の
-genius-target seed / support theorem を狙う。
+bridge certificate を source-ref handoff から導出する theorem、または finite holonomy-obstruction correspondence の
+broader theorem program を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 58 の研究成果として、finite route holonomy obstruction support theorem を追加します。Cycle 55-57 の finite scan、ordered first-failing selector、heterogeneous bridge obstruction を、selected finite route atlas 上の holonomy support vanishing criterion と first obstruction certificate に統合します。

Tracking Issue は score 10000 まで継続するため、この PR では close しません。

## 証明した定理

- `bridgeHolonomyClear_iff_bridgeAligned`
- `loopHolonomyClearBool_eq_true_iff`
- `hasHolonomySupport_of_clearBool_false`
- `bridgeObstruction_of_holonomySupport`
- `routeLoopHolonomyClear_iff_interactionExact_of_local`
- `routeAtlasInteractionExact_iff_localAndHolonomyClear`
- `firstObstructingLoop?_some_mem`
- `firstObstructingLoop?_some_nonemptySupport`
- `firstObstructingLoop?_some_bridgeObstruction`
- `firstObstructingLoop?_some_obstructs_atlasInteractionExact`
- `firstObstructingLoop?_none_iff_holonomyVanishes`
- `mixedHolonomyAtlas_localExact`
- `mixedHolonomyAtlas_handoff_nonemptySupport`
- `mixedHolonomyAtlas_firstObstructingLoop`
- `mixedHolonomyAtlas_firstObstructionCertificate`
- `mixedHolonomyAtlas_not_interactionExact`
- `alignedHolonomyAtlas_interactionExact`
- `alignedHolonomyAtlas_holonomyVanishes`
- `routeAtlasHolonomyObstruction_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-finite-route-holonomy-obstruction-support.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/RouteHolonomyObstructionSupport.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `#print axioms` for reported declarations
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking issue 継続のため意図的に `Refs #2348`）
- [x] Lean status を `proved` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない