### PR TITLE
研究: source-ref handoff bridge を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -55,3 +55,4 @@ import Formal.AG.Research.QualitySurface.FiniteRouteFamilyExactLocus
 import Formal.AG.Research.QualitySurface.FailingSlotCertificate
 import Formal.AG.Research.QualitySurface.FiniteRouteScan
 import Formal.AG.Research.QualitySurface.RouteHolonomyObstructionSupport
+import Formal.AG.Research.QualitySurface.SourceRefHandoffBridge

--- a/Formal/AG/Research/QualitySurface/SourceRefHandoffBridge.lean
+++ b/Formal/AG/Research/QualitySurface/SourceRefHandoffBridge.lean
@@ -1,0 +1,415 @@
+import Formal.AG.Research.QualitySurface.HeterogeneousRouteInteraction
+import Formal.AG.Research.QualitySurface.SourceRefTupleBridge
+
+/-!
+Cycle 59 evidence for `G-aat-quality-surface-01`.
+
+This file derives the heterogeneous bridge certificate from a bounded
+source-ref handoff between a supplied `SourceRefPacket` and an endpoint
+certificate tuple. The bridge booleans are tied by iff proofs to support,
+trace-token, and repair-frontier compatibility laws. The result is relative
+to the selected finite packet/tuple handoff and does not assert source
+extraction completeness, ArchMap correctness, runtime repair synthesis,
+arbitrary route enumeration, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SourceRefHandoffBridge
+
+open CodebaseTracePacket
+open HeterogeneousRouteInteraction
+open MultiRouteCorrectionSystem
+open ParametrizedSelectedCorrectionSystem
+open ProfileTupleIntegration
+open SourceRefTupleBridge
+open TraceLocus
+open BridgeComponent
+open RepairStage
+open RouteSlot
+
+abbrev EndpointTuple :=
+  ProfileTupleIntegration.TupleCertificateAt SourceRefTupleBridge.endpointProfile
+
+/-! ## Source-ref handoff laws -/
+
+/-- Support coverage compatibility between a source-ref packet and endpoint tuple. -/
+def HandoffSupportCompatible
+    (packet : SourceRefPacket) (tuple : EndpointTuple) : Prop :=
+  forall atom,
+    tuple.selectedSupport (toLocusAtom atom) <-> packet.codeSupport atom
+
+/-- Trace-token compatibility between a source-ref packet and endpoint tuple. -/
+def HandoffTraceCompatible
+    (packet : SourceRefPacket) (tuple : EndpointTuple) : Prop :=
+  forall atom,
+    tuple.traceField (toLocusAtom atom) =
+      Option.map sourceRefToTraceToken (packet.sourceRefTable atom)
+
+/-- Repair-frontier compatibility between a source-ref packet and endpoint tuple. -/
+def HandoffRepairFrontierCompatible
+    (packet : SourceRefPacket) (tuple : EndpointTuple) : Prop :=
+  forall atom,
+    tuple.repairFrontier (toLocusAtom atom) <-> packet.repairFrontier atom
+
+/--
+A bounded source-ref handoff.
+
+The three boolean fields are not raw bridge data: each is certified by an iff
+against the corresponding source-ref / tuple compatibility law.
+-/
+structure SourceRefHandoff where
+  packet : SourceRefPacket
+  tuple : EndpointTuple
+  supportCertified : Bool
+  traceCertified : Bool
+  repairFrontierCertified : Bool
+  supportCertified_iff :
+    supportCertified = true <->
+      HandoffSupportCompatible packet tuple
+  traceCertified_iff :
+    traceCertified = true <->
+      HandoffTraceCompatible packet tuple
+  repairFrontierCertified_iff :
+    repairFrontierCertified = true <->
+      HandoffRepairFrontierCompatible packet tuple
+
+/-- Read the certified source-ref handoff component. -/
+def SourceRefHandoff.component
+    (handoff : SourceRefHandoff) : BridgeComponent -> Bool
+  | support => handoff.supportCertified
+  | trace => handoff.traceCertified
+  | repairFrontier => handoff.repairFrontierCertified
+
+/-- The source-ref handoff law represented by one bridge component. -/
+def SourceRefHandoff.ComponentLaw
+    (handoff : SourceRefHandoff) : BridgeComponent -> Prop
+  | support => HandoffSupportCompatible handoff.packet handoff.tuple
+  | trace => HandoffTraceCompatible handoff.packet handoff.tuple
+  | repairFrontier => HandoffRepairFrontierCompatible handoff.packet handoff.tuple
+
+/-- Convert a source-ref handoff into the heterogeneous bridge certificate. -/
+def SourceRefHandoff.toBridgeCertificate
+    (handoff : SourceRefHandoff) : BridgeCertificate where
+  supportPreserved := handoff.supportCertified
+  tracePreserved := handoff.traceCertified
+  repairFrontierPreserved := handoff.repairFrontierCertified
+
+/-- A source-ref handoff is aligned when all three underlying laws hold. -/
+def SourceRefHandoff.Aligned
+    (handoff : SourceRefHandoff) : Prop :=
+  HandoffSupportCompatible handoff.packet handoff.tuple /\
+    HandoffTraceCompatible handoff.packet handoff.tuple /\
+    HandoffRepairFrontierCompatible handoff.packet handoff.tuple
+
+/-- The derived bridge reads the same certified component as the handoff. -/
+theorem sourceRefHandoff_bridgeCertificate_component
+    (handoff : SourceRefHandoff)
+    (component : BridgeComponent) :
+    handoff.toBridgeCertificate.component component =
+      handoff.component component := by
+  cases component <;> rfl
+
+/-- Handoff alignment is exactly bridge alignment of the derived certificate. -/
+theorem sourceRefHandoff_aligned_iff_bridgeAligned
+    (handoff : SourceRefHandoff) :
+    handoff.Aligned <-> handoff.toBridgeCertificate.Aligned := by
+  constructor
+  · intro haligned
+    rcases haligned with ⟨hsupport, htrace, hrepair⟩
+    exact
+      ⟨handoff.supportCertified_iff.mpr hsupport,
+        handoff.traceCertified_iff.mpr htrace,
+        handoff.repairFrontierCertified_iff.mpr hrepair⟩
+  · intro hbridge
+    rcases hbridge with ⟨hsupport, htrace, hrepair⟩
+    exact
+      ⟨handoff.supportCertified_iff.mp hsupport,
+        handoff.traceCertified_iff.mp htrace,
+        handoff.repairFrontierCertified_iff.mp hrepair⟩
+
+/-- An aligned source-ref handoff yields an aligned bridge certificate. -/
+theorem sourceRefHandoff_bridgeAligned
+    {handoff : SourceRefHandoff}
+    (haligned : handoff.Aligned) :
+    handoff.toBridgeCertificate.Aligned :=
+  (sourceRefHandoff_aligned_iff_bridgeAligned handoff).mp haligned
+
+/-! ## Component failures -/
+
+/-- A source-ref handoff failure remembers the failed underlying law. -/
+structure SourceRefHandoffFailure
+    (handoff : SourceRefHandoff) where
+  component : BridgeComponent
+  certifiedFalse : handoff.component component = false
+  lawFailure : Not (handoff.ComponentLaw component)
+
+/-- A failed handoff law has false certified bridge component. -/
+theorem sourceRefHandoffFailure_component_false
+    {handoff : SourceRefHandoff}
+    (failure : SourceRefHandoffFailure handoff) :
+    handoff.component failure.component = false :=
+  failure.certifiedFalse
+
+/-- A source-ref handoff failure derives a heterogeneous bridge obstruction. -/
+def sourceRefHandoffFailure_bridgeObstruction
+    {handoff : SourceRefHandoff}
+    (failure : SourceRefHandoffFailure handoff) :
+    BridgeObstruction handoff.toBridgeCertificate where
+  component := failure.component
+  fails := by
+    simpa [BridgeCertificate.component,
+      SourceRefHandoff.toBridgeCertificate, SourceRefHandoff.component]
+      using sourceRefHandoffFailure_component_false failure
+
+/-- A source-ref handoff failure obstructs any state using the derived bridge. -/
+theorem sourceRefHandoffFailure_obstructs_interactionExact
+    {handoff : SourceRefHandoff}
+    {state : HeterogeneousRouteState}
+    (hbridge : state.bridge = handoff.toBridgeCertificate)
+    (failure : SourceRefHandoffFailure handoff) :
+    Not (InteractionExact state) := by
+  have obstruction : BridgeObstruction state.bridge := by
+    simpa [hbridge] using
+      sourceRefHandoffFailure_bridgeObstruction failure
+  exact bridgeObstruction_obstructs_interactionExact obstruction
+
+/-! ## Concrete source-ref handoff witnesses -/
+
+/-- Endpoint trace field with the endpoint token renamed but the missing locus unchanged. -/
+def traceRenamedEndpointTraceField :
+    LocusAtom -> Option LocusTraceToken
+  | LocusAtom.api => some LocusTraceToken.refDatabase
+  | LocusAtom.database => none
+  | LocusAtom.queue => some LocusTraceToken.refQueue
+
+/-- Repair frontier on the database locus. -/
+def databaseLocusRepairFrontier : Set LocusAtom :=
+  fun atom => atom = LocusAtom.database
+
+/--
+Tuple with the same support and repair frontier as the partial source-ref
+packet, but with a wrong endpoint trace token.
+-/
+def traceRenamedEndpointTuple : EndpointTuple where
+  gridCertificate := endpointGridCertificate
+  sigma := partialPacket.visibleScalarReading
+  omega := partialPacket.obligation
+  selectedSupport := fun _ => True
+  repairFrontier := databaseLocusRepairFrontier
+  nu := partialPacket.verdict
+  traceField := traceRenamedEndpointTraceField
+
+/-- The trace-renamed tuple still has an exact repair frontier. -/
+theorem sourceRefHandoff_traceRenamedTuple_repairFrontierExact :
+    TupleRepairFrontierExact traceRenamedEndpointTuple := by
+  intro atom
+  cases atom <;>
+    simp [TupleTraceMissingLocus, traceRenamedEndpointTuple,
+      traceRenamedEndpointTraceField, databaseLocusRepairFrontier]
+
+/-- The trace-renamed tuple is support-compatible with the partial packet. -/
+theorem traceRenamedHandoff_supportCompatible :
+    HandoffSupportCompatible partialPacket traceRenamedEndpointTuple := by
+  intro atom
+  cases atom <;> rfl
+
+/-- The trace-renamed tuple is repair-frontier-compatible with the partial packet. -/
+theorem traceRenamedHandoff_repairFrontierCompatible :
+    HandoffRepairFrontierCompatible partialPacket traceRenamedEndpointTuple := by
+  intro atom
+  cases atom <;>
+    simp [traceRenamedEndpointTuple, partialPacket, storageRepairFrontier,
+      databaseLocusRepairFrontier, toLocusAtom]
+
+/-- The endpoint trace token is not compatible with the partial packet. -/
+theorem traceRenamedHandoff_not_traceCompatible :
+    Not (HandoffTraceCompatible partialPacket traceRenamedEndpointTuple) := by
+  intro htrace
+  have hendpoint := htrace CodeAtom.endpoint
+  simp [traceRenamedEndpointTuple, traceRenamedEndpointTraceField,
+    partialPacket, partialSourceRefTable, sourceRefToTraceToken,
+    toLocusAtom] at hendpoint
+
+/-- Source-ref handoff with support and repair laws but a trace-token failure. -/
+def traceRenamedHandoff : SourceRefHandoff where
+  packet := partialPacket
+  tuple := traceRenamedEndpointTuple
+  supportCertified := true
+  traceCertified := false
+  repairFrontierCertified := true
+  supportCertified_iff := by
+    constructor
+    · intro _h
+      exact traceRenamedHandoff_supportCompatible
+    · intro _h
+      rfl
+  traceCertified_iff := by
+    constructor
+    · intro h
+      cases h
+    · intro h
+      exact False.elim (traceRenamedHandoff_not_traceCompatible h)
+  repairFrontierCertified_iff := by
+    constructor
+    · intro _h
+      exact traceRenamedHandoff_repairFrontierCompatible
+    · intro _h
+      rfl
+
+/-- The trace-renamed handoff keeps packet and tuple repair frontier exactness. -/
+theorem traceRenamedHandoff_exactRepairEvidence :
+    RepairFrontierExact partialPacket /\
+      TupleRepairFrontierExact traceRenamedEndpointTuple :=
+  ⟨partialTrace_repairFrontierExact,
+    sourceRefHandoff_traceRenamedTuple_repairFrontierExact⟩
+
+/-- The trace-renamed handoff carries a source-ref trace failure. -/
+def traceRenamedHandoff_failure :
+    SourceRefHandoffFailure traceRenamedHandoff where
+  component := trace
+  certifiedFalse := rfl
+  lawFailure := traceRenamedHandoff_not_traceCompatible
+
+/-- The trace-renamed handoff derives a bridge obstruction. -/
+def traceRenamedHandoff_bridgeObstruction :
+    BridgeObstruction traceRenamedHandoff.toBridgeCertificate :=
+  sourceRefHandoffFailure_bridgeObstruction traceRenamedHandoff_failure
+
+/-- Source-ref handoff induced by the full packet-to-tuple bridge. -/
+def alignedSourceRefHandoff : SourceRefHandoff where
+  packet := fullPacket
+  tuple := fullPacketEndpointTuple
+  supportCertified := true
+  traceCertified := true
+  repairFrontierCertified := true
+  supportCertified_iff := by
+    constructor
+    · intro _h atom
+      cases atom <;> rfl
+    · intro _h
+      rfl
+  traceCertified_iff := by
+    constructor
+    · intro _h atom
+      cases atom <;> rfl
+    · intro _h
+      rfl
+  repairFrontierCertified_iff := by
+    constructor
+    · intro _h atom
+      cases atom <;> rfl
+    · intro _h
+      rfl
+
+/-- The aligned handoff is the existing packet-to-tuple bridge witness. -/
+theorem alignedSourceRefHandoff_packetTupleAligned :
+    PacketTupleAligned fullPacket alignedSourceRefHandoff.tuple := by
+  simpa [alignedSourceRefHandoff] using
+    fullPacket_aligns_fullPacketEndpointTuple
+
+/-- The aligned source-ref handoff satisfies all underlying handoff laws. -/
+theorem alignedSourceRefHandoff_aligned :
+    alignedSourceRefHandoff.Aligned :=
+  (sourceRefHandoff_aligned_iff_bridgeAligned
+    alignedSourceRefHandoff).mpr
+    ⟨rfl, rfl, rfl⟩
+
+/-! ## Derived heterogeneous states -/
+
+/-- Heterogeneous state using the trace-renamed derived bridge. -/
+def sourceRefHandoffBridgeBrokenState : HeterogeneousRouteState where
+  selectedStage := allBranches
+  scanAssignment := allBranchesScanAssignment
+  bridge := traceRenamedHandoff.toBridgeCertificate
+
+/-- Heterogeneous state using the aligned source-ref derived bridge. -/
+def alignedSourceRefHandoffState : HeterogeneousRouteState where
+  selectedStage := allBranches
+  scanAssignment := allBranchesScanAssignment
+  bridge := alignedSourceRefHandoff.toBridgeCertificate
+
+/-- The trace-renamed source-ref handoff state is locally exact on both routes. -/
+theorem sourceRefHandoffBridgeBroken_productLocalExact :
+    ProductLocalExact sourceRefHandoffBridgeBrokenState := by
+  constructor
+  · simpa [SelectedRouteLocalExact, sourceRefHandoffBridgeBrokenState]
+      using stagedCorrection_allBranches_exact
+  · simpa [ScanRouteLocalExact, sourceRefHandoffBridgeBrokenState]
+      using allBranchesScanAssignment_exact
+
+/-- A source-ref trace-token failure obstructs the derived interaction exactness. -/
+theorem sourceRefHandoffBridgeBroken_not_interactionExact :
+    Not (InteractionExact sourceRefHandoffBridgeBrokenState) :=
+  sourceRefHandoffFailure_obstructs_interactionExact
+    (handoff := traceRenamedHandoff)
+    (state := sourceRefHandoffBridgeBrokenState)
+    rfl
+    traceRenamedHandoff_failure
+
+/--
+The source-ref handoff witness is product-local-exact but not interaction exact.
+-/
+theorem sourceRefHandoff_productLocalExact_not_interactionExact :
+    ProductLocalExact sourceRefHandoffBridgeBrokenState /\
+      Not (InteractionExact sourceRefHandoffBridgeBrokenState) :=
+  ⟨sourceRefHandoffBridgeBroken_productLocalExact,
+    sourceRefHandoffBridgeBroken_not_interactionExact⟩
+
+/-- The aligned source-ref handoff comparator is interaction exact. -/
+theorem alignedSourceRefHandoff_interactionExact :
+    InteractionExact alignedSourceRefHandoffState := by
+  constructor
+  · constructor
+    · simpa [SelectedRouteLocalExact, alignedSourceRefHandoffState]
+        using stagedCorrection_allBranches_exact
+    · simpa [ScanRouteLocalExact, alignedSourceRefHandoffState]
+        using allBranchesScanAssignment_exact
+  · simpa [alignedSourceRefHandoffState]
+      using sourceRefHandoff_bridgeAligned
+        alignedSourceRefHandoff_aligned
+
+/-! ## Theorem package -/
+
+/--
+Cycle-59 theorem package: source-ref handoff laws derive the heterogeneous
+bridge certificate, component law failure derives bridge obstruction, and a
+trace-token handoff failure separates local exactness from interaction
+exactness.
+-/
+theorem sourceRefHandoffBridge_package :
+    PacketTupleAligned fullPacket alignedSourceRefHandoff.tuple /\
+      RepairFrontierExact partialPacket /\
+      TupleRepairFrontierExact traceRenamedEndpointTuple /\
+      HandoffSupportCompatible partialPacket traceRenamedEndpointTuple /\
+      Not (HandoffTraceCompatible partialPacket traceRenamedEndpointTuple) /\
+      HandoffRepairFrontierCompatible partialPacket traceRenamedEndpointTuple /\
+      (forall handoff : SourceRefHandoff,
+        handoff.Aligned <-> handoff.toBridgeCertificate.Aligned) /\
+      (exists _obstruction :
+        BridgeObstruction traceRenamedHandoff.toBridgeCertificate, True) /\
+      ProductLocalExact sourceRefHandoffBridgeBrokenState /\
+      Not (InteractionExact sourceRefHandoffBridgeBrokenState) /\
+      InteractionExact alignedSourceRefHandoffState /\
+      (forall {handoff : SourceRefHandoff},
+        SourceRefHandoffFailure handoff ->
+          exists _obstruction :
+            BridgeObstruction handoff.toBridgeCertificate, True) := by
+  exact
+    ⟨alignedSourceRefHandoff_packetTupleAligned,
+      traceRenamedHandoff_exactRepairEvidence.1,
+      traceRenamedHandoff_exactRepairEvidence.2,
+      traceRenamedHandoff_supportCompatible,
+      traceRenamedHandoff_not_traceCompatible,
+      traceRenamedHandoff_repairFrontierCompatible,
+      sourceRefHandoff_aligned_iff_bridgeAligned,
+      ⟨traceRenamedHandoff_bridgeObstruction, trivial⟩,
+      sourceRefHandoffBridgeBroken_productLocalExact,
+      sourceRefHandoffBridgeBroken_not_interactionExact,
+      alignedSourceRefHandoff_interactionExact,
+      fun failure =>
+        ⟨sourceRefHandoffFailure_bridgeObstruction failure, trivial⟩⟩
+
+end SourceRefHandoffBridge
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-source-ref-handoff-derived-bridge.md
+++ b/research/ideas/g-aat-quality-surface-01-source-ref-handoff-derived-bridge.md
@@ -1,0 +1,128 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: bridge
+capability_category: traceability / certificate-transport / obstruction / repair-potential / quality-surface
+expected_base_score: 80
+expected_evidence_multiplier: 2.0
+expected_final_score: 160
+evidence_stage: proved-in-research
+rival_advantage: ADL / architecture conformance tools can display cross-view or cross-route mismatch, but this candidate derives a support / trace / repair-frontier bridge obstruction certificate from a bounded source-ref handoff law.
+origin: cycle-59
+tags: [quality-surface, source-ref, handoff, bridge, obstruction]
+created: 2026-06-21
+cycle: 59
+lean: Formal/AG/Research/QualitySurface/SourceRefHandoffBridge.lean
+---
+
+# Source-ref handoff derived bridge certificate theorem
+
+## 主張
+
+source-ref handoff が finite `SourceRefPacket` と profile endpoint tuple の間の support coverage、
+trace-token compatibility、repair-frontier transport の三成分 law を持つとき、Cycle 57 の supplied `BridgeCertificate` は
+外生ラベルではなく、その handoff data から導出できる。
+逆に三成分のいずれかが失敗すると、対応する `BridgeObstruction` が得られ、local exactness product は保たれていても
+heterogeneous interaction exactness は阻まれる。
+
+この主張は bounded source-ref evidence contract、selected finite handoff、既存の heterogeneous route state に相対化する。
+source extraction completeness、ArchMap correctness、runtime repair synthesis、任意 route system の列挙、
+whole-codebase quality は主張しない。
+
+## 候補種別
+
+`bridge`
+
+## 依拠
+
+- Cycle 13: source-ref packet と profile tuple の bridge
+- Cycle 57: heterogeneous route bridge obstruction
+- Cycle 58: finite route holonomy obstruction support theorem
+- GOAL frontier: source-ref handoff derived bridge certificate theorem
+
+## 非自明性
+
+Cycle 57-58 では bridge certificate と holonomy support は supplied evidence contract として読まれていた。
+本候補は、`SourceRefPacket` と endpoint tuple の間に support、trace-token、repair-frontier の compatibility law を置き、
+その law の certified truth value から bridge certificate を構成する。component failure は単なる `BridgeCertificate` の Bool ではなく、
+source-ref / tuple handoff law の否定として保持され、その否定から bridge obstruction を導く。
+つまり bridge obstruction は入力ラベルではなく、source-ref handoff square の失敗として説明される。
+
+## 数学的興味
+
+local exactness product と heterogeneous interaction exactness の差を、
+source-ref handoff の三成分可換性で説明する。これにより Quality Surface の red/green 表示は、
+route ごとの local result だけでなく、source-ref evidence transport がどの component で壊れたかを持つ。
+
+## GOAL への前進
+
+`source-ref handoff derived bridge certificate theorem` という Next Frontier を直接閉じる。
+traceability、certificate transport、obstruction、repair-potential を同じ finite theorem surface に載せる。
+
+## ライバルに対する有効性
+
+ADL、architecture conformance checker、metric dashboard は cross-view mismatch や rule violation を表示できる。
+この候補は、mismatch を source-ref handoff の support / trace / repair-frontier component law の失敗として導出し、
+その失敗を `BridgeObstruction` と interaction exactness obstruction へ接続する。
+
+## SCORE 見込み
+
+- `score_reason`: supplied bridge certificate を derived source-ref handoff invariant へ上げ、Cycle 57-58 の open frontier を閉じる。G2 A の strict revise 後は base 80 を G4 入力値とする。
+- `dullness_risk`: `BridgeCertificate` の constructor を包むだけなら reject。Bool は source-ref packet / endpoint tuple の三 component compatibility と iff で結び、failure predicate は compatibility law の否定を持つ。
+- `proof_or_evidence_plan`: Lean で `SourceRefHandoff`、source-ref support / trace-token / repair-frontier compatibility、component reader、derived bridge certificate、aligned handoff criterion、component failure certificate、trace-renamed handoff witness、aligned handoff comparator、package theoremを証明した。
+
+## CS / SWE への帰結
+
+local route surfaces が green でも、source-ref handoff の trace-token または repair-frontier transport が壊れれば、
+Quality Surface は cross-route interaction failure を component-level certificate として返せる。
+ただしこれは supplied finite evidence surface 上の theorem であり、runtime source observation や repair generation の完全性ではない。
+
+## 証明・根拠
+
+Lean file `SourceRefHandoffBridge.lean` に置いた。
+主要 declaration は次である。
+
+- `SourceRefHandoff`
+- `HandoffSupportCompatible`
+- `HandoffTraceCompatible`
+- `HandoffRepairFrontierCompatible`
+- `SourceRefHandoff.component`
+- `SourceRefHandoff.toBridgeCertificate`
+- `SourceRefHandoff.Aligned`
+- `SourceRefHandoffFailure`
+- `sourceRefHandoff_bridgeCertificate_component`
+- `sourceRefHandoff_aligned_iff_bridgeAligned`
+- `sourceRefHandoff_bridgeAligned`
+- `sourceRefHandoffFailure_component_false`
+- `sourceRefHandoffFailure_bridgeObstruction`
+- `sourceRefHandoffFailure_obstructs_interactionExact`
+- `sourceRefHandoff_traceRenamedTuple_repairFrontierExact`
+- `traceRenamedHandoff`
+- `traceRenamedHandoff_failure`
+- `traceRenamedHandoff_bridgeObstruction`
+- `alignedSourceRefHandoff_packetTupleAligned`
+- `alignedSourceRefHandoff_aligned`
+- `sourceRefHandoff_productLocalExact_not_interactionExact`
+- `alignedSourceRefHandoff_interactionExact`
+- `sourceRefHandoffBridge_package`
+
+## 審判メモ
+
+- G1: 四つの独立候補生成サブエージェントが、いずれも source-ref handoff から bridge certificate を導出する候補を上位候補として提示した。open genius target theorem は supplied summary 上なし。今回は通常 SCORE の bridge candidate として扱う。
+- G2 A: initial `revise`。`SourceRefHandoff` が既存 `BridgeCertificate` の三 Bool を包むだけに見える危険があるため、source-ref packet / endpoint tuple compatibility law と Bool certificate の iff、component law の否定からの obstruction、`SourceRefTupleBridge` との接続を Lean statement に明示すること。
+- G2 B: `accept`, base 85。required evidence は derived certificate、三成分 failure-to-obstruction、positive comparator、local exact product と interaction exactness の分離。
+- G2 C: `accept`, base 85。repo-wide value は Lean / paper / tooling / website。runtime extraction や repair generation へ越境しないことが条件。
+- G2 D: `accept`, base 88。ADL / conformance checker が表示する mismatch を bounded source-ref handoff theorem に移す点を評価。ただし ADL-style Boolean constraint の包装は不可。
+- G3: `lake env lean Formal/AG/Research/QualitySurface/SourceRefHandoffBridge.lean` と `lake build FormalAGResearch` は pass。core construction、alignment equivalence、failure-to-obstruction constructor、aligned packet-tuple witness は axiom-free。repair / interaction witness と package は標準 `propext` / `Quot.sound` を継承する。`sorryAx`、custom axiom、`Classical.choice` はない。
+- G3 形式化品質: `pass`。三 component compatibility は packet / endpoint tuple data 上で定義され、`BridgeCertificate.component = true` の循環定義ではない。`SourceRefHandoffFailure` は `certifiedFalse` と underlying `lawFailure` の両方を保持するため、anti-rename 条件を満たす。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-source-ref-tuple-bridge.md`
+- `research/ideas/g-aat-quality-surface-01-heterogeneous-route-interaction-curvature.md`
+- `research/ideas/g-aat-quality-surface-01-finite-route-holonomy-obstruction-support.md`
+
+## 進捗ログ
+
+- 2026-06-21: cycle 59 G1 候補 pool から G2 審判対象として作成。
+- 2026-06-21: G2 revise 解消、G3 Lean 証拠固定。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 7546
+- total SCORE: 7706
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -63,8 +63,9 @@
   - computability / obstruction / certificate-transport / traceability / quality-surface: 140
   - profile-curvature / certificate-transport / obstruction / repair-potential / traceability / quality-surface: 160
   - profile-curvature / certificate-transport / obstruction / traceability / computability / repair-potential / quality-surface: 156
+  - traceability / certificate-transport / obstruction / repair-potential / quality-surface: 160
 - evidence portfolio:
-  - proved-in-research: 58
+  - proved-in-research: 59
 
 ## Phase synthesis
 
@@ -80,7 +81,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-58 件の Lean-proved research artifacts は、次の paper seed を形成している。
+59 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -2655,12 +2656,62 @@ arbitrary route system enumeration、global canonical minimality、runtime repai
 source extraction completeness、ArchMap correctness、実コード全体の品質判定は結論しない。
 genius scoring は適用しない。G2 四審判は通常 SCORE として accept し、strict base 78 を G4 入力値とした。
 
+## Cycle 59: Source-ref handoff derived bridge certificate theorem
+
+```text
+candidate: Source-ref handoff derived bridge certificate theorem
+candidate_type: bridge
+evidence_stage: proved-in-research
+base_score: 80
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 160
+category: traceability / certificate-transport / obstruction / repair-potential / quality-surface
+goal_delta: Cycle 57-58 で supplied evidence contract として扱っていた bridge certificate を、finite SourceRefPacket / endpoint tuple の source-ref handoff law から導出する theorem へ上げた。
+project_value_delta: source-ref traceability、certificate transport、bridge obstruction、repair-frontier compatibility を同じ Lean surface に置き、future tooling / website の drill-down explanation に接続できる bounded handoff theorem を固定した。
+rival_delta: ADL / conformance checker は cross-view mismatch や rule violation を表示できるが、その mismatch を source-ref handoff の support / trace-token / repair-frontier compatibility failure から bridge obstruction certificate として導出し、local exact product と interaction exactness の分離へ接続しない。
+formalization_quality: pass。`lake env lean` と `lake build FormalAGResearch` は pass。core construction、alignment equivalence、failure-to-obstruction constructor、aligned packet-tuple witness は axiom-free。repair / interaction witness と package theorem は既存 exactness infrastructure 由来の標準 `propext` / `Quot.sound` を継承する。`sorryAx`、custom axiom、`Classical.choice` はない。compatibility laws は packet / endpoint tuple data 上で定義され、`BridgeCertificate.component = true` の循環定義ではない。
+open_questions: heterogeneous bridge law minimality matrix、finite holonomy-obstruction correspondence の broader theorem program、source-ref handoff obstruction の order-independent locus 化。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SourceRefHandoffBridge.lean` は、
+finite `SourceRefPacket` と endpoint tuple の間に source-ref handoff law を置く。
+`SourceRefHandoff` は support、trace-token、repair-frontier の三 component Bool を持つが、
+それぞれは `HandoffSupportCompatible`、`HandoffTraceCompatible`、`HandoffRepairFrontierCompatible` と
+iff で結ばれる。したがって derived `BridgeCertificate` は単なる三 Bool の入力ではなく、
+source-ref packet / endpoint tuple compatibility law から読まれる。
+
+Lean 証拠は次を固定する。
+
+- `HandoffSupportCompatible`、`HandoffTraceCompatible`、`HandoffRepairFrontierCompatible`: packet / endpoint tuple 上の三 component compatibility。
+- `SourceRefHandoff.toBridgeCertificate`: source-ref handoff の certified component から heterogeneous `BridgeCertificate` を導出する。
+- `sourceRefHandoff_bridgeCertificate_component`: derived bridge certificate の component は handoff component と一致する。
+- `sourceRefHandoff_aligned_iff_bridgeAligned`: source-ref handoff alignment は derived bridge alignment と同値である。
+- `SourceRefHandoffFailure`: failed component の certified false と underlying compatibility law failure を保持する。
+- `sourceRefHandoffFailure_bridgeObstruction`: handoff law failure は bridge obstruction certificate を導く。
+- `sourceRefHandoffFailure_obstructs_interactionExact`: handoff-derived obstruction は、その bridge を使う heterogeneous state の interaction exactness を阻む。
+- `sourceRefHandoff_traceRenamedTuple_repairFrontierExact`: trace-renamed tuple は repair-frontier exactness を保つ。
+- `traceRenamedHandoff`: support と repair-frontier は compatible だが trace-token compatibility が壊れる concrete handoff。
+- `traceRenamedHandoff_bridgeObstruction`: trace-renamed handoff は derived bridge obstruction を持つ。
+- `alignedSourceRefHandoff_packetTupleAligned`: aligned handoff は既存 `SourceRefTupleBridge` の packet-to-tuple bridge witness に接続する。
+- `sourceRefHandoff_productLocalExact_not_interactionExact`: derived bridge を使う concrete state は local exact product を満たすが interaction exact ではない。
+- `alignedSourceRefHandoff_interactionExact`: aligned source-ref handoff comparator は interaction exact である。
+- `sourceRefHandoffBridge_package`: handoff laws、derived bridge obstruction、local/interaction exactness separation、aligned comparator を束ねる。
+
+この結果により、Cycle 57 の heterogeneous bridge certificate と Cycle 58 の holonomy support は、
+source-ref handoff square の三 component compatibility として説明できる。
+ただし主張は bounded source-ref evidence contract、selected finite handoff、finite packet / endpoint tuple、
+existing heterogeneous route state に相対化され、
+source extraction completeness、ArchMap correctness、runtime repair synthesis、arbitrary route enumeration、
+実コード全体の品質判定は結論しない。genius scoring は適用しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 10000 であり、cycle 58 後の total SCORE は 7546 である。
+次フェーズの tracking Issue active threshold は 10000 であり、cycle 59 後の total SCORE は 7706 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 threshold 10000 には未達であるため、次 cycle では lawful criterion の necessity / minimality、
-bridge certificate を source-ref handoff から導出する theorem、または finite holonomy-obstruction correspondence の
-broader theorem program を狙う。
+heterogeneous bridge law minimality matrix、または finite holonomy-obstruction correspondence の broader theorem program を狙う。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -125,9 +125,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 58 後の total SCORE は 7546 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 59 後の total SCORE は 7706 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 58 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 59 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
 


### PR DESCRIPTION
## 概要

Refs #2348

cycle 59 として、source-ref handoff から heterogeneous bridge certificate を導出する Lean 証拠を追加しました。
`SourceRefHandoff` は support / trace-token / repair-frontier の三 component Bool を持ちますが、それぞれを finite `SourceRefPacket` と endpoint tuple の compatibility law と iff で結び、単なる `BridgeCertificate` wrapper にならないようにしています。

SCORE は G4 監査で `base 80 * evidence 2.0 = +160` と確定し、tracking Issue の total は `7706 / 10000` です。threshold 未達のため、この PR は tracking Issue を close しません。

## 証明した定理

- `HandoffSupportCompatible`
- `HandoffTraceCompatible`
- `HandoffRepairFrontierCompatible`
- `SourceRefHandoff`
- `SourceRefHandoff.toBridgeCertificate`
- `SourceRefHandoffFailure`
- `sourceRefHandoff_bridgeCertificate_component`
- `sourceRefHandoff_aligned_iff_bridgeAligned`
- `sourceRefHandoffFailure_bridgeObstruction`
- `sourceRefHandoffFailure_obstructs_interactionExact`
- `sourceRefHandoff_traceRenamedTuple_repairFrontierExact`
- `traceRenamedHandoff_bridgeObstruction`
- `alignedSourceRefHandoff_packetTupleAligned`
- `sourceRefHandoff_productLocalExact_not_interactionExact`
- `alignedSourceRefHandoff_interactionExact`
- `sourceRefHandoffBridge_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-source-ref-handoff-derived-bridge.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SourceRefHandoffBridge.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` audit for reported declarations

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した
- [x] Lean status を `proved` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
