### PR TITLE
AGENTSの概念説明を整理

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,58 +8,28 @@
 - [Tooling guideline](docs/tool/guideline.md)
 - [Website guideline](docs/website/guideline.md)
 
-## 基本運用
+## 基礎概念
 
-- ユーザーへの応答は日本語で行う。
-- コミットメッセージ、Pull Request のタイトルと本文、GitHub Issue のタイトルと本文は日本語で書く。
-- Lean の識別子、ファイル名、コマンド名、定理名、既存の英語技術用語はそのまま残してよい。
-- 作業は原則として GitHub Issue 起点で進める。次タスクを選ぶ場合は `priority:blocking`, `status:ready`, milestone の依存順を優先する。
-- このリポジトリは個人開発であり、常に最小実装・最小差分を選ぶ必要はない。目的に対して自然に必要な設計、実装、docs、tests、website surface まで広げてよい。
-- ただし、無関係な既存変更の巻き戻し、claim boundary を越える主張、根拠のない互換性維持、不要な抽象化は避ける。
-- AAT / Lean / ArchSig の境界は作業前に必ず分ける。
-  - 現行 AAT は代数幾何的アーキテクチャ論である。Atom は primitive architectural fact
-    として公理化され、Atom family / configuration から architecture object が生成される。
-    その上に architecture geometry、AAT site、sheaf、ringed AAT topos、law algebra、
-    obstruction ideal sheaf、lawful locus、architecture scheme、Čech descent、
-    derived law geometry が立つ。
-  - AAT 自体に source observation、measurement、tooling validation の境界を持ち込まない。
-    測定境界は ArchMap / ArchSig / FieldSig 側の artifact contract として扱う。
-  - Lean 形式化は神様の視点ではない。語れる命題だけを形式化し、全 runtime、全 semantic universe、
-    全未来予測のような証明対象を勝手にスコープへ入れない。
-  - ArchSig は Rust tooling であり Lean 証明器ではない。Rust と Lean の対応を要求しない。
-    ArchSig は `ArchMap + LawPolicy + evidence contract` に相対化して、選ばれた語彙内の肯定的な
-    diagnostic conclusion を出す。
-- ウィトゲンシュタイン的責務境界:
-  ArchSig は、与えられた `ArchMap + LawPolicy + evidence contract` から語れることだけを語る。
-  語れないことには沈黙する。ArchMap の観測・Atom mapping・evidence の正しさは ArchMap author の責務であり、
-  law / axis / witness / coverage の選択は LawPolicy author の責務である。ArchSig は入力 contract を補完・推測・拡張せず、
-  その範囲内で一貫した bounded diagnostic conclusion を出す。
-- 完了レビューや残タスク整理では、対象 Issue / PRD / 計画書 / acceptance test が実際に要求している
-  concrete condition だけを判定する。現実コード全体、意味宇宙全体、未来予測全体のような
-  無制限 claim を勝手に残タスク化しない。
-- claim boundary は、現在の主張を正確に保つための制約として扱う。ユーザーが求めていない限り、
-  「証明できない巨大 claim」や一般的限界を列挙して作業計画の中心にしない。
-- 語り得ない領域は、残タスクや失敗ではなく沈黙として扱う。必要な場合だけ、結論の近くに
-  最小限の boundary として書く。ArchSig / website / report では `SAFE_WITHIN_POLICY`、
-  `NO_SELECTED_OBSTRUCTION`、`ACCEPTABLE_UNDER_EVIDENCE_CONTRACT` のような肯定的結論を中心にし、
-  外側の未観測領域を長い `non-conclusion` 一覧として主役化しない。
-- 禁止: AAT の完了レビューで source extraction / ArchMap observation / tooling validation の完全性を
-  「未完了部分」「非主張」「残タスク」「証明不能な限界」として持ち出さない。
-  source-observation layer の性質は AAT の内側の claim ではない。必要な場合は tooling / SFT 側の
-  具体的な artifact、fixture、schema、validator、Issue acceptance として別に扱う。
-- AAT / SFT の数学本文は根幹文書である。ユーザーがはっきりと明示的に本文編集を指示した場合のみ、
-  `docs/aat/algebraic_geometric_theory/`、`docs/sft/software_field_theory.md`、
-  `docs/sft/aat_interface.md` を更新してよい。
-  - 例: 「数学本文を編集して」「`docs/aat/algebraic_geometric_theory/...` を修正して」。
-  - 「読み直して」「理解して」「レビューして」「差分を確認して」「常識の観点で見て」
-    「PR 作成して」は本文編集の許可ではない。
-  - 本文に問題を見つけても、明示的な本文編集指示がない限り、提案、PR コメント、Issue、
-    周辺 docs / 台帳の修正として扱い、数学本文は read-only とする。
-- 実装作業は `main` を最新化してから専用ブランチを切る。ブランチ名は Issue 番号または作業内容が分かる名前にする。
-- PR 本文には対象 Issue を `Closes #N` 形式で明記し、`.github/pull_request_template.md` に沿って書く。
-- 既存の未コミット変更はユーザーの変更として扱い、勝手に戻さない。
-- `git reset --hard` や `git checkout --` のような破壊的操作は、明示的な依頼なしに実行しない。
-- `.lake` は Lake の build / dependency cache 専用として扱い、検証出力、PR / Issue 下書き、一時 JSON などの temp 置き場に使わない。一時出力は `.tmp/` または `/private/tmp` などに置く。
+- AAT は、Atom を primitive architectural fact として公理化し、law を方程式系として重ねる
+  代数幾何的アーキテクチャ論である。Atom family から生成される architecture object を、
+  lawful locus、obstruction、sheaf、cohomology、derived / stacky structure として読む。
+- AAT の強みは、言語、フレームワーク、実装形態を越えたアーキテクチャ構造を、局所性、
+  貼り合わせ、obstruction、変形、高次構造まで含むひとつの幾何学的基盤で扱える点にある。
+- SFT は、artifact、practice、AI、review、CI、operational feedback が software evolution の
+  reachable future をどう変えるかを扱う。AAT が構造の幾何を扱い、SFT が実践と進化の場を扱う。
+- SFT の強みは、個別の artifact や workflow を、software evolution の reachable future を変える
+  場の操作として統一的に読める点にある。
+- ArchMap は、選ばれた Atom vocabulary と evidence contract の中で architecture evidence を記録する
+  有限 artifact である。
+- LawPolicy / MeasurementProfile は、law reading、cover、witness、measurement regime を固定する
+  contract である。
+- ArchSig は ArchMap と LawPolicy から bounded diagnostic / analysis packet を計算する tooling である。
+- ArchSig の強みは、AAT の強力な幾何的理論を tooling 上で活かし、ArchMap と LawPolicy から
+  lawful locus、obstruction、coverage、witness を読む高度な architecture analysis を計算できる点にある。
+- ArchView は ArchSig の結果を可視化し、FieldSig は analysis packet と workflow evidence を
+  SFT 側の evolution measurement / governance input として読む。
+- Website は、AAT / SFT / tooling を公開向けに読むための publication surface である。
+- Lean status は、証明済みの主張、定義のみの概念、将来の証明義務、実証仮説を区別して読む。
 
 ## モノレポの地図
 
@@ -76,36 +46,36 @@
 | 研究プログラム | `research/`, `Formal/AG/Research` | 研究 GOAL の下で候補探索 → 三審判 → Lean 検証 / 証拠固定 → SCORE 監査 → フェーズ区切り判定を回すループ engine と検証 sandbox。 | [research README](research/README.md) |
 | Archive | `docs/archive` | 過去文書の退避先。現行 source of truth として扱わない。 | [docs README](docs/README.md) |
 
-## 基礎概念
+## 責務境界
 
-- 現行 AAT は、Atom 公理系から Atom family、configuration、architecture object を構成し、
-  そこに law universe、coverage topology、係数環 / 係数 sheaf を載せて architecture geometry、
-  site、sheaf、law algebra、obstruction ideal sheaf、lawful locus、Čech cohomology、
-  derived / stacky geometry として読む純粋数学理論である。
-- Atom、law、obstruction、flatness、signature は代数幾何版の基礎データや局所 presentation
-  として現れる。外部設計パターン語彙へ潰して説明しない。
-- source extraction / ArchMap observation / tooling validation は、AAT 入力を提示・検査する
-  前段または後段 surface であり、AAT の完了条件や残タスクではない。
-- Lean で証明済みの主張、定義のみの概念、将来の証明義務、実証仮説は混同しない。
-- SFT は artifact、practice、AI、review、CI、operational feedback が software evolution の reachable future をどう変えるかを扱う。
-- ArchMap は source-grounded observation artifact であり、AAT site / measurement profile へ渡す
-  有限 evidence surface を記録する。AAT の source of truth ではない。
-- LawPolicy / MeasurementProfile は選ばれた policy、law reading、cover、係数、witness family、
-  measurement regime を与える artifact contract であり、AAT そのものではない。
-- ArchSig は Rust tooling であり、ArchMap、LawPolicy、MeasurementProfile、evidence contract から
-  bounded diagnostic / measurement artifact を出す。Lean 証明器ではない。
-- ArchView は ArchSig が出力した viewer data / summary / manifest を読む可視化レイヤーである。
-  新しい structural verdict を作らず、測定済み artifact の AAT geometry projection として表示する。
-  release bundle では `archview/archview.html` と README を同梱する。
-- ウィトゲンシュタイン的責務境界では、ArchSig は入力された世界の中で語れることだけを出力し、語れない領域を診断・安全・失敗として作らない。
-- FieldSig は ArchSig analysis packet と workflow evidence を SFT 側の evolution measurement / governance input として読む。raw ArchMap を forecast truth として読まない。
-- Website は docs の複製ではなく、AAT / SFT / ArchSig を公開向けに読むための web-native publication surface である。
+- AAT は Atom と law から立つ純粋理論である。ArchSig は ArchMap と LawPolicy から
+  bounded diagnostic を計算する。観測者境界は ArchMap author と evidence contract の責務として
+  一括して扱う。
+- ウィトゲンシュタイン的責務境界を守る。選ばれた vocabulary、policy、evidence contract から
+  語れることだけを語る。語れない領域は、失敗や残タスクではなく沈黙として扱う。
+
+## 作業規律
+
+- ユーザーへの応答、commit message、PR / Issue の title と本文は日本語で書く。
+  Lean 識別子、ファイル名、コマンド名、定理名、既存の英語技術用語はそのまま扱う。
+- `docs/aat/algebraic_geometric_theory/`、`docs/sft/software_field_theory.md`、
+  `docs/sft/aat_interface.md` は、明示的な本文編集タスクの対象になった場合だけ更新する。
+- 完了レビューや残タスク整理では、対象 Issue / PRD / 計画書 / acceptance test が要求する
+  concrete condition だけを判定する。
+- 作業は原則として GitHub Issue 起点で進める。次タスクは `priority:blocking`、`status:ready`、
+  milestone の依存順を優先する。
+- 目的に対して自然に必要な設計、実装、docs、tests、website surface まで広げてよい。
+  ただし、無関係な既存変更の巻き戻し、claim boundary を越える主張、根拠のない互換性維持、
+  不要な抽象化は避ける。
+- 実装作業は `main` を最新化してから専用ブランチを切る。ブランチ名は Issue 番号または作業内容が
+  分かる名前にする。PR 本文には `Closes #N` を明記し、`.github/pull_request_template.md` に沿って書く。
+- 既存の未コミット変更はユーザーの変更として扱い、勝手に戻さない。
+  `git reset --hard` や `git checkout --` は明示的な依頼なしに実行しない。
+- `.lake` は Lake の build / dependency cache 専用とし、一時出力は `.tmp/` または `/private/tmp` に置く。
 
 ## 主要な入口
 
-- `PHILOSOPHY.md`: プロジェクトの核となる思想と問い(なぜ)。旧 VISION.md を統合。
-  原理を述べるのが役割で、作業規律としての規範効力はこの AGENTS.md を正とし、両者が食い違う場合は AGENTS.md に従う。
-  数学的精密さは AG版本文(`docs/aat/algebraic_geometric_theory/`)が担う。
+- `PHILOSOPHY.md`: プロジェクトの核となる思想と問い(なぜ)。
 - `docs/README.md`: 研究 docs 全体の読み方。
 - `docs/aat/algebraic_geometric_theory/README.md`: 代数幾何的 AAT 数学本文の入口。
 - `docs/aat/proof_obligations.md`: Lean proof obligation と empirical hypothesis の台帳。


### PR DESCRIPTION
## 概要

AGENTS.md の入口説明を整理し、AAT / SFT / ArchSig の強みが先に読める構成へ更新した。

対象 Issue: なし（会話での直接指示）

## 証明した定理

- なし

## 編集したドキュメント

- AGENTS.md

## 実施したテスト

- [ ] `lake build`（docs-only のため未実施）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 実装変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 実装変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（AGENTS.md 対象）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
