### PR TITLE
研究: source-ref handoff holonomy correspondenceを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -56,3 +56,4 @@ import Formal.AG.Research.QualitySurface.FailingSlotCertificate
 import Formal.AG.Research.QualitySurface.FiniteRouteScan
 import Formal.AG.Research.QualitySurface.RouteHolonomyObstructionSupport
 import Formal.AG.Research.QualitySurface.SourceRefHandoffBridge
+import Formal.AG.Research.QualitySurface.SourceRefHandoffHolonomyCorrespondence

--- a/Formal/AG/Research/QualitySurface/SourceRefHandoffHolonomyCorrespondence.lean
+++ b/Formal/AG/Research/QualitySurface/SourceRefHandoffHolonomyCorrespondence.lean
@@ -1,0 +1,608 @@
+import Formal.AG.Research.QualitySurface.RouteHolonomyObstructionSupport
+import Formal.AG.Research.QualitySurface.SourceRefHandoffBridge
+
+/-!
+Cycle 60 evidence for `G-aat-quality-surface-01`.
+
+This file packages a finite route atlas whose loops carry source-ref handoff
+data.  The loop state bridge is required to be the bridge derived from the
+handoff, so handoff component-law failure, bridge obstruction, holonomy
+support, and interaction-exactness obstruction are the same bounded finite
+certificate phenomenon.  The result is relative to the selected finite atlas
+and supplied loop order.  It does not assert source extraction completeness,
+ArchMap correctness, runtime repair synthesis, arbitrary route enumeration,
+or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SourceRefHandoffHolonomyCorrespondence
+
+open HeterogeneousRouteInteraction
+open BridgeComponent
+open RouteHolonomyObstructionSupport
+open RouteLoopName
+open SourceRefHandoffBridge
+
+/-! ## Source-ref handoff loops -/
+
+/--
+A route loop whose bridge is derived from a bounded source-ref handoff.
+
+The equality pins the route state bridge to `handoff.toBridgeCertificate`;
+without it, handoff law failure and loop holonomy support would not be the
+same locus.
+-/
+structure SourceRefHandoffLoop where
+  name : RouteLoopName
+  state : HeterogeneousRouteState
+  handoff : SourceRefHandoff
+  bridge_eq : state.bridge = handoff.toBridgeCertificate
+
+/-- Forget the source-ref handoff and read the underlying route loop. -/
+def SourceRefHandoffLoop.toRouteLoop
+    (loop : SourceRefHandoffLoop) : RouteLoop where
+  name := loop.name
+  state := loop.state
+
+/-- A finite source-ref handoff atlas with its supplied loop order. -/
+structure SourceRefHandoffAtlas where
+  loops : List SourceRefHandoffLoop
+
+/-- Forget source-ref handoff data and read the supplied loops as a route atlas. -/
+def SourceRefHandoffAtlas.toRouteAtlas
+    (atlas : SourceRefHandoffAtlas) : RouteAtlas where
+  loops := atlas.loops.map SourceRefHandoffLoop.toRouteLoop
+
+/-! ## Handoff holonomy support -/
+
+/-- Handoff holonomy support is failure of one source-ref handoff law. -/
+def HandoffHolonomySupport
+    (loop : SourceRefHandoffLoop) (component : BridgeComponent) : Prop :=
+  Not (loop.handoff.ComponentLaw component)
+
+/-- A source-ref handoff loop has nonempty handoff holonomy support. -/
+def HasHandoffHolonomySupport
+    (loop : SourceRefHandoffLoop) : Prop :=
+  exists component, HandoffHolonomySupport loop component
+
+/-- A source-ref handoff loop is clear when every handoff law holds. -/
+def HandoffHolonomyClear
+    (loop : SourceRefHandoffLoop) : Prop :=
+  forall component, loop.handoff.ComponentLaw component
+
+/--
+Certified component failure is equivalent to failure of the underlying
+source-ref handoff law.
+-/
+theorem sourceRefHandoff_component_false_iff_lawFailure
+    (handoff : SourceRefHandoff)
+    (component : BridgeComponent) :
+    handoff.component component = false <->
+      Not (handoff.ComponentLaw component) := by
+  cases component with
+  | support =>
+      constructor
+      · intro hfalse hlaw
+        have htrue := handoff.supportCertified_iff.mpr hlaw
+        rw [SourceRefHandoff.component, htrue] at hfalse
+        cases hfalse
+      · intro hfailure
+        cases hcert : handoff.supportCertified
+        · simp [SourceRefHandoff.component, hcert]
+        · exact False.elim
+            (hfailure (handoff.supportCertified_iff.mp hcert))
+  | trace =>
+      constructor
+      · intro hfalse hlaw
+        have htrue := handoff.traceCertified_iff.mpr hlaw
+        rw [SourceRefHandoff.component, htrue] at hfalse
+        cases hfalse
+      · intro hfailure
+        cases hcert : handoff.traceCertified
+        · simp [SourceRefHandoff.component, hcert]
+        · exact False.elim
+            (hfailure (handoff.traceCertified_iff.mp hcert))
+  | repairFrontier =>
+      constructor
+      · intro hfalse hlaw
+        have htrue := handoff.repairFrontierCertified_iff.mpr hlaw
+        rw [SourceRefHandoff.component, htrue] at hfalse
+        cases hfalse
+      · intro hfailure
+        cases hcert : handoff.repairFrontierCertified
+        · simp [SourceRefHandoff.component, hcert]
+        · exact False.elim
+            (hfailure (handoff.repairFrontierCertified_iff.mp hcert))
+
+/-- A handoff law failure gives the failure object required by Cycle 59. -/
+def sourceRefHandoffFailure_of_handoffHolonomySupport
+    {loop : SourceRefHandoffLoop}
+    {component : BridgeComponent}
+    (hsupport : HandoffHolonomySupport loop component) :
+    SourceRefHandoffFailure loop.handoff where
+  component := component
+  certifiedFalse :=
+    (sourceRefHandoff_component_false_iff_lawFailure
+      loop.handoff component).mpr hsupport
+  lawFailure := hsupport
+
+/--
+For a handoff-derived route loop, source-ref handoff support is the same
+locus as the loop holonomy support.
+-/
+theorem handoffHolonomySupport_iff_loopHolonomySupport
+    (loop : SourceRefHandoffLoop)
+    (component : BridgeComponent) :
+    HandoffHolonomySupport loop component <->
+      HolonomySupport loop.toRouteLoop component := by
+  rw [HolonomySupport, SourceRefHandoffLoop.toRouteLoop, loop.bridge_eq]
+  rw [sourceRefHandoff_bridgeCertificate_component]
+  exact (sourceRefHandoff_component_false_iff_lawFailure
+    loop.handoff component).symm
+
+/-- Handoff clearance and loop holonomy clearance are the same condition. -/
+theorem handoffHolonomyClear_iff_loopHolonomyClear
+    (loop : SourceRefHandoffLoop) :
+    HandoffHolonomyClear loop <->
+      LoopHolonomyClear loop.toRouteLoop := by
+  constructor
+  · intro hclear component
+    cases component with
+    | support =>
+        have hcert :
+            loop.handoff.supportCertified = true :=
+          loop.handoff.supportCertified_iff.mpr (hclear support)
+        simpa [BridgeCertificate.component,
+          SourceRefHandoff.toBridgeCertificate,
+          SourceRefHandoffLoop.toRouteLoop, loop.bridge_eq] using hcert
+    | trace =>
+        have hcert :
+            loop.handoff.traceCertified = true :=
+          loop.handoff.traceCertified_iff.mpr (hclear trace)
+        simpa [BridgeCertificate.component,
+          SourceRefHandoff.toBridgeCertificate,
+          SourceRefHandoffLoop.toRouteLoop, loop.bridge_eq] using hcert
+    | repairFrontier =>
+        have hcert :
+            loop.handoff.repairFrontierCertified = true :=
+          loop.handoff.repairFrontierCertified_iff.mpr
+            (hclear repairFrontier)
+        simpa [BridgeCertificate.component,
+          SourceRefHandoff.toBridgeCertificate,
+          SourceRefHandoffLoop.toRouteLoop, loop.bridge_eq] using hcert
+  · intro hclear component
+    cases component with
+    | support =>
+        have hcomponent := hclear support
+        exact loop.handoff.supportCertified_iff.mp
+          (by
+            simpa [BridgeCertificate.component,
+              SourceRefHandoff.toBridgeCertificate,
+              SourceRefHandoffLoop.toRouteLoop, loop.bridge_eq] using hcomponent)
+    | trace =>
+        have hcomponent := hclear trace
+        exact loop.handoff.traceCertified_iff.mp
+          (by
+            simpa [BridgeCertificate.component,
+              SourceRefHandoff.toBridgeCertificate,
+              SourceRefHandoffLoop.toRouteLoop, loop.bridge_eq] using hcomponent)
+    | repairFrontier =>
+        have hcomponent := hclear repairFrontier
+        exact loop.handoff.repairFrontierCertified_iff.mp
+          (by
+            simpa [BridgeCertificate.component,
+              SourceRefHandoff.toBridgeCertificate,
+              SourceRefHandoffLoop.toRouteLoop, loop.bridge_eq] using hcomponent)
+
+/-- Handoff clearance is equivalent to interaction exactness under local exactness. -/
+theorem handoffLoopHolonomyClear_iff_interactionExact_of_local
+    {loop : SourceRefHandoffLoop}
+    (hlocal : ProductLocalExact loop.state) :
+    HandoffHolonomyClear loop <-> InteractionExact loop.state :=
+  Iff.trans (handoffHolonomyClear_iff_loopHolonomyClear loop)
+    (routeLoopHolonomyClear_iff_interactionExact_of_local
+      (loop := loop.toRouteLoop) hlocal)
+
+/-! ## Atlas-level correspondence -/
+
+/-- Every listed handoff loop is locally exact before reading handoff holonomy. -/
+def HandoffAtlasLocalExact
+    (atlas : SourceRefHandoffAtlas) : Prop :=
+  forall loop, loop ∈ atlas.loops -> ProductLocalExact loop.state
+
+/-- All listed handoff loops have vanishing source-ref handoff support. -/
+def HandoffAtlasHolonomyVanishes
+    (atlas : SourceRefHandoffAtlas) : Prop :=
+  forall loop, loop ∈ atlas.loops -> HandoffHolonomyClear loop
+
+/-- Atlas-level interaction exactness for source-ref handoff loops. -/
+def HandoffAtlasInteractionExact
+    (atlas : SourceRefHandoffAtlas) : Prop :=
+  forall loop, loop ∈ atlas.loops -> InteractionExact loop.state
+
+/-- Local exactness is preserved and reflected by the route-atlas projection. -/
+theorem handoffAtlasLocalExact_iff_routeAtlasLocalExact
+    (atlas : SourceRefHandoffAtlas) :
+    HandoffAtlasLocalExact atlas <->
+      AtlasLocalExact atlas.toRouteAtlas := by
+  constructor
+  · intro hlocal routeLoop hmem
+    rcases List.mem_map.mp hmem with ⟨loop, hloop, hroute⟩
+    subst hroute
+    exact hlocal loop hloop
+  · intro hlocal loop hmem
+    exact hlocal loop.toRouteLoop
+      (List.mem_map_of_mem (f := SourceRefHandoffLoop.toRouteLoop) hmem)
+
+/-- Handoff holonomy vanishing is the same as route-atlas holonomy vanishing. -/
+theorem handoffAtlasHolonomyVanishes_iff_routeAtlasHolonomyVanishes
+    (atlas : SourceRefHandoffAtlas) :
+    HandoffAtlasHolonomyVanishes atlas <->
+      AtlasHolonomyVanishes atlas.toRouteAtlas := by
+  constructor
+  · intro hclear routeLoop hmem
+    rcases List.mem_map.mp hmem with ⟨loop, hloop, hroute⟩
+    subst hroute
+    exact (handoffHolonomyClear_iff_loopHolonomyClear loop).mp
+      (hclear loop hloop)
+  · intro hclear loop hmem
+    exact (handoffHolonomyClear_iff_loopHolonomyClear loop).mpr
+      (hclear loop.toRouteLoop
+        (List.mem_map_of_mem (f := SourceRefHandoffLoop.toRouteLoop) hmem))
+
+/--
+The source-ref handoff atlas and its underlying route atlas have the same
+interaction-exact loops.
+-/
+theorem handoffAtlasInteractionExact_iff_routeAtlasInteractionExact
+    (atlas : SourceRefHandoffAtlas) :
+    HandoffAtlasInteractionExact atlas <->
+      RouteAtlasInteractionExact atlas.toRouteAtlas := by
+  constructor
+  · intro hexact routeLoop hmem
+    rcases List.mem_map.mp hmem with ⟨loop, hloop, hroute⟩
+    subst hroute
+    exact hexact loop hloop
+  · intro hexact loop hmem
+    exact hexact loop.toRouteLoop
+      (List.mem_map_of_mem (f := SourceRefHandoffLoop.toRouteLoop) hmem)
+
+/--
+For a source-ref handoff atlas, interaction exactness is exactly local
+exactness plus all-loop handoff holonomy vanishing.
+-/
+theorem handoffAtlasInteractionExact_iff_localAndHandoffHolonomyClear
+    (atlas : SourceRefHandoffAtlas) :
+    HandoffAtlasInteractionExact atlas <->
+      HandoffAtlasLocalExact atlas /\
+        HandoffAtlasHolonomyVanishes atlas := by
+  constructor
+  · intro hexact
+    constructor
+    · intro loop hmem
+      exact (hexact loop hmem).1
+    · intro loop hmem
+      exact
+        (handoffLoopHolonomyClear_iff_interactionExact_of_local
+          (hexact loop hmem).1).mpr (hexact loop hmem)
+  · intro hpair loop hmem
+    exact
+      (handoffLoopHolonomyClear_iff_interactionExact_of_local
+        (hpair.1 loop hmem)).mp (hpair.2 loop hmem)
+
+/-! ## First source-ref handoff obstruction -/
+
+/-- Boolean clearance for the handoff laws on a loop. -/
+def handoffHolonomyClearBool
+    (loop : SourceRefHandoffLoop) : Bool :=
+  loop.handoff.supportCertified &&
+    loop.handoff.traceCertified &&
+    loop.handoff.repairFrontierCertified
+
+/-- The boolean clearance agrees with source-ref handoff holonomy clearance. -/
+theorem handoffHolonomyClearBool_eq_true_iff
+    (loop : SourceRefHandoffLoop) :
+    handoffHolonomyClearBool loop = true <->
+      HandoffHolonomyClear loop := by
+  constructor
+  · intro hclear component
+    cases component with
+    | support =>
+        cases hsupport : loop.handoff.supportCertified <;>
+          simp [handoffHolonomyClearBool, hsupport] at hclear
+        exact loop.handoff.supportCertified_iff.mp hsupport
+    | trace =>
+        cases hsupport : loop.handoff.supportCertified <;>
+          cases htrace : loop.handoff.traceCertified <;>
+            simp [handoffHolonomyClearBool, hsupport, htrace] at hclear
+        exact loop.handoff.traceCertified_iff.mp htrace
+    | repairFrontier =>
+        cases hsupport : loop.handoff.supportCertified <;>
+          cases htrace : loop.handoff.traceCertified <;>
+            cases hrepair : loop.handoff.repairFrontierCertified <;>
+              simp [handoffHolonomyClearBool, hsupport, htrace,
+                hrepair] at hclear
+        exact loop.handoff.repairFrontierCertified_iff.mp hrepair
+  · intro hclear
+    have hsupport :
+        loop.handoff.supportCertified = true :=
+      loop.handoff.supportCertified_iff.mpr (hclear support)
+    have htrace :
+        loop.handoff.traceCertified = true :=
+      loop.handoff.traceCertified_iff.mpr (hclear trace)
+    have hrepair :
+        loop.handoff.repairFrontierCertified = true :=
+      loop.handoff.repairFrontierCertified_iff.mpr
+        (hclear repairFrontier)
+    simp [handoffHolonomyClearBool, hsupport, htrace, hrepair]
+
+/-- A false handoff-clearance exposes nonempty source-ref handoff support. -/
+theorem hasHandoffHolonomySupport_of_clearBool_false
+    {loop : SourceRefHandoffLoop}
+    (hclear : handoffHolonomyClearBool loop = false) :
+    HasHandoffHolonomySupport loop := by
+  cases hsupport : loop.handoff.supportCertified
+  · exact ⟨support,
+      (sourceRefHandoff_component_false_iff_lawFailure
+        loop.handoff support).mp
+        (by simp [SourceRefHandoff.component, hsupport])⟩
+  · cases htrace : loop.handoff.traceCertified
+    · exact ⟨trace,
+        (sourceRefHandoff_component_false_iff_lawFailure
+          loop.handoff trace).mp
+          (by simp [SourceRefHandoff.component, htrace])⟩
+    · cases hrepair : loop.handoff.repairFrontierCertified
+      · exact ⟨repairFrontier,
+          (sourceRefHandoff_component_false_iff_lawFailure
+            loop.handoff repairFrontier).mp
+            (by simp [SourceRefHandoff.component, hrepair])⟩
+      · simp [handoffHolonomyClearBool, hsupport, htrace, hrepair]
+          at hclear
+
+/-- First listed loop whose source-ref handoff support is nonempty. -/
+def firstHandoffObstructingLoop? :
+    List SourceRefHandoffLoop -> Option SourceRefHandoffLoop
+  | [] => none
+  | loop :: rest =>
+      if handoffHolonomyClearBool loop = true then
+        firstHandoffObstructingLoop? rest
+      else
+        some loop
+
+/-- A returned first handoff obstruction is listed in the supplied order. -/
+theorem firstHandoffObstructingLoop?_some_mem :
+    forall {loops : List SourceRefHandoffLoop} {loop : SourceRefHandoffLoop},
+      firstHandoffObstructingLoop? loops = some loop ->
+        loop ∈ loops
+  | [], _loop, hsome => by
+      cases hsome
+  | head :: rest, loop, hsome => by
+      by_cases hhead : handoffHolonomyClearBool head = true
+      · have htail :
+            firstHandoffObstructingLoop? rest = some loop := by
+          simpa [firstHandoffObstructingLoop?, hhead] using hsome
+        exact List.mem_cons_of_mem head
+          (firstHandoffObstructingLoop?_some_mem htail)
+      · have hloop : loop = head := by
+          simpa [firstHandoffObstructingLoop?, hhead] using hsome.symm
+        subst hloop
+        simp
+
+/-- A returned first handoff obstruction has nonempty handoff support. -/
+theorem firstHandoffObstructingLoop?_some_nonemptySupport :
+    forall {loops : List SourceRefHandoffLoop} {loop : SourceRefHandoffLoop},
+      firstHandoffObstructingLoop? loops = some loop ->
+        HasHandoffHolonomySupport loop
+  | [], _loop, hsome => by
+      cases hsome
+  | head :: rest, loop, hsome => by
+      by_cases hhead : handoffHolonomyClearBool head = true
+      · have htail :
+            firstHandoffObstructingLoop? rest = some loop := by
+          simpa [firstHandoffObstructingLoop?, hhead] using hsome
+        exact firstHandoffObstructingLoop?_some_nonemptySupport htail
+      · have hloop : loop = head := by
+          simpa [firstHandoffObstructingLoop?, hhead] using hsome.symm
+        have hfalse : handoffHolonomyClearBool head = false := by
+          cases hbool : handoffHolonomyClearBool head
+          · rfl
+          · exact False.elim (hhead hbool)
+        simpa [hloop] using
+          hasHandoffHolonomySupport_of_clearBool_false hfalse
+
+/-- A returned first handoff obstruction carries a source-ref law failure. -/
+theorem firstHandoffObstructingLoop?_some_failure
+    {loops : List SourceRefHandoffLoop}
+    {loop : SourceRefHandoffLoop}
+    (hfirst : firstHandoffObstructingLoop? loops = some loop) :
+    exists _failure : SourceRefHandoffFailure loop.handoff, True := by
+  rcases firstHandoffObstructingLoop?_some_nonemptySupport hfirst with
+    ⟨component, hsupport⟩
+  exact
+    ⟨sourceRefHandoffFailure_of_handoffHolonomySupport hsupport,
+      trivial⟩
+
+/-- A returned first handoff obstruction carries a derived bridge obstruction. -/
+theorem firstHandoffObstructingLoop?_some_bridgeObstruction
+    {loops : List SourceRefHandoffLoop}
+    {loop : SourceRefHandoffLoop}
+    (hfirst : firstHandoffObstructingLoop? loops = some loop) :
+    exists _obstruction : BridgeObstruction loop.handoff.toBridgeCertificate,
+      True := by
+  rcases firstHandoffObstructingLoop?_some_failure hfirst with
+    ⟨failure, _⟩
+  exact ⟨sourceRefHandoffFailure_bridgeObstruction failure, trivial⟩
+
+/-- A returned first handoff obstruction has nonempty loop holonomy support. -/
+theorem firstHandoffObstructingLoop?_some_loopHolonomySupport
+    {loops : List SourceRefHandoffLoop}
+    {loop : SourceRefHandoffLoop}
+    (hfirst : firstHandoffObstructingLoop? loops = some loop) :
+    HasHolonomySupport loop.toRouteLoop := by
+  rcases firstHandoffObstructingLoop?_some_nonemptySupport hfirst with
+    ⟨component, hsupport⟩
+  exact ⟨component,
+    (handoffHolonomySupport_iff_loopHolonomySupport
+      loop component).mp hsupport⟩
+
+/-- A returned first handoff obstruction rules out atlas interaction exactness. -/
+theorem firstHandoffObstructingLoop?_some_obstructs_atlasInteractionExact
+    {loops : List SourceRefHandoffLoop}
+    {loop : SourceRefHandoffLoop}
+    (hfirst : firstHandoffObstructingLoop? loops = some loop) :
+    Not (HandoffAtlasInteractionExact { loops := loops }) := by
+  intro hexact
+  rcases firstHandoffObstructingLoop?_some_failure hfirst with
+    ⟨failure, _⟩
+  exact
+    sourceRefHandoffFailure_obstructs_interactionExact
+      loop.bridge_eq failure
+      (hexact loop (firstHandoffObstructingLoop?_some_mem hfirst))
+
+/-! ## Concrete mixed and aligned source-ref handoff atlases -/
+
+/-- Handoff-clear loop using the aligned source-ref handoff comparator. -/
+def alignedSourceRefHandoffLoop : SourceRefHandoffLoop where
+  name := stable
+  state := alignedSourceRefHandoffState
+  handoff := alignedSourceRefHandoff
+  bridge_eq := rfl
+
+/-- Handoff loop whose trace-token source-ref law is obstructed. -/
+def traceRenamedSourceRefHandoffLoop : SourceRefHandoffLoop where
+  name := handoff
+  state := sourceRefHandoffBridgeBrokenState
+  handoff := traceRenamedHandoff
+  bridge_eq := rfl
+
+@[simp] theorem alignedSourceRefHandoffLoop_clearBool :
+    handoffHolonomyClearBool alignedSourceRefHandoffLoop = true :=
+  rfl
+
+@[simp] theorem traceRenamedSourceRefHandoffLoop_clearBool :
+    handoffHolonomyClearBool traceRenamedSourceRefHandoffLoop = false :=
+  rfl
+
+/-- Mixed source-ref atlas: one aligned loop followed by one handoff obstruction. -/
+def mixedSourceRefHandoffAtlas : SourceRefHandoffAtlas where
+  loops := [alignedSourceRefHandoffLoop, traceRenamedSourceRefHandoffLoop]
+
+/-- Positive comparator atlas: every listed handoff loop is aligned. -/
+def alignedSourceRefHandoffAtlas : SourceRefHandoffAtlas where
+  loops := [alignedSourceRefHandoffLoop]
+
+/-- The mixed source-ref handoff atlas is locally exact on all listed loops. -/
+theorem mixedSourceRefHandoffAtlas_localExact :
+    HandoffAtlasLocalExact mixedSourceRefHandoffAtlas := by
+  intro loop hmem
+  simp [mixedSourceRefHandoffAtlas] at hmem
+  rcases hmem with hloop | hloop
+  · subst hloop
+    exact alignedSourceRefHandoff_interactionExact.1
+  · subst hloop
+    exact sourceRefHandoffBridgeBroken_productLocalExact
+
+/-- The mixed source-ref atlas selects the trace-renamed loop as first obstruction. -/
+theorem mixedSourceRefHandoffAtlas_firstObstructingLoop :
+    firstHandoffObstructingLoop? mixedSourceRefHandoffAtlas.loops =
+      some traceRenamedSourceRefHandoffLoop := by
+  simp [mixedSourceRefHandoffAtlas, firstHandoffObstructingLoop?]
+
+/-- The mixed source-ref atlas is locally exact but not interaction exact. -/
+theorem mixedSourceRefHandoffAtlas_not_interactionExact :
+    HandoffAtlasLocalExact mixedSourceRefHandoffAtlas /\
+      Not (HandoffAtlasInteractionExact mixedSourceRefHandoffAtlas) :=
+  ⟨mixedSourceRefHandoffAtlas_localExact,
+    firstHandoffObstructingLoop?_some_obstructs_atlasInteractionExact
+      mixedSourceRefHandoffAtlas_firstObstructingLoop⟩
+
+/-- The aligned source-ref handoff comparator atlas is interaction exact. -/
+theorem alignedSourceRefHandoffAtlas_interactionExact :
+    HandoffAtlasInteractionExact alignedSourceRefHandoffAtlas := by
+  intro loop hmem
+  simp [alignedSourceRefHandoffAtlas] at hmem
+  subst hmem
+  exact alignedSourceRefHandoff_interactionExact
+
+/-! ## Theorem package -/
+
+/--
+Cycle-60 theorem package: source-ref handoff law failure, derived bridge
+obstruction, loop holonomy support, first obstruction, and atlas interaction
+failure are the same bounded finite correspondence.
+-/
+theorem sourceRefHandoffHolonomyCorrespondence_package :
+    HandoffAtlasInteractionExact alignedSourceRefHandoffAtlas /\
+      HandoffAtlasLocalExact mixedSourceRefHandoffAtlas /\
+      HasHandoffHolonomySupport traceRenamedSourceRefHandoffLoop /\
+      HasHolonomySupport traceRenamedSourceRefHandoffLoop.toRouteLoop /\
+      firstHandoffObstructingLoop? mixedSourceRefHandoffAtlas.loops =
+        some traceRenamedSourceRefHandoffLoop /\
+      (exists _failure :
+        SourceRefHandoffFailure traceRenamedSourceRefHandoffLoop.handoff,
+        True) /\
+      (exists _obstruction :
+        BridgeObstruction traceRenamedSourceRefHandoffLoop.handoff.toBridgeCertificate,
+        True) /\
+      Not (HandoffAtlasInteractionExact mixedSourceRefHandoffAtlas) /\
+      (forall loop component,
+        HandoffHolonomySupport loop component <->
+          HolonomySupport loop.toRouteLoop component) /\
+      (forall loop,
+        HandoffHolonomyClear loop <->
+          LoopHolonomyClear loop.toRouteLoop) /\
+      (forall atlas,
+        HandoffAtlasLocalExact atlas <->
+          AtlasLocalExact atlas.toRouteAtlas) /\
+      (forall atlas,
+        HandoffAtlasHolonomyVanishes atlas <->
+          AtlasHolonomyVanishes atlas.toRouteAtlas) /\
+      (forall atlas,
+        HandoffAtlasInteractionExact atlas <->
+          RouteAtlasInteractionExact atlas.toRouteAtlas) /\
+      (forall atlas,
+        HandoffAtlasInteractionExact atlas <->
+          HandoffAtlasLocalExact atlas /\
+            HandoffAtlasHolonomyVanishes atlas) /\
+      (forall loops loop,
+        firstHandoffObstructingLoop? loops = some loop ->
+          loop ∈ loops /\
+            HasHandoffHolonomySupport loop /\
+            HasHolonomySupport loop.toRouteLoop /\
+            (exists _failure :
+              SourceRefHandoffFailure loop.handoff, True) /\
+            (exists _obstruction :
+              BridgeObstruction loop.handoff.toBridgeCertificate, True) /\
+            Not (HandoffAtlasInteractionExact { loops := loops })) := by
+  exact
+    ⟨alignedSourceRefHandoffAtlas_interactionExact,
+      mixedSourceRefHandoffAtlas_localExact,
+      firstHandoffObstructingLoop?_some_nonemptySupport
+        mixedSourceRefHandoffAtlas_firstObstructingLoop,
+      firstHandoffObstructingLoop?_some_loopHolonomySupport
+        mixedSourceRefHandoffAtlas_firstObstructingLoop,
+      mixedSourceRefHandoffAtlas_firstObstructingLoop,
+      firstHandoffObstructingLoop?_some_failure
+        mixedSourceRefHandoffAtlas_firstObstructingLoop,
+      firstHandoffObstructingLoop?_some_bridgeObstruction
+        mixedSourceRefHandoffAtlas_firstObstructingLoop,
+      mixedSourceRefHandoffAtlas_not_interactionExact.2,
+      handoffHolonomySupport_iff_loopHolonomySupport,
+      handoffHolonomyClear_iff_loopHolonomyClear,
+      handoffAtlasLocalExact_iff_routeAtlasLocalExact,
+      handoffAtlasHolonomyVanishes_iff_routeAtlasHolonomyVanishes,
+      handoffAtlasInteractionExact_iff_routeAtlasInteractionExact,
+      handoffAtlasInteractionExact_iff_localAndHandoffHolonomyClear,
+      fun loops loop hfirst =>
+        ⟨firstHandoffObstructingLoop?_some_mem hfirst,
+          firstHandoffObstructingLoop?_some_nonemptySupport hfirst,
+          firstHandoffObstructingLoop?_some_loopHolonomySupport hfirst,
+          firstHandoffObstructingLoop?_some_failure hfirst,
+          firstHandoffObstructingLoop?_some_bridgeObstruction hfirst,
+          firstHandoffObstructingLoop?_some_obstructs_atlasInteractionExact
+            hfirst⟩⟩
+
+end SourceRefHandoffHolonomyCorrespondence
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-source-ref-handoff-holonomy-correspondence.md
+++ b/research/ideas/g-aat-quality-surface-01-source-ref-handoff-holonomy-correspondence.md
@@ -1,0 +1,140 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification / bridge
+capability_category: traceability / certificate-transport / obstruction / computability / quality-surface
+expected_base_score: 80
+expected_evidence_multiplier: 2.0
+expected_final_score: 160
+evidence_stage: proved-in-research
+rival_advantage: ADL / architecture conformance tools can display cross-view mismatch or a failing route list, but this candidate identifies source-ref handoff law failure, derived bridge obstruction, closed-route holonomy support, and interaction exactness failure as one finite certificate correspondence.
+origin: cycle-60
+tags: [quality-surface, source-ref, handoff, holonomy, obstruction, correspondence]
+created: 2026-06-21
+cycle: 60
+lean: Formal/AG/Research/QualitySurface/SourceRefHandoffHolonomyCorrespondence.lean
+---
+
+# Source-ref handoff holonomy correspondence for finite route atlases
+
+## 主張
+
+selected finite route atlas の各 loop に `SourceRefHandoff` と
+`bridge = handoff.toBridgeCertificate` を載せると、loop holonomy support は
+source-ref handoff component law failure と同じ protected locus として読める。
+local exactness の下で、atlas interaction exactness は「全 loop の source-ref handoff law が aligned であること」と同値になる。
+さらに first obstruction selector が返す loop は、source-ref handoff failure、derived bridge obstruction、
+nonempty holonomy support、interaction exactness obstruction の各射影を同時に持つ。
+
+この主張は selected finite route atlas、bounded `SourceRefHandoff`、finite `SourceRefPacket` / endpoint tuple、
+existing heterogeneous route state に相対化する。source extraction completeness、ArchMap correctness、
+runtime repair synthesis、arbitrary route enumeration、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`unification / bridge`
+
+## 依拠
+
+- Cycle 57: heterogeneous route bridge obstruction
+- Cycle 58: finite route holonomy obstruction support theorem
+- Cycle 59: source-ref handoff derived bridge certificate theorem
+- GOAL frontier: finite holonomy-obstruction correspondence broader theorem program
+
+## 非自明性
+
+Cycle 58 は supplied bridge certificate 上で holonomy support と interaction exactness criterion を証明した。
+Cycle 59 は単一 handoff から bridge certificate を導出した。
+本候補はそれらを単に rewrite するのではなく、handoff-indexed route loop / atlas と handoff obstruction locus を導入し、
+source-ref law failure、derived bridge obstruction、holonomy support、interaction exactness failure を同じ finite correspondence として束ねる。
+
+## 数学的興味
+
+closed-route holonomy obstruction は、抽象的な loop defect ではなく、source-ref packet / endpoint tuple compatibility の failure locus として読むことができる。
+これにより Quality Surface の route atlas は、local exactness product、source-ref handoff law、derived bridge、
+holonomy support、interaction exactness の同一対象上の複数 presentation になる。
+
+## GOAL への前進
+
+traceability、certificate transport、obstruction、computability を、
+finite route atlas 上の handoff-holonomy correspondence として統合する。
+threshold 10000 へ向けて、broader finite holonomy-obstruction correspondence theorem program を通常 SCORE で前進させる。
+
+## ライバルに対する有効性
+
+ADL、architecture conformance checker、metric dashboard は cross-view inconsistency や failing route list を表示できる。
+この候補は、その表示を source-ref handoff law failure、derived bridge obstruction、closed-route holonomy support、
+interaction exactness obstruction の同一 finite certificate geometry へ持ち上げる。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 57-59 の bridge obstruction、route holonomy support、source-ref handoff derivation を一つの theorem package に圧縮する。G2 厳密性審判の strict base 80 を G4 入力値とする。
+- `dullness_risk`: `sourceRefHandoff_aligned_iff_bridgeAligned` と `routeAtlasInteractionExact_iff_localAndHolonomyClear` の機械的 rewrite だけなら reject。`SourceRefHandoffLoop` / `SourceRefHandoffAtlas` / handoff law failure locus / first obstruction package を新しい protected structure として明示する。
+- `proof_or_evidence_plan`: Lean で `SourceRefHandoffLoop`、`SourceRefHandoffAtlas`、`HandoffHolonomySupport`、`HandoffHolonomyClear`、`SourceRefHandoffAtlas.toRouteAtlas` を定義し、handoff law failure iff loop holonomy support、handoff clear iff loop clear、RouteAtlas projection correspondence、local exactness 下の interaction exactness criterion、first handoff obstruction certificate、mixed / aligned concrete atlas、package theorem を証明した。
+
+## CS / SWE への帰結
+
+route dashboard の green / red や first failing loop は、source-ref handoff law failure locus の report projection として読める。
+ただしこれは supplied finite evidence surface 上の theorem であり、runtime source observation、repair generation、global conformance completeness ではない。
+
+## 証明・根拠
+
+Lean file `Formal/AG/Research/QualitySurface/SourceRefHandoffHolonomyCorrespondence.lean` に固定した。
+`lake env lean Formal/AG/Research/QualitySurface/SourceRefHandoffHolonomyCorrespondence.lean`、
+`lake env lean Formal/AG/Research.lean`、`lake build FormalAGResearch`、full `lake build` は通過した。
+full build の警告は既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter 警告のみである。
+
+証明済み declaration は次である。
+
+- `SourceRefHandoffLoop`
+- `SourceRefHandoffAtlas`
+- `SourceRefHandoffAtlas.toRouteAtlas`
+- `HandoffHolonomySupport`
+- `HasHandoffHolonomySupport`
+- `HandoffHolonomyClear`
+- `sourceRefHandoff_component_false_iff_lawFailure`
+- `sourceRefHandoffFailure_of_handoffHolonomySupport`
+- `handoffHolonomySupport_iff_loopHolonomySupport`
+- `handoffHolonomyClear_iff_loopHolonomyClear`
+- `handoffLoopHolonomyClear_iff_interactionExact_of_local`
+- `handoffAtlasLocalExact_iff_routeAtlasLocalExact`
+- `handoffAtlasHolonomyVanishes_iff_routeAtlasHolonomyVanishes`
+- `handoffAtlasInteractionExact_iff_routeAtlasInteractionExact`
+- `handoffAtlasInteractionExact_iff_localAndHandoffHolonomyClear`
+- `firstHandoffObstructingLoop?`
+- `firstHandoffObstructingLoop?_some_mem`
+- `firstHandoffObstructingLoop?_some_nonemptySupport`
+- `firstHandoffObstructingLoop?_some_failure`
+- `firstHandoffObstructingLoop?_some_bridgeObstruction`
+- `firstHandoffObstructingLoop?_some_loopHolonomySupport`
+- `firstHandoffObstructingLoop?_some_obstructs_atlasInteractionExact`
+- `mixedSourceRefHandoffAtlas_firstObstructingLoop`
+- `mixedSourceRefHandoffAtlas_not_interactionExact`
+- `alignedSourceRefHandoffAtlas_interactionExact`
+- `sourceRefHandoffHolonomyCorrespondence_package`
+
+`#print axioms` では、core clearance、handoff-loop local exactness、handoff atlas exactness criterion は axiom-free である。
+handoff law failure と selector の一部は `propext`、RouteAtlas projection theorem、mixed / aligned concrete witness、package は既存 list / exactness infrastructure 由来の `propext` / `Quot.sound` を継承する。
+`sorryAx`、custom axiom、`Classical.choice` はない。
+finite witness として標準公理を自動 clean 扱いせずに監査し、`Quot.sound` は source-ref handoff / selector の新規論理ではなく既存 concrete local exactness witness 側からの伝播として扱う。
+
+## 審判メモ
+
+- G1: 四つの独立候補生成サブエージェントは、three-law minimality、order-independent obstruction locus、source-ref handoff holonomy correspondence を主要候補として提示した。三体が handoff-holonomy correspondence / obstruction locus を高 SCORE 通常候補として出し、open genius target theorem は supplied summary 上なし。今回は通常 SCORE 候補として G2 に出す。
+- G2 A 厳密性: accept、base 80、genius no。`SourceRefHandoffLoop`、component law failure iff、support iff loop holonomy support、RouteAtlas / HandoffAtlas exactness correspondence、first obstruction の membership / failure / derived bridge obstruction / support / atlas obstruction を要求した。
+- G2 B 研究価値: accept、base 86、genius no。source-ref handoff、derived bridge、closed-route holonomy、interaction exactness を一つの finite correspondence として圧縮する点を評価した。
+- G2 C repo 全体価値: accept、base 86、genius no。Lean / research report / future paper / tooling explanation surface への接続価値を評価した。
+- G2 D ライバル比較: accept、base 86、genius no。ADL / conformance checker / dashboard が表示する failing route を、source-ref law failure と derived bridge obstruction の同一 finite certificate geometry へ上げる点を評価した。
+- G3 公理検査: pass。`sorryAx`、custom axiom、`Classical.choice` はなく、標準 `propext` / `Quot.sound` のみ。finite witness としての理由を上記に記録した。
+- G3 形式化品質監査: 初回は `RouteAtlasInteractionExact` 側の明示 correspondence 欠落で revise。`SourceRefHandoffAtlas.toRouteAtlas` と local / holonomy / interaction exactness の projection theorem を追加し、package theorem に含めて解消した。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-heterogeneous-route-interaction-curvature.md`
+- `research/ideas/g-aat-quality-surface-01-finite-route-holonomy-obstruction-support.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-handoff-derived-bridge.md`
+
+## 進捗ログ
+
+- 2026-06-21: cycle 60 G1 候補 pool から G2 審判対象として作成。
+- 2026-06-21: Lean proof と RouteAtlas projection correspondence を固定し、候補カードを `proved-in-research` に同期。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 7706
+- total SCORE: 7866
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -64,8 +64,9 @@
   - profile-curvature / certificate-transport / obstruction / repair-potential / traceability / quality-surface: 160
   - profile-curvature / certificate-transport / obstruction / traceability / computability / repair-potential / quality-surface: 156
   - traceability / certificate-transport / obstruction / repair-potential / quality-surface: 160
+  - traceability / certificate-transport / obstruction / computability / quality-surface: 160
 - evidence portfolio:
-  - proved-in-research: 59
+  - proved-in-research: 60
 
 ## Phase synthesis
 
@@ -81,7 +82,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-59 件の Lean-proved research artifacts は、次の paper seed を形成している。
+60 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -125,11 +126,11 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 59 後の total SCORE は 7706 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 60 後の total SCORE は 7866 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 59 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 60 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
-scalar-collapse counterexample、finite trace / source-ref exactness example を含む。
+scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -2707,11 +2708,66 @@ existing heterogeneous route state に相対化され、
 source extraction completeness、ArchMap correctness、runtime repair synthesis、arbitrary route enumeration、
 実コード全体の品質判定は結論しない。genius scoring は適用しない。
 
+## Cycle 60: Source-ref handoff holonomy correspondence for finite route atlases
+
+```text
+candidate: Source-ref handoff holonomy correspondence for finite route atlases
+candidate_type: unification / bridge
+evidence_stage: proved-in-research
+base_score: 80
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 160
+category: traceability / certificate-transport / obstruction / computability / quality-surface
+goal_delta: Source-ref handoff law failure、derived bridge obstruction、closed-route holonomy support、atlas interaction exactness failureを、selected finite route atlas 上の同一 certificate correspondence として固定した。
+project_value_delta: Cycle 57-59 の heterogeneous bridge、route holonomy、source-ref handoff derivation を、`SourceRefHandoffLoop` / `SourceRefHandoffAtlas` と RouteAtlas projection theorem を持つ reportable Lean package へ統合した。
+rival_delta: ADL / conformance checker / metric dashboard は failing route や mismatch を表示できるが、その failure を source-ref law failure、derived bridge obstruction、closed-route holonomy support、interaction exactness obstruction の同一 finite geometry としては束ねない。
+formalization_quality: pass。`lake env lean`、`lake env lean Formal/AG/Research.lean`、`lake build FormalAGResearch`、full `lake build` は pass。full build の警告は既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter 警告のみである。`sorryAx`、custom axiom、`Classical.choice` はない。core clearance、handoff-loop local exactness、handoff atlas exactness criterion は axiom-free。law failure と selector の一部は `propext`、RouteAtlas projection theorem、mixed / aligned concrete witness、package は既存 list / exactness infrastructure 由来の `propext` / `Quot.sound` を継承する。
+open_questions: source-ref handoff obstruction の order-independent locus 化、heterogeneous bridge law minimality matrix、finite holonomy-obstruction correspondence の broader theorem program。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SourceRefHandoffHolonomyCorrespondence.lean` は、
+source-ref handoff data を載せた selected finite route atlas を定義する。
+各 `SourceRefHandoffLoop` は route `state`、`SourceRefHandoff`、および
+`state.bridge = handoff.toBridgeCertificate` を持つ。これにより、source-ref handoff の
+component law failure と route loop の holonomy support は同じ protected locus として読める。
+
+Lean 証拠は次を固定する。
+
+- `SourceRefHandoffAtlas.toRouteAtlas`: source-ref handoff atlas を underlying `RouteAtlas` へ射影する。
+- `sourceRefHandoff_component_false_iff_lawFailure`: certified component false は underlying source-ref handoff law failure と同値である。
+- `sourceRefHandoffFailure_of_handoffHolonomySupport`: handoff holonomy support から Cycle 59 の `SourceRefHandoffFailure` を作る。
+- `handoffHolonomySupport_iff_loopHolonomySupport`: handoff support と loop holonomy support は同じ locus である。
+- `handoffHolonomyClear_iff_loopHolonomyClear`: handoff clearance と loop holonomy clearance は同値である。
+- `handoffLoopHolonomyClear_iff_interactionExact_of_local`: local exactness の下で handoff clearance は interaction exactness と同値である。
+- `handoffAtlasLocalExact_iff_routeAtlasLocalExact`: handoff atlas local exactness は underlying route atlas local exactness と同値である。
+- `handoffAtlasHolonomyVanishes_iff_routeAtlasHolonomyVanishes`: handoff holonomy vanishing は route atlas holonomy vanishing と同値である。
+- `handoffAtlasInteractionExact_iff_routeAtlasInteractionExact`: handoff atlas interaction exactness は underlying route atlas interaction exactness と同値である。
+- `handoffAtlasInteractionExact_iff_localAndHandoffHolonomyClear`: handoff atlas interaction exactness は local exactness と all-loop handoff holonomy vanishing の組と同値である。
+- `firstHandoffObstructingLoop?_some_mem`: ordered selector が返す loop は supplied loop order の member である。
+- `firstHandoffObstructingLoop?_some_failure`: returned loop は source-ref handoff failure を持つ。
+- `firstHandoffObstructingLoop?_some_bridgeObstruction`: returned loop は derived bridge obstruction を持つ。
+- `firstHandoffObstructingLoop?_some_loopHolonomySupport`: returned loop は route loop holonomy support を持つ。
+- `firstHandoffObstructingLoop?_some_obstructs_atlasInteractionExact`: returned first obstruction は handoff atlas interaction exactness を阻む。
+- `mixedSourceRefHandoffAtlas_not_interactionExact`: mixed atlas は locally exact だが interaction exact ではない。
+- `alignedSourceRefHandoffAtlas_interactionExact`: aligned comparator atlas は interaction exact である。
+- `sourceRefHandoffHolonomyCorrespondence_package`: aligned comparator、mixed obstruction、support / holonomy correspondence、RouteAtlas projection correspondence、first obstruction consequence を束ねる。
+
+この結果により、Cycle 58 の route holonomy support と Cycle 59 の source-ref handoff derived bridge は、
+selected finite route atlas 上の一つの correspondence として読める。
+ただし主張は selected finite route atlas、bounded source-ref handoff、finite packet / endpoint tuple、
+supplied loop order、existing heterogeneous route state に相対化される。
+source extraction completeness、ArchMap correctness、runtime repair synthesis、arbitrary route enumeration、
+実コード全体の品質判定は結論しない。genius scoring は適用しない。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 10000 であり、cycle 59 後の total SCORE は 7706 である。
+次フェーズの tracking Issue active threshold は 10000 であり、cycle 60 後の total SCORE は 7866 である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
 threshold 10000 には未達であるため、次 cycle では lawful criterion の necessity / minimality、
-heterogeneous bridge law minimality matrix、または finite holonomy-obstruction correspondence の broader theorem program を狙う。
+source-ref handoff obstruction の order-independent locus 化、heterogeneous bridge law minimality matrix、
+または finite holonomy-obstruction correspondence の broader theorem program を狙う。


### PR DESCRIPTION
## 概要
- Cycle 60 の成果として source-ref handoff law failure、derived bridge obstruction、closed-route holonomy support、atlas interaction exactness failure を同じ finite route atlas correspondence として Lean 形式化しました。
- `SourceRefHandoffAtlas.toRouteAtlas` と local / holonomy / interaction exactness projection theorem を追加し、RouteAtlas 側との対応も package theorem に含めました。
- 候補カードと research report を G4 確定 SCORE +160、total 7866、proved artifacts 60 に同期しました。

## 検証
- `lake env lean Formal/AG/Research/QualitySurface/SourceRefHandoffHolonomyCorrespondence.lean`
- `lake env lean Formal/AG/Research.lean`
- `lake build FormalAGResearch`
- `lake build`（既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter 警告のみ）
- `#print axioms` audit: `sorryAx`、custom axiom、`Classical.choice` なし。標準 `propext` / `Quot.sound` のみ。
- `git diff --check`
- `git diff --cached --check`
- hidden Unicode scan
- private path scan

Refs #2348