### PR TITLE
研究: handoff repair transversalを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -60,3 +60,4 @@ import Formal.AG.Research.QualitySurface.SourceRefHandoffHolonomyCorrespondence
 import Formal.AG.Research.QualitySurface.SourceRefHandoffObstructionLocus
 import Formal.AG.Research.QualitySurface.RepairTransportHandoffObstructionBridge
 import Formal.AG.Research.QualitySurface.SourceRefHandoffComponentSupport
+import Formal.AG.Research.QualitySurface.HandoffRepairTransversal

--- a/Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean
+++ b/Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean
@@ -1,0 +1,345 @@
+import Formal.AG.Research.QualitySurface.SourceRefHandoffComponentSupport
+
+/-!
+Cycle 64 evidence for `G-aat-quality-surface-01`.
+
+This file reads source-ref handoff component support as a declared repair
+transversal problem.  The construction is relative to selected finite
+handoff atlases and declared component-level repair predicates.  It does not
+assert runtime repair synthesis, global minimal repair planning, source
+extraction completeness, ArchMap correctness, arbitrary route enumeration, or
+whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace HandoffRepairTransversalTheorem
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open SourceRefHandoffBridge
+open SourceRefHandoffHolonomyCorrespondence
+open SourceRefHandoffComponentSupport
+
+/-! ## Declared component-level repair plans -/
+
+/-- Component support touched by a declared handoff repair plan. -/
+abbrev HandoffRepairSupport := BridgeComponent -> Prop
+
+/--
+A bounded handoff repair plan.
+
+`clears` is a declared component-support clearance predicate, not a runtime
+repair result.  The boundary law says that a plan may clear only components it
+touches.
+-/
+structure HandoffRepairPlan where
+  touched : HandoffRepairSupport
+  clears : BridgeComponent -> Prop
+  clears_only_if_touched :
+    forall component, clears component -> touched component
+
+/-- Component support that remains after declared component clearance. -/
+def DeclaredResidualComponentSupport
+    (atlas : SourceRefHandoffAtlas)
+    (plan : HandoffRepairPlan)
+    (component : BridgeComponent) : Prop :=
+  HandoffComponentSupport atlas component /\ Not (plan.clears component)
+
+/-- Declared clearance of every supported component. -/
+def DeclaredHandoffRepairClears
+    (atlas : SourceRefHandoffAtlas)
+    (plan : HandoffRepairPlan) : Prop :=
+  forall component,
+    HandoffComponentSupport atlas component -> plan.clears component
+
+/-- A repair support is a transversal for the handoff component support. -/
+def HandoffRepairTransversal
+    (atlas : SourceRefHandoffAtlas)
+    (support : HandoffRepairSupport) : Prop :=
+  forall component,
+    HandoffComponentSupport atlas component -> support component
+
+/-- A plan is component-complete when every touched supported component clears. -/
+def ComponentCompleteHandoffRepairPlan
+    (atlas : SourceRefHandoffAtlas)
+    (plan : HandoffRepairPlan) : Prop :=
+  forall component,
+    HandoffComponentSupport atlas component ->
+      plan.touched component -> plan.clears component
+
+/-- A missed component support remains as declared residual support. -/
+theorem missedHandoffComponentSupport_survives
+    {atlas : SourceRefHandoffAtlas}
+    {plan : HandoffRepairPlan}
+    {component : BridgeComponent}
+    (hsupport : HandoffComponentSupport atlas component)
+    (hmiss : Not (plan.touched component)) :
+    DeclaredResidualComponentSupport atlas plan component := by
+  refine ⟨hsupport, ?_⟩
+  intro hclear
+  exact hmiss (plan.clears_only_if_touched component hclear)
+
+/-- Declared clearance forces the touched support to hit every component support. -/
+theorem hitsEveryHandoffComponentSupport_of_declaredClearance
+    {atlas : SourceRefHandoffAtlas}
+    {plan : HandoffRepairPlan}
+    (hclear : DeclaredHandoffRepairClears atlas plan) :
+    HandoffRepairTransversal atlas plan.touched := by
+  intro component hsupport
+  exact plan.clears_only_if_touched component (hclear component hsupport)
+
+/-- Component completeness turns a transversal into declared clearance. -/
+theorem declaredClearance_of_hitsEveryHandoffComponentSupport_of_componentComplete
+    {atlas : SourceRefHandoffAtlas}
+    {plan : HandoffRepairPlan}
+    (hcomplete : ComponentCompleteHandoffRepairPlan atlas plan)
+    (hhits : HandoffRepairTransversal atlas plan.touched) :
+    DeclaredHandoffRepairClears atlas plan := by
+  intro component hsupport
+  exact hcomplete component hsupport (hhits component hsupport)
+
+/-- In a component-complete regime, declared clearance is exactly transversality. -/
+theorem declaredClearance_iff_hitsEvery_of_componentComplete
+    {atlas : SourceRefHandoffAtlas}
+    {plan : HandoffRepairPlan}
+    (hcomplete : ComponentCompleteHandoffRepairPlan atlas plan) :
+    DeclaredHandoffRepairClears atlas plan <->
+      HandoffRepairTransversal atlas plan.touched := by
+  constructor
+  · exact hitsEveryHandoffComponentSupport_of_declaredClearance
+  · exact
+      declaredClearance_of_hitsEveryHandoffComponentSupport_of_componentComplete
+        hcomplete
+
+/-! ## Exact singleton component support in Cycle 63 deletion witnesses -/
+
+/-- The support-law deletion atlas has exactly the support component. -/
+theorem supportLawDeletion_componentSupport_iff
+    (component : BridgeComponent) :
+    HandoffComponentSupport supportLawDeletionAtlas component <->
+      component = BridgeComponent.support := by
+  constructor
+  · intro hcomponent
+    rcases hcomponent with ⟨loop, hmem, hsupport⟩
+    simp [supportLawDeletionAtlas, componentSupportAtlas] at hmem
+    subst loop
+    cases component with
+    | support => rfl
+    | trace =>
+        exact False.elim
+          (hsupport supportDeletion_traceCompatible)
+    | repairFrontier =>
+        exact False.elim
+          (hsupport supportDeletion_repairFrontierCompatible)
+  · intro hcomponent
+    subst component
+    exact supportLawDeletion_componentSupport
+
+/-- The trace-law deletion atlas has exactly the trace component. -/
+theorem traceLawDeletion_componentSupport_iff
+    (component : BridgeComponent) :
+    HandoffComponentSupport traceLawDeletionAtlas component <->
+      component = BridgeComponent.trace := by
+  constructor
+  · intro hcomponent
+    rcases hcomponent with ⟨loop, hmem, hsupport⟩
+    simp [traceLawDeletionAtlas, componentSupportAtlas,
+      traceLawDeletionHandoff] at hmem
+    subst loop
+    cases component with
+    | support =>
+        exact False.elim
+          (hsupport traceRenamedHandoff_supportCompatible)
+    | trace => rfl
+    | repairFrontier =>
+        exact False.elim
+          (hsupport traceRenamedHandoff_repairFrontierCompatible)
+  · intro hcomponent
+    subst component
+    exact traceLawDeletion_componentSupport
+
+/-- The repair-frontier-law deletion atlas has exactly the repair-frontier component. -/
+theorem repairFrontierLawDeletion_componentSupport_iff
+    (component : BridgeComponent) :
+    HandoffComponentSupport repairFrontierLawDeletionAtlas component <->
+      component = BridgeComponent.repairFrontier := by
+  constructor
+  · intro hcomponent
+    rcases hcomponent with ⟨loop, hmem, hsupport⟩
+    simp [repairFrontierLawDeletionAtlas, componentSupportAtlas] at hmem
+    subst loop
+    cases component with
+    | support =>
+        exact False.elim
+          (hsupport repairFrontierDeletion_supportCompatible)
+    | trace =>
+        exact False.elim
+          (hsupport repairFrontierDeletion_traceCompatible)
+    | repairFrontier => rfl
+  · intro hcomponent
+    subst component
+    exact repairFrontierLawDeletion_componentSupport
+
+/-! ## Minimal transversals and visible nonfaithfulness -/
+
+/-- Inclusion-minimal repair transversal for a selected handoff atlas. -/
+def MinimalHandoffRepairTransversal
+    (atlas : SourceRefHandoffAtlas)
+    (support : HandoffRepairSupport) : Prop :=
+  HandoffRepairTransversal atlas support /\
+    forall other : HandoffRepairSupport,
+      HandoffRepairTransversal atlas other ->
+        (forall component, other component -> support component) ->
+          forall component, support component -> other component
+
+/-- Singleton support for one bridge component. -/
+def singletonRepairSupport
+    (component : BridgeComponent) : HandoffRepairSupport :=
+  fun candidate => candidate = component
+
+/-- The support-law deletion witness has a singleton minimal repair transversal. -/
+theorem supportLawDeletion_minimalTransversal :
+    MinimalHandoffRepairTransversal supportLawDeletionAtlas
+      (singletonRepairSupport BridgeComponent.support) := by
+  constructor
+  · intro component hsupport
+    exact (supportLawDeletion_componentSupport_iff component).mp hsupport
+  · intro other hother _hsub component hsingle
+    subst component
+    exact hother BridgeComponent.support supportLawDeletion_componentSupport
+
+/-- The trace-law deletion witness has a singleton minimal repair transversal. -/
+theorem traceLawDeletion_minimalTransversal :
+    MinimalHandoffRepairTransversal traceLawDeletionAtlas
+      (singletonRepairSupport BridgeComponent.trace) := by
+  constructor
+  · intro component hsupport
+    exact (traceLawDeletion_componentSupport_iff component).mp hsupport
+  · intro other hother _hsub component hsingle
+    subst component
+    exact hother BridgeComponent.trace traceLawDeletion_componentSupport
+
+/-- The repair-frontier-law deletion witness has a singleton minimal repair transversal. -/
+theorem repairFrontierLawDeletion_minimalTransversal :
+    MinimalHandoffRepairTransversal repairFrontierLawDeletionAtlas
+      (singletonRepairSupport BridgeComponent.repairFrontier) := by
+  constructor
+  · intro component hsupport
+    exact (repairFrontierLawDeletion_componentSupport_iff component).mp hsupport
+  · intro other hother _hsub component hsingle
+    subst component
+    exact hother BridgeComponent.repairFrontier
+      repairFrontierLawDeletion_componentSupport
+
+/-- Lossful visible shape projection for one-component repair displays. -/
+inductive VisibleRepairShape where
+  | oneComponent
+  deriving DecidableEq
+
+/--
+The visible projection deliberately forgets the protected component identity.
+
+It is only intended for singleton component-repair displays in this theorem
+package.
+-/
+def visibleOneComponentRepairShapeProjection
+    (_support : HandoffRepairSupport) : VisibleRepairShape :=
+  VisibleRepairShape.oneComponent
+
+/-- The support and trace singleton repairs have the same visible projection. -/
+theorem support_trace_same_visibleOneComponentRepairShape :
+    visibleOneComponentRepairShapeProjection
+        (singletonRepairSupport BridgeComponent.support) =
+      visibleOneComponentRepairShapeProjection
+        (singletonRepairSupport BridgeComponent.trace) := by
+  rfl
+
+/-- The support and trace singleton repair supports are protected-distinct. -/
+theorem support_trace_transversalSupport_distinct :
+    singletonRepairSupport BridgeComponent.support ≠
+      singletonRepairSupport BridgeComponent.trace := by
+  intro heq
+  have hsupport :
+      singletonRepairSupport BridgeComponent.support BridgeComponent.support := rfl
+  have htrace :
+      singletonRepairSupport BridgeComponent.trace BridgeComponent.support := by
+    simpa [heq] using hsupport
+  cases htrace
+
+/--
+The visible one-component repair shape is not faithful to protected repair
+transversal support.
+-/
+theorem oneComponentRepairShape_not_faithful_to_repairTransversal :
+    exists supportTrace : HandoffRepairSupport,
+      visibleOneComponentRepairShapeProjection
+          (singletonRepairSupport BridgeComponent.support) =
+        visibleOneComponentRepairShapeProjection supportTrace /\
+      singletonRepairSupport BridgeComponent.support ≠ supportTrace /\
+      MinimalHandoffRepairTransversal supportLawDeletionAtlas
+        (singletonRepairSupport BridgeComponent.support) /\
+      MinimalHandoffRepairTransversal traceLawDeletionAtlas supportTrace := by
+  exact
+    ⟨singletonRepairSupport BridgeComponent.trace,
+      support_trace_same_visibleOneComponentRepairShape,
+      support_trace_transversalSupport_distinct,
+      supportLawDeletion_minimalTransversal,
+      traceLawDeletion_minimalTransversal⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-64 theorem package: declared component-support clearance induces a
+repair transversal; component-complete repair plans turn transversality into
+declared clearance; the three Cycle-63 deletion witnesses have singleton
+minimal repair transversals; and one-component visible repair shape is not
+faithful to protected repair transversal support.
+-/
+theorem handoffRepairTransversal_package :
+    (forall (atlas : SourceRefHandoffAtlas) (plan : HandoffRepairPlan),
+      DeclaredHandoffRepairClears atlas plan ->
+        HandoffRepairTransversal atlas plan.touched) /\
+      (forall (atlas : SourceRefHandoffAtlas) (plan : HandoffRepairPlan),
+        ComponentCompleteHandoffRepairPlan atlas plan ->
+          (DeclaredHandoffRepairClears atlas plan <->
+            HandoffRepairTransversal atlas plan.touched)) /\
+      (forall component,
+        HandoffComponentSupport supportLawDeletionAtlas component <->
+          component = BridgeComponent.support) /\
+      (forall component,
+        HandoffComponentSupport traceLawDeletionAtlas component <->
+          component = BridgeComponent.trace) /\
+      (forall component,
+        HandoffComponentSupport repairFrontierLawDeletionAtlas component <->
+          component = BridgeComponent.repairFrontier) /\
+      MinimalHandoffRepairTransversal supportLawDeletionAtlas
+        (singletonRepairSupport BridgeComponent.support) /\
+      MinimalHandoffRepairTransversal traceLawDeletionAtlas
+        (singletonRepairSupport BridgeComponent.trace) /\
+      MinimalHandoffRepairTransversal repairFrontierLawDeletionAtlas
+        (singletonRepairSupport BridgeComponent.repairFrontier) /\
+      exists supportTrace : HandoffRepairSupport,
+        visibleOneComponentRepairShapeProjection
+            (singletonRepairSupport BridgeComponent.support) =
+          visibleOneComponentRepairShapeProjection supportTrace /\
+        singletonRepairSupport BridgeComponent.support ≠ supportTrace /\
+        MinimalHandoffRepairTransversal supportLawDeletionAtlas
+          (singletonRepairSupport BridgeComponent.support) /\
+        MinimalHandoffRepairTransversal traceLawDeletionAtlas supportTrace := by
+  exact
+    ⟨fun _atlas _plan =>
+        hitsEveryHandoffComponentSupport_of_declaredClearance,
+      fun _atlas _plan hcomplete =>
+        declaredClearance_iff_hitsEvery_of_componentComplete hcomplete,
+      supportLawDeletion_componentSupport_iff,
+      traceLawDeletion_componentSupport_iff,
+      repairFrontierLawDeletion_componentSupport_iff,
+      supportLawDeletion_minimalTransversal,
+      traceLawDeletion_minimalTransversal,
+      repairFrontierLawDeletion_minimalTransversal,
+      oneComponentRepairShape_not_faithful_to_repairTransversal⟩
+
+end HandoffRepairTransversalTheorem
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-component-support-transversal-handoff-repairs.md
+++ b/research/ideas/g-aat-quality-surface-01-component-support-transversal-handoff-repairs.md
@@ -1,0 +1,314 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure / bridge
+capability_category: repair-potential / obstruction / traceability / computability / invariance / certificate-transport
+expected_base_score: 82
+expected_evidence_multiplier: 2.0
+expected_final_score: 164
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance tools can display a failing route or component, but this candidate turns protected source-ref handoff component support into a repair transversal theorem and a nonfaithfulness witness for visible one-component repair views.
+origin: cycle-64
+tags: [quality-surface, source-ref, handoff, repair, transversal]
+created: 2026-06-21
+cycle: 64
+lean: Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean
+---
+
+# Component-support transversal theorem for handoff repairs
+
+## 主張
+
+selected finite `SourceRefHandoffAtlas` に対して、Cycle 63 の
+`HandoffComponentSupport atlas component` を repair necessity の hypergraph として読む。
+
+repair plan は、触る component support `touched : BridgeComponent -> Prop` と、宣言された
+component-support clearance `clears : BridgeComponent -> Prop` を持つ。これは actual runtime repair result
+ではなく、selected finite handoff atlas 上で「この component support を clear したと主張できる」という
+bounded certificate predicate である。基本境界として、component を clear する repair はその component を
+触っていなければならない。
+
+```text
+clears_only_if_touched : forall component, clears component -> touched component
+```
+
+declared residual component support は
+
+```text
+DeclaredResidualComponentSupport atlas plan component :=
+  HandoffComponentSupport atlas component and not plan.clears component
+```
+
+として読む。したがって、declared component-support clearance
+
+```text
+DeclaredHandoffRepairClears atlas plan :=
+  forall component, HandoffComponentSupport atlas component -> plan.clears component
+```
+
+を満たす repair plan は、もとの `HandoffComponentSupport` をすべて hit しなければならない。
+
+さらに `component-complete` regime、すなわち touched した supported component は必ず clear される regime では、
+declared clearance と component support transversal が同値になる。
+
+最後に、Cycle 63 の three one-component deletion witnesses に対して、support-only / trace-only /
+repair-frontier-only の singleton repair support がそれぞれ minimal transversal になることを Lean で固定する。
+これにより、visible one-component repair shape は同じでも、必要な protected component repair support は
+support / trace / repair-frontier で異なることを示す。SCORE の核は、基本 hitting statement そのものではなく、
+この exact component-support iff、singleton minimality、lossful visible repair shape nonfaithfulness に置く。
+
+主張は bounded source-ref handoff、selected finite atlas、existing heterogeneous route state、
+finite `BridgeComponent` vocabulary、declared component-level repair plan に相対化する。runtime repair synthesis、
+global minimal repair planning、source extraction completeness、ArchMap correctness、arbitrary route enumeration、
+実コード全体の品質判定は主張しない。
+
+## 候補種別
+
+`closure / bridge`
+
+## 依拠
+
+- Cycle 61: order-independent source-ref handoff obstruction locus
+- Cycle 62: repair/transport commutator bridge for handoff obstruction loci
+- Cycle 63: source-ref handoff component support bitset and law minimality matrix
+- Cycle 1: minimal-support hitting theorem for local repair
+
+## 非自明性
+
+単に `HandoffComponentSupportNonempty` と `HandoffObstructionLocusNonempty` の同値を言い換えるだけなら価値はない。
+本候補の非自明性は、declared component-support clearance という boundary を明示したうえで、
+三 deletion witness の exact component-support iff、singleton minimal transversal、visible one-component repair shape の
+非忠実性を同じ theorem package に入れる点にある。基本 hitting theorem は入口であり、SCORE の核ではない。
+
+## 数学的興味
+
+component support bitset は診断結果ではなく、repair が満たすべき transversal condition として読める。
+obstruction locus、component support、repair exactness、minimal transversal が同一有限対象で結ばれることで、
+Quality Surface の repair-potential が hypergraph duality として現れる。
+
+## GOAL への前進
+
+Cycle 63 で得た component support invariant を、repair-potential / obstruction / traceability / computability の
+共通 object へ進める。これにより、Quality Geometry が failure display ではなく repair reachability geometry を
+持つことを示す。
+
+## ライバルに対する有効性
+
+ADL、architecture conformance checker、metric dashboard は failing component や route mismatch を表示できる。
+しかし、その表示から「どの protected component support を必ず hit しなければ obstruction が残るか」を
+Lean-proved theorem として導くわけではない。さらに、visible one-component repair shape が同じでも
+support / trace / repair-frontier の必要 repair support が違うことを theorem として固定しない。
+
+## SCORE 見込み
+
+- `score_reason`: declared clearance theorem、component-complete iff、three deletion witness の exact component-support iff、minimal singleton transversal、visible repair view nonfaithfulness まで通れば、Cycle 63 の support invariant を repair necessity calculus に変換するため strict base 82 を見込む。
+- `dullness_risk`: 「support を hit せよ」という一般 hitting-set の名前替えに落ちる危険がある。actual repaired atlas や runtime repair result は主張せず、declared clearance、singleton minimality、visible repair view nonfaithfulness を証拠の核にする。
+- `proof_or_evidence_plan`: Lean で `HandoffRepairPlan`、`DeclaredResidualComponentSupport`、`DeclaredHandoffRepairClears`、`HandoffRepairTransversal`、`missedHandoffComponentSupport_survives`、`hitsEveryHandoffComponentSupport_of_declaredClearance`、`declaredClearance_iff_hitsEvery_of_componentComplete`、`*_componentSupport_iff`、singleton deletion minimal transversal、`oneComponentRepairShape_not_faithful_to_repairTransversal` を証明する。
+
+## CS / SWE への帰結
+
+repair UI や review report が「この component を直すべき」と表示するだけでは不十分である。
+必要なのは、source-ref handoff obstruction locus が要求する repair transversal を保持し、
+visible shape が同じ repair 候補でも protected component support が違う場合を区別することである。
+
+## 証明・根拠の見込み
+
+Lean file: `Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean`
+
+予定 declaration:
+
+- `HandoffRepairSupport`
+- `HandoffRepairPlan`
+- `DeclaredResidualComponentSupport`
+- `DeclaredHandoffRepairClears`
+- `HandoffRepairTransversal`
+- `ComponentCompleteHandoffRepairPlan`
+- `missedHandoffComponentSupport_survives`
+- `hitsEveryHandoffComponentSupport_of_declaredClearance`
+- `declaredClearance_of_hitsEveryHandoffComponentSupport_of_componentComplete`
+- `declaredClearance_iff_hitsEvery_of_componentComplete`
+- `supportLawDeletion_componentSupport_iff`
+- `traceLawDeletion_componentSupport_iff`
+- `repairFrontierLawDeletion_componentSupport_iff`
+- `MinimalHandoffRepairTransversal`
+- `supportLawDeletion_minimalTransversal`
+- `traceLawDeletion_minimalTransversal`
+- `repairFrontierLawDeletion_minimalTransversal`
+- `oneComponentRepairShape_not_faithful_to_repairTransversal`
+- `handoffRepairTransversal_package`
+
+証明方針:
+
+1. `clears_only_if_touched` により、missed component support は declared residual support として残ることを示す。
+2. declared clearance なら、各 supported component は clear され、したがって touched されることを示す。
+3. component-complete regime では、touched transversal から clear が導かれるため、clearing と hitting が同値になる。
+4. Cycle 63 の support / trace / repair-frontier deletion witnesses について、component support が singleton であることを cases で示す。
+5. singleton support が minimal transversal であることを証明する。
+6. singleton repair shape は同じでも、support-only と trace-only の required repair support は等しくないことを非忠実性 witness として固定する。
+
+## 審判メモ
+
+- 厳密性: G2-A revise -> accept / base 80 / genius no。declared component-support clearance へ相対化し、singleton minimality と visible repair shape nonfaithfulness を SCORE の核に置いた。
+- 研究価値: G2-B accept / base 82 / genius no。repair transversal、survival、clearing iff、visible repair nonfaithfulness が揃えば GOAL の repair reachability geometry を増やす。
+- repo 全体価値: G2-C accept / base 85 provisional / genius no。AAT / Lean / paper / future Tooling surface に価値があるが、一般 hitting-set の名前替えを避ける必要がある。
+- ライバル比較: G2-D accept / base 85 / genius no。ADL / conformance style の failure display を theorem-level repair transversal condition へ持ち上げる差分がある。
+
+## G2 revise response
+
+- G2-A 厳密性: revise、base 70 provisional、genius no。core transversal theorem は
+  `PostRepairComponentSupport := support and not clears` の定義展開に近く、actual repaired atlas / runtime repair result と
+  誤読される危険がある。SCORE の核を exact component-support iff、singleton minimality、lossful visible repair shape
+  nonfaithfulness へ明示的に移す必要がある。
+- 対応: `PostRepairHandoffLocusEmpty` という語を避け、`DeclaredHandoffRepairClears` と
+  `DeclaredResidualComponentSupport` として bounded certificate predicate を明示した。expected base を 82 に下げ、
+  G3 の必須証拠を `*_componentSupport_iff`、`MinimalHandoffRepairTransversal`、三 deletion witness の
+  singleton minimality、`oneComponentRepairShape_not_faithful_to_repairTransversal` に絞った。
+- G2-A 再審判: accept、base 80、genius no。runtime / post-repair result を避け、declared component-support
+  clearance に相対化し、SCORE の核を exact component-support iff、singleton minimality、visible repair shape
+  nonfaithfulness に移したため、G3 に進める水準と判定された。
+
+## G3 evidence
+
+- Lean file: `Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean`
+- aggregate import: `Formal/AG/Research.lean`
+- local checks:
+  - `lake env lean Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean`: pass
+  - `lake env lean Formal/AG/Research.lean`: pass
+  - `lake build FormalAGResearch`: pass
+  - `lake build`: pass。既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning のみ。
+  - `lake env lean .tmp/handoff_repair_transversal_axioms.lean`: pass
+  - target `axiom|admit|sorry|unsafe` scan: no matches
+
+証明済み declaration:
+
+- `HandoffRepairSupport`
+- `HandoffRepairPlan`
+- `DeclaredResidualComponentSupport`
+- `DeclaredHandoffRepairClears`
+- `HandoffRepairTransversal`
+- `ComponentCompleteHandoffRepairPlan`
+- `missedHandoffComponentSupport_survives`
+- `hitsEveryHandoffComponentSupport_of_declaredClearance`
+- `declaredClearance_of_hitsEveryHandoffComponentSupport_of_componentComplete`
+- `declaredClearance_iff_hitsEvery_of_componentComplete`
+- `supportLawDeletion_componentSupport_iff`
+- `traceLawDeletion_componentSupport_iff`
+- `repairFrontierLawDeletion_componentSupport_iff`
+- `MinimalHandoffRepairTransversal`
+- `singletonRepairSupport`
+- `supportLawDeletion_minimalTransversal`
+- `traceLawDeletion_minimalTransversal`
+- `repairFrontierLawDeletion_minimalTransversal`
+- `VisibleRepairShape`
+- `visibleOneComponentRepairShapeProjection`
+- `support_trace_same_visibleOneComponentRepairShape`
+- `support_trace_transversalSupport_distinct`
+- `oneComponentRepairShape_not_faithful_to_repairTransversal`
+- `handoffRepairTransversal_package`
+
+公理検査の実績:
+
+- axiom-free: repair support / plan / declared residual / declared clearance / transversal / component-complete /
+  missed survival / declared clearance to transversal / component-complete iff / minimal support definitions /
+  visible shape projection / protected support distinctness。
+- standard `propext` only: `*_componentSupport_iff`、singleton minimal transversal、
+  `oneComponentRepairShape_not_faithful_to_repairTransversal`、package theorem。
+- `sorryAx`、custom axiom、`Classical.choice`、`Quot.sound`、`unsafe` はない。
+
+G3 公理検査: pass。`sorryAx`、custom axiom、`Classical.choice`、`Quot.sound`、`unsafe` はない。
+`propext` は finite `BridgeComponent` case split と Prop-valued support predicate の iff / simplification 側だけに残る。
+singleton witness は明示的な `support` / `trace` / `repairFrontier` であり、minimality は explicit transversal argument から出ている。
+
+G3 形式化品質監査: pass。
+
+- 初回 revise: `VisibleOneComponentRepairShape` が Prop predicate で、明示的な lossful projection ではなかった。
+- 対応: Lean 側に `VisibleRepairShape` と `visibleOneComponentRepairShapeProjection` を追加し、
+  `oneComponentRepairShape_not_faithful_to_repairTransversal` を projection output equality と
+  protected support inequality の形へ強めた。
+- 再監査: pass。`HandoffRepairPlan.clears` は declared clearance であり、repaired atlas を主張しない。
+  三 deletion witness は exact component-support iff と singleton inclusion-minimal transversal を持ち、
+  visible-shape nonfaithfulness は明示的な projection equality と protected support inequality で述べられている。
+
+## G3.5 planned sync
+
+G4 後の report には、Cycle 64 section として次の declaration 名を載せる。
+
+- `HandoffRepairPlan`
+- `DeclaredResidualComponentSupport`
+- `DeclaredHandoffRepairClears`
+- `HandoffRepairTransversal`
+- `ComponentCompleteHandoffRepairPlan`
+- `missedHandoffComponentSupport_survives`
+- `hitsEveryHandoffComponentSupport_of_declaredClearance`
+- `declaredClearance_iff_hitsEvery_of_componentComplete`
+- `supportLawDeletion_componentSupport_iff`
+- `traceLawDeletion_componentSupport_iff`
+- `repairFrontierLawDeletion_componentSupport_iff`
+- `supportLawDeletion_minimalTransversal`
+- `traceLawDeletion_minimalTransversal`
+- `repairFrontierLawDeletion_minimalTransversal`
+- `visibleOneComponentRepairShapeProjection`
+- `support_trace_same_visibleOneComponentRepairShape`
+- `support_trace_transversalSupport_distinct`
+- `oneComponentRepairShape_not_faithful_to_repairTransversal`
+- `handoffRepairTransversal_package`
+
+## G4 SCORE audit
+
+```text
+score_verdict: confirm
+base_score: 82
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 164
+category: repair-potential / obstruction / traceability / computability / invariance / certificate-transport
+genius_verdict: downgrade-to-normal
+```
+
+G4 は proposed base 82 と Lean-proved evidence multiplier x2.0 を confirm した。
+G2-A は strict base 80 だったが、revise 後の Lean evidence が exact component-support iff、
+三 singleton minimal transversals、projection equality plus protected support inequality を満たし、
+G2-B の base 82 と G2-C/D の base 85 側を支えているため、base 82 は過大ではないと判定された。
+
+GOAL delta: Cycle 63 の component support invariant を、declared repair clearance、component-complete iff、
+singleton minimal transversal、visible repair shape nonfaithfulness を持つ repair necessity calculus へ進める。
+
+Rival delta: ADL / conformance tools の failure display に対し、protected component support を必ず hit する必要性と、
+同じ one-component visible shape が異なる repair support を隠すことを Lean theorem として固定した。
+
+Report sync: `research/reports/G-aat-quality-surface-01.md` は total 8490、proved artifacts 64、
+Cycle 64 section、Next Frontier の残り 1510 SCORE として更新する。
+
+## G1 候補 pool
+
+四つの独立候補生成サブエージェントは、重複を除いて次を主要候補として出した。
+
+- Component-support transversal theorem / handoff component support hitting theorem for exact repairs
+- Handoff repair hitting theorem with ADL-view nonfaithfulness
+- Refinement-invariant source-ref handoff obstruction locus
+- Exact refinement invariance for source-ref handoff obstruction loci
+- Handoff atlas refinement invariance / support-surjective refinement invariance
+- Finite handoff holonomy-obstruction basis theorem
+- Finite Cech-style holonomy-obstruction exactness package
+- Law-refinement commutator curvature for handoff atlases
+
+三体が repair hitting / transversal theorem を第一候補として出したため、本 cycle ではこれを picked とする。
+refinement invariance と finite basis theorem は後続 frontier に残す。
+
+## Genius potential
+
+この候補単体は `genius unlock` ではない。finite holonomy-obstruction repair-transversal duality や
+Cech-style exactness package の将来 support cycle にはなりうるが、今回は通常 SCORE 候補として扱う。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-source-ref-handoff-obstruction-locus.md`
+- `research/ideas/g-aat-quality-surface-01-repair-transport-handoff-obstruction-bridge.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-handoff-component-support-bitset.md`
+
+## 進捗ログ
+
+- 2026-06-21: cycle 64 G1 候補 pool から G2 審判対象として作成。
+- 2026-06-21: G2-A revise を受け、actual repair result ではなく declared component-support clearance として主張を相対化し、SCORE の核を singleton minimality と visible repair shape nonfaithfulness へ移した。
+- 2026-06-21: Lean proof を固定し、local build と axiom scan を通過。G3 独立監査待ち。
+- 2026-06-21: G3 公理検査 / 形式化品質監査 / G3.5 同期監査を通過。G4 SCORE 監査で +164 を confirm。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 8326
+- total SCORE: 8490
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -68,8 +68,9 @@
   - obstruction / certificate-transport / traceability / computability / invariance / quality-surface: 160
   - repair-potential / certificate-transport / obstruction / traceability / quality-surface: 140
   - obstruction / computability / traceability / certificate-transport / invariance: 160
+  - repair-potential / obstruction / traceability / computability / invariance / certificate-transport: 164
 - evidence portfolio:
-  - proved-in-research: 63
+  - proved-in-research: 64
 
 ## Phase synthesis
 
@@ -85,7 +86,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-63 件の Lean-proved research artifacts は、次の paper seed を形成している。
+64 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -94,6 +95,7 @@ certificate の基本単位は
 - endpoint view では消える route-internal defect excursion も、selected internal support family と repair necessity を持つ。
 - repair / transport endpoint pair の順序差を source-ref handoff obstruction locus に戻して読める。
 - source-ref handoff obstruction locus を component-indexed support と三 law minimality matrix として読める。
+- component support を declared repair clearance の transversal condition として読める。
 
 ### Related-work separation
 
@@ -131,13 +133,13 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 63 後の total SCORE は 8326 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 64 後の total SCORE は 8490 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 63 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 64 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
-component support bitset / law minimality matrix を含む。
+component support bitset / law minimality matrix、declared repair transversal theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -2926,13 +2928,72 @@ finite `BridgeComponent` vocabulary に相対化される。global canonical min
 source extraction completeness、ArchMap correctness、arbitrary route enumeration、実コード全体の品質判定は結論しない。
 G2 四審判はいずれも `genius_eligibility: no` を返し、G4 は通常 SCORE として base 80 を confirm した。
 
+## Cycle 64: Component-support transversal theorem for handoff repairs
+
+```text
+candidate: Component-support transversal theorem for handoff repairs
+candidate_type: closure / bridge
+evidence_stage: proved-in-research
+base_score: 82
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 164
+category: repair-potential / obstruction / traceability / computability / invariance / certificate-transport
+goal_delta: Cycle 63 の component support invariant を、declared repair clearance、component-complete iff、singleton minimal transversal、visible repair shape nonfaithfulness を持つ repair necessity calculus へ進めた。
+project_value_delta: Cycle 61-63 の handoff obstruction / support 系列を repair-potential frontier に接続し、次の refinement invariance / finite holonomy-obstruction program の足場を作った。
+rival_delta: ADL / conformance tools の failure display に対し、protected component support を必ず hit する必要性と、同じ one-component visible shape が異なる repair support を隠すことを Lean theorem として固定した。
+formalization_quality: pass。`lake env lean`、`lake env lean Formal/AG/Research.lean`、`lake build FormalAGResearch`、full `lake build` は pass。full build の警告は既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter 警告のみである。core repair / transversal definitions と visible projection は axiom-free。exact component-support iff、singleton minimal transversal、nonfaithfulness、package theorem は標準 `propext` のみに依存する。`sorryAx`、custom axiom、`Classical.choice`、`Quot.sound`、`unsafe` はない。
+open_questions: refinement-invariant handoff obstruction loci、component support hitting under atlas refinement、finite handoff holonomy-obstruction basis theorem、finite Cech-style holonomy-obstruction exactness package。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean` は、
+source-ref handoff component support を declared repair transversal condition として読む。
+repair plan は `touched : BridgeComponent -> Prop` と declared clearance `clears : BridgeComponent -> Prop`
+を持ち、`clears_only_if_touched` によって clear する component は必ず touched される。
+ここで `clears` は runtime repair result ではなく、selected finite atlas 上の declared component-support
+clearance predicate である。
+
+Lean 証拠は次を固定する。
+
+- `HandoffRepairPlan`: declared component-level repair plan。
+- `DeclaredResidualComponentSupport`: supported だが declared clear されていない component support。
+- `DeclaredHandoffRepairClears`: atlas の全 component support を declared clear する predicate。
+- `HandoffRepairTransversal`: repair support が handoff component support を hit する predicate。
+- `ComponentCompleteHandoffRepairPlan`: touched supported component を必ず clear する regime。
+- `missedHandoffComponentSupport_survives`: touched されていない component support は declared residual support として残る。
+- `hitsEveryHandoffComponentSupport_of_declaredClearance`: declared clearance は repair support transversal を強制する。
+- `declaredClearance_iff_hitsEvery_of_componentComplete`: component-complete regime では declared clearance と transversal は同値である。
+- `supportLawDeletion_componentSupport_iff`、`traceLawDeletion_componentSupport_iff`、
+  `repairFrontierLawDeletion_componentSupport_iff`: Cycle 63 の三 deletion atlas は、それぞれ support / trace /
+  repair-frontier component ちょうどを support として持つ。
+- `supportLawDeletion_minimalTransversal`、`traceLawDeletion_minimalTransversal`、
+  `repairFrontierLawDeletion_minimalTransversal`: 三 deletion witness の required repair support は singleton
+  inclusion-minimal transversal である。
+- `VisibleRepairShape` と `visibleOneComponentRepairShapeProjection`: protected component identity を忘れる
+  one-component visible shape projection。
+- `support_trace_transversalSupport_distinct`: support singleton と trace singleton は protected repair support として異なる。
+- `oneComponentRepairShape_not_faithful_to_repairTransversal`: visible projection は同じでも、protected repair
+  transversal support は異なりうる。
+- `handoffRepairTransversal_package`: declared clearance / transversal iff、singleton minimal transversals、
+  visible-shape nonfaithfulness を束ねる。
+
+この結果により、source-ref handoff component support は failure display ではなく、declared repair が hit すべき
+protected repair support hypergraph として読める。ADL / conformance surface が一つの component repair として
+見せる repair shape は、support / trace / repair-frontier の protected repair transversal を復元しない。
+ただし主張は selected finite source-ref handoff atlas、finite `BridgeComponent` vocabulary、
+declared component-level repair predicate に相対化される。runtime repair synthesis、global minimal repair planning、
+source extraction completeness、ArchMap correctness、arbitrary route enumeration、実コード全体の品質判定は結論しない。
+G2 四審判はいずれも `genius_eligibility: no` を返し、G4 は通常 SCORE として base 82 を confirm した。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 10000 であり、cycle 63 後の total SCORE は 8326 である。
-threshold 10000 までは残り 1674 SCORE である。
+次フェーズの tracking Issue active threshold は 10000 であり、cycle 64 後の total SCORE は 8490 である。
+threshold 10000 までは残り 1510 SCORE である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation を備えた。
-threshold 10000 には未達であるため、次 cycle では component support hitting theorem for handoff repairs、
-handoff atlas refinement invariance、finite holonomy-obstruction correspondence の broader theorem program、
-または handoff component support を repair planning / refinement invariant へ接続する theorem を狙う。
+threshold 10000 には未達であるため、次 cycle では handoff atlas refinement invariance、
+component support hitting under atlas refinement、finite handoff holonomy-obstruction basis theorem、
+finite Cech-style holonomy-obstruction exactness package、または law-refinement commutator curvature を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 64 として、source-ref handoff component support を declared repair transversal condition として読む Lean theorem package を追加しました。

G4 SCORE 監査は `base_score: 82`、`evidence_multiplier: 2.0`、`penalty: 0`、`final_score: 164` を confirm しました。これにより report の total SCORE は 8490、proved-in-research artifact は 64 件になります。

## 証明した定理

- `HandoffRepairPlan`
- `DeclaredResidualComponentSupport`
- `DeclaredHandoffRepairClears`
- `HandoffRepairTransversal`
- `ComponentCompleteHandoffRepairPlan`
- `missedHandoffComponentSupport_survives`
- `hitsEveryHandoffComponentSupport_of_declaredClearance`
- `declaredClearance_iff_hitsEvery_of_componentComplete`
- `supportLawDeletion_componentSupport_iff`
- `traceLawDeletion_componentSupport_iff`
- `repairFrontierLawDeletion_componentSupport_iff`
- `supportLawDeletion_minimalTransversal`
- `traceLawDeletion_minimalTransversal`
- `repairFrontierLawDeletion_minimalTransversal`
- `VisibleRepairShape`
- `visibleOneComponentRepairShapeProjection`
- `support_trace_same_visibleOneComponentRepairShape`
- `support_trace_transversalSupport_distinct`
- `oneComponentRepairShape_not_faithful_to_repairTransversal`
- `handoffRepairTransversal_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-component-support-transversal-handoff-repairs.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean`
- [x] `lake env lean Formal/AG/Research.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning のみ）
- [x] `lake env lean .tmp/handoff_repair_transversal_axioms.lean`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 追跡 Issue は research-loop のため `Refs #2348` として記載し、`Closes` では閉じない
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
