### PR TITLE
研究: handoff Cech exactnessを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -61,3 +61,4 @@ import Formal.AG.Research.QualitySurface.SourceRefHandoffObstructionLocus
 import Formal.AG.Research.QualitySurface.RepairTransportHandoffObstructionBridge
 import Formal.AG.Research.QualitySurface.SourceRefHandoffComponentSupport
 import Formal.AG.Research.QualitySurface.HandoffRepairTransversal
+import Formal.AG.Research.QualitySurface.HandoffCechExactness

--- a/Formal/AG/Research/QualitySurface/HandoffCechExactness.lean
+++ b/Formal/AG/Research/QualitySurface/HandoffCechExactness.lean
@@ -1,0 +1,250 @@
+import Formal.AG.Research.QualitySurface.HandoffRepairTransversal
+
+/-!
+Cycle 65 evidence for `G-aat-quality-surface-01`.
+
+This file packages a finite Cech-style handoff cover.  A cover has chart
+atlases and a separate overlap cocycle atlas; global exactness is local chart
+interaction exactness plus overlap holonomy vanishing.  The overlap component
+support is read directly from the overlap cocycle atlas, not from failure of
+global exactness.
+
+The claim is relative to selected finite source-ref handoff atlases, supplied
+chart and overlap data, bounded handoff laws, the finite `BridgeComponent`
+vocabulary, and declared component-level repair predicates.  It does not assert
+source extraction completeness, ArchMap correctness, runtime repair synthesis,
+arbitrary route enumeration, global sheaf completeness, or whole-codebase
+quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace HandoffCechExactness
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open SourceRefHandoffBridge
+open SourceRefHandoffHolonomyCorrespondence
+open SourceRefHandoffObstructionLocus
+open SourceRefHandoffComponentSupport
+open HandoffRepairTransversalTheorem
+
+/-! ## Finite chart/overlap handoff covers -/
+
+/--
+A finite Cech-style handoff cover.
+
+The chart atlases and overlap cocycle atlas are intentionally separate fields.
+This prevents the cover from being a shallow alias for one
+`SourceRefHandoffAtlas`.
+-/
+structure HandoffCechCover where
+  charts : List SourceRefHandoffAtlas
+  overlapCocycle : SourceRefHandoffAtlas
+
+/-- Every chart atlas is already interaction exact. -/
+def HandoffCechLocalExact
+    (cover : HandoffCechCover) : Prop :=
+  forall chart, chart ∈ cover.charts -> HandoffAtlasInteractionExact chart
+
+/-- The overlap cocycle has no handoff holonomy. -/
+def HandoffCechOverlapHolonomyVanishes
+    (cover : HandoffCechCover) : Prop :=
+  HandoffAtlasHolonomyVanishes cover.overlapCocycle
+
+/-- Global exactness is local chart exactness plus overlap cocycle vanishing. -/
+def HandoffCechGlobalExact
+    (cover : HandoffCechCover) : Prop :=
+  HandoffCechLocalExact cover /\
+    HandoffCechOverlapHolonomyVanishes cover
+
+/-- Protected component support of the overlap cocycle. -/
+def HandoffCechOverlapSupport
+    (cover : HandoffCechCover)
+    (component : BridgeComponent) : Prop :=
+  HandoffComponentSupport cover.overlapCocycle component
+
+/-- The overlap cocycle has some protected component support. -/
+def HandoffCechOverlapSupportNonempty
+    (cover : HandoffCechCover) : Prop :=
+  exists component, HandoffCechOverlapSupport cover component
+
+/-- The overlap cocycle has no protected component support. -/
+def HandoffCechOverlapSupportEmpty
+    (cover : HandoffCechCover) : Prop :=
+  Not (HandoffCechOverlapSupportNonempty cover)
+
+/-- Empty overlap support is exactly overlap holonomy vanishing. -/
+theorem handoffCech_overlapSupportEmpty_iff_holonomyVanishes
+    (cover : HandoffCechCover) :
+    HandoffCechOverlapSupportEmpty cover <->
+      HandoffCechOverlapHolonomyVanishes cover := by
+  exact handoffComponentSupport_empty_iff_holonomyVanishes
+    cover.overlapCocycle
+
+/-- Nonempty component support is exactly nonvanishing handoff holonomy. -/
+theorem handoffComponentSupport_nonempty_iff_not_holonomyVanishes
+    (atlas : SourceRefHandoffAtlas) :
+    HandoffComponentSupportNonempty atlas <->
+      Not (HandoffAtlasHolonomyVanishes atlas) :=
+  (handoffComponentSupport_nonempty_iff_locusNonempty atlas).trans
+    (handoffObstructionLocus_nonempty_iff_not_holonomyVanishes atlas)
+
+/-- Global exactness is local chart exactness plus empty overlap support. -/
+theorem handoffCech_globalExact_iff_localExact_and_overlapSupportEmpty
+    (cover : HandoffCechCover) :
+    HandoffCechGlobalExact cover <->
+      HandoffCechLocalExact cover /\
+        HandoffCechOverlapSupportEmpty cover := by
+  constructor
+  · intro hglobal
+    exact
+      ⟨hglobal.1,
+        (handoffCech_overlapSupportEmpty_iff_holonomyVanishes cover).mpr
+          hglobal.2⟩
+  · intro hpair
+    exact
+      ⟨hpair.1,
+        (handoffCech_overlapSupportEmpty_iff_holonomyVanishes cover).mp
+          hpair.2⟩
+
+/--
+Under local chart exactness, a nonempty overlap support is exactly failure of
+global handoff exactness.
+-/
+theorem handoffCech_overlapSupport_nonempty_iff_notGlobalExact_of_local
+    {cover : HandoffCechCover}
+    (hlocal : HandoffCechLocalExact cover) :
+    HandoffCechOverlapSupportNonempty cover <->
+      Not (HandoffCechGlobalExact cover) := by
+  constructor
+  · intro hsupport hglobal
+    have hnotVanish :
+        Not (HandoffAtlasHolonomyVanishes cover.overlapCocycle) :=
+      (handoffComponentSupport_nonempty_iff_not_holonomyVanishes
+        cover.overlapCocycle).mp hsupport
+    exact hnotVanish hglobal.2
+  · intro hnotGlobal
+    apply
+      (handoffComponentSupport_nonempty_iff_not_holonomyVanishes
+        cover.overlapCocycle).mpr
+    intro hvanish
+    exact hnotGlobal ⟨hlocal, hvanish⟩
+
+/-! ## Declared repair obligations for overlap cocycles -/
+
+/-- Declared repair clearance of all overlap component support. -/
+def HandoffCechRepairObligation
+    (cover : HandoffCechCover)
+    (plan : HandoffRepairPlan) : Prop :=
+  DeclaredHandoffRepairClears cover.overlapCocycle plan
+
+/-- The declared repair support hits every overlap component support. -/
+def HandoffCechOverlapRepairTransversal
+    (cover : HandoffCechCover)
+    (support : HandoffRepairSupport) : Prop :=
+  HandoffRepairTransversal cover.overlapCocycle support
+
+/--
+For component-complete declared repair plans, overlap repair clearance is
+exactly overlap repair transversality.
+-/
+theorem handoffCech_repairObligation_iff_overlapRepairTransversal_of_componentComplete
+    {cover : HandoffCechCover}
+    {plan : HandoffRepairPlan}
+    (hcomplete :
+      ComponentCompleteHandoffRepairPlan cover.overlapCocycle plan) :
+    HandoffCechRepairObligation cover plan <->
+      HandoffCechOverlapRepairTransversal cover plan.touched :=
+  declaredClearance_iff_hitsEvery_of_componentComplete hcomplete
+
+/-! ## A local-green / overlap-obstructed finite witness -/
+
+/--
+A cover whose only chart is interaction exact but whose separate overlap
+cocycle has a support-law deletion obstruction.
+-/
+def locallyExactOverlapObstructedCover : HandoffCechCover where
+  charts := [alignedSourceRefHandoffAtlas]
+  overlapCocycle := supportLawDeletionAtlas
+
+/-- Every chart in the witness cover is interaction exact. -/
+theorem locallyExactOverlapObstructedCover_localExact :
+    HandoffCechLocalExact locallyExactOverlapObstructedCover := by
+  intro chart hmem
+  simp [locallyExactOverlapObstructedCover] at hmem
+  subst chart
+  exact alignedSourceRefHandoffAtlas_interactionExact
+
+/-- The witness cover has protected support in its overlap cocycle. -/
+theorem locallyExactOverlapObstructedCover_overlapSupportNonempty :
+    HandoffCechOverlapSupportNonempty
+      locallyExactOverlapObstructedCover :=
+  ⟨BridgeComponent.support, supportLawDeletion_componentSupport⟩
+
+/-- The witness cover is not globally exact. -/
+theorem locallyExactOverlapObstructedCover_notGlobalExact :
+    Not (HandoffCechGlobalExact locallyExactOverlapObstructedCover) :=
+  (handoffCech_overlapSupport_nonempty_iff_notGlobalExact_of_local
+    locallyExactOverlapObstructedCover_localExact).mp
+      locallyExactOverlapObstructedCover_overlapSupportNonempty
+
+/--
+Local chart exactness is not faithful to global handoff exactness unless the
+overlap cocycle support is also exposed.
+-/
+theorem locallyExact_not_faithful_without_overlapCocycle :
+    HandoffCechLocalExact locallyExactOverlapObstructedCover /\
+      HandoffCechOverlapSupportNonempty locallyExactOverlapObstructedCover /\
+      Not (HandoffCechGlobalExact locallyExactOverlapObstructedCover) :=
+  ⟨locallyExactOverlapObstructedCover_localExact,
+    locallyExactOverlapObstructedCover_overlapSupportNonempty,
+    locallyExactOverlapObstructedCover_notGlobalExact⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-65 theorem package: a finite Cech-style handoff cover separates local
+chart exactness from overlap cocycle support.  Global exactness is equivalent
+to local exactness plus empty overlap support, and component-complete declared
+repair clears the overlap exactly when its support is an overlap repair
+transversal.  There is a finite witness with exact local charts and obstructed
+overlap cocycle support.
+-/
+theorem handoffCechExactness_package :
+    (forall cover,
+      HandoffCechOverlapSupportEmpty cover <->
+        HandoffCechOverlapHolonomyVanishes cover) /\
+      (forall cover,
+        HandoffCechGlobalExact cover <->
+          HandoffCechLocalExact cover /\
+            HandoffCechOverlapSupportEmpty cover) /\
+      (forall {cover},
+        HandoffCechLocalExact cover ->
+          (HandoffCechOverlapSupportNonempty cover <->
+            Not (HandoffCechGlobalExact cover))) /\
+      (forall {cover} {plan : HandoffRepairPlan},
+        ComponentCompleteHandoffRepairPlan cover.overlapCocycle plan ->
+          (HandoffCechRepairObligation cover plan <->
+            HandoffCechOverlapRepairTransversal cover plan.touched)) /\
+      HandoffCechLocalExact locallyExactOverlapObstructedCover /\
+      HandoffCechOverlapSupportNonempty
+        locallyExactOverlapObstructedCover /\
+      Not (HandoffCechGlobalExact
+        locallyExactOverlapObstructedCover) := by
+  exact
+    ⟨handoffCech_overlapSupportEmpty_iff_holonomyVanishes,
+      handoffCech_globalExact_iff_localExact_and_overlapSupportEmpty,
+      fun {cover} hlocal =>
+        handoffCech_overlapSupport_nonempty_iff_notGlobalExact_of_local
+          (cover := cover) hlocal,
+      fun {cover} {plan} hcomplete =>
+        handoffCech_repairObligation_iff_overlapRepairTransversal_of_componentComplete
+          (cover := cover) (plan := plan) hcomplete,
+      locallyExactOverlapObstructedCover_localExact,
+      locallyExactOverlapObstructedCover_overlapSupportNonempty,
+      locallyExactOverlapObstructedCover_notGlobalExact⟩
+
+end HandoffCechExactness
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-finite-cech-handoff-obstruction-exactness.md
+++ b/research/ideas/g-aat-quality-surface-01-finite-cech-handoff-obstruction-exactness.md
@@ -1,0 +1,264 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: bridge
+capability_category: obstruction / certificate-transport / traceability / quality-surface / computability / invariance / repair-potential
+expected_base_score: 84
+expected_evidence_multiplier: 2.0
+expected_final_score: 168
+evidence_stage: proved-in-research
+rival_advantage: ADL can compare local views and constraints, but it does not usually provide a local-chart exactness plus overlap cocycle obstruction theorem with source-ref repair support.
+origin: research-loop-cycle-65
+tags: [quality-surface, handoff, cech, obstruction, exactness, repair-transversal]
+created: 2026-06-21
+cycle: 65
+lean: proved-in-research
+---
+
+# Finite Cech-style handoff obstruction exactness package
+
+## 主張
+
+A finite handoff cover is not just another name for one handoff atlas: it
+bundles a finite family of chart atlases together with a separate overlap
+cocycle atlas.  Global handoff interaction exactness is defined as local chart
+interaction exactness plus vanishing of the overlap cocycle support.  The main
+claim is the non-circular exactness criterion that this global predicate is
+equivalent to local chart exactness together with empty protected overlap
+obstruction support, plus a finite witness where every chart is interaction
+exact but the overlap cocycle obstructs global exactness.  Under
+component-complete declared repair, global repair clearance is equivalent to
+hitting the overlap component support.
+
+The claim is relative to selected finite source-ref handoff atlases, supplied
+finite chart and overlap data, bounded handoff laws, finite `BridgeComponent`
+vocabulary, and declared component-level repair predicates.  It does not assert
+source extraction completeness, ArchMap correctness, runtime repair synthesis,
+arbitrary route enumeration, global sheaf completeness, or whole-codebase
+quality.
+
+## 候補種別
+
+`bridge`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/SourceRefHandoffHolonomyCorrespondence.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefHandoffObstructionLocus.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefHandoffComponentSupport.lean`
+- `Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean`
+- Cycle 60-64 の handoff atlas、obstruction locus、component support、repair transversal 系列。
+
+## 非自明性
+
+This is not another ordered scan or first-failure display.  It lifts the
+source-ref handoff obstruction locus to finite local/global exactness data:
+local charts may be green while overlap cocycle support still obstructs global
+handoff interaction exactness.  The protected overlap support then controls
+both exactness and declared repair obligations.
+
+## 数学的興味
+
+The candidate gives a finite Cech-style reading of handoff obstruction.  The
+new object is the separation between chart atlases and an overlap cocycle
+atlas.  It connects local exactness, overlap cocycle support, obstruction locus
+emptiness, and repair transversality in one theorem package without moving
+outside the bounded source-ref handoff regime.
+
+## GOAL への前進
+
+It strengthens the Quality Surface as a certificate geometry rather than a
+dashboard: a local chart surface can look exact, while the protected overlap
+cocycle contains the actual obstruction and repair necessity.
+
+## ライバルに対する有効性
+
+ADL and conformance tools can compare declared views and list view-level
+mismatches.  This candidate adds a theorem-level local-to-global boundary:
+which hidden overlap support prevents global exactness, and which protected
+components a declared repair must hit.  That is a stronger repair/obstruction
+object than local conformance status or raw violation count.
+
+## SCORE 見込み
+
+- `score_reason`: High bridge value.  The result compresses handoff holonomy,
+  local/global exactness, traceability, computability, and repair support into a
+  finite certificate package aligned with the GOAL's certificate diagram and
+  paper-seed phase boundary.  G2 revised the expected base score from 92 to 88
+  because the value depends on proving that the cover/overlap object is not a
+  shallow rename of existing atlas iff theorems.  After G2-A and G2-C both
+  returned base 82 and G2-B/G2-D returned base 88, the synchronized expected
+  base is set to 84 pending G4 audit.
+- `dullness_risk`: Medium-high unless the Lean evidence includes the explicit
+  chart/overlap separation.  It would be dull if it only renamed an atlas as a
+  cover or defined overlap support as the global obstruction complement.  The
+  proof must include local-chart green / global-overlap failure, exact iff,
+  protected obstruction support, and repair-transversal extraction.
+- `proof_or_evidence_plan`: Define a finite `HandoffCechCover` with chart
+  atlases and a separate overlap cocycle atlas.  Define local exactness as
+  interaction exactness on every chart and define overlap support directly from
+  the overlap cocycle atlas, not as the complement of global exactness.  Define
+  global exactness as local exactness plus overlap holonomy vanishing.  Prove
+  the exact iff against empty overlap component support, nonempty support iff
+  global exactness failure under local exactness, and component-complete repair
+  clearance iff the declared repair hits the overlap component support.  Add a
+  finite witness where all local charts are exact but the overlap cocycle
+  obstructs global exactness.
+
+## CS / SWE への帰結
+
+A system can pass local view checks while failing at hidden overlap handoff
+interfaces.  The theorem identifies the protected overlap component support
+that must be exposed in a drill-down or repair workflow; a green local dashboard
+is not a faithful global certificate unless the overlap cocycle support is
+empty.
+
+## 証明・根拠の見込み
+
+Planned Lean declarations:
+
+- `HandoffCechCover`
+- `HandoffCechLocalExact`
+- `HandoffCechGlobalExact`
+- `HandoffCechOverlapSupport`
+- `HandoffCechOverlapSupportEmpty`
+- `HandoffCechRepairObligation`
+- `handoffCech_globalExact_iff_localExact_and_overlapSupportEmpty`
+- `handoffCech_overlapSupport_nonempty_iff_notGlobalExact_of_local`
+- `handoffCech_repairObligation_iff_overlapRepairTransversal_of_componentComplete`
+- `locallyExact_not_faithful_without_overlapCocycle`
+- `handoffCechExactness_package`
+
+Actual Lean evidence stage: `proved-in-research`.
+
+Implemented in:
+
+- `Formal/AG/Research/QualitySurface/HandoffCechExactness.lean`
+- aggregate import: `Formal/AG/Research.lean`
+
+Implemented Lean declarations:
+
+- `HandoffCechCover`
+- `HandoffCechLocalExact`
+- `HandoffCechOverlapHolonomyVanishes`
+- `HandoffCechGlobalExact`
+- `HandoffCechOverlapSupport`
+- `HandoffCechOverlapSupportNonempty`
+- `HandoffCechOverlapSupportEmpty`
+- `handoffCech_overlapSupportEmpty_iff_holonomyVanishes`
+- `handoffComponentSupport_nonempty_iff_not_holonomyVanishes`
+- `handoffCech_globalExact_iff_localExact_and_overlapSupportEmpty`
+- `handoffCech_overlapSupport_nonempty_iff_notGlobalExact_of_local`
+- `HandoffCechRepairObligation`
+- `HandoffCechOverlapRepairTransversal`
+- `handoffCech_repairObligation_iff_overlapRepairTransversal_of_componentComplete`
+- `locallyExactOverlapObstructedCover`
+- `locallyExactOverlapObstructedCover_localExact`
+- `locallyExactOverlapObstructedCover_overlapSupportNonempty`
+- `locallyExactOverlapObstructedCover_notGlobalExact`
+- `locallyExact_not_faithful_without_overlapCocycle`
+- `handoffCechExactness_package`
+
+Build evidence:
+
+- `lake env lean Formal/AG/Research/QualitySurface/HandoffCechExactness.lean`: pass
+- `lake env lean Formal/AG/Research.lean`: pass
+- `lake build FormalAGResearch`: pass
+- target scan for `axiom|admit|sorry|unsafe`: no matches
+- `#print axioms`: core definitions, overlap support definitions, repair
+  obligation definitions, repair equivalence, and `locallyExactOverlapObstructedCover`
+  are `Quot.sound`-free; iff/support exactness declarations use standard
+  `propext`; nonempty local-green witness declarations and the package use
+  standard `propext` plus `Quot.sound` inherited from the existing
+  `alignedSourceRefHandoffAtlas_interactionExact` proof.  No `sorryAx`, custom
+  axiom, `Classical.choice`, or `unsafe`.
+- `git diff --check`: pass
+
+Witness boundary:
+
+- `locallyExactOverlapObstructedCover` uses a nonempty chart list containing
+  `alignedSourceRefHandoffAtlas`, a nonempty exact source-ref handoff chart,
+  together with a distinct support-law deletion overlap cocycle.  Thus the
+  local chart surface is genuinely green while the separate overlap cocycle
+  obstructs global exactness.  This stronger nonempty chart witness imports the
+  standard `Quot.sound` dependency from the existing aligned chart exactness
+  proof; G3 accepted this with disclosure, and G4 must audit whether the
+  evidence still deserves `x2.0`.
+
+G2 revise requirements:
+
+- `HandoffCechCover` must contain chart atlases and a distinct overlap cocycle
+  atlas; it must not be a shallow alias of `SourceRefHandoffAtlas`.
+- `HandoffCechOverlapSupport` must be defined from the overlap cocycle atlas,
+  not from `Not HandoffCechGlobalExact`.
+- The finite witness must prove that each chart is interaction exact while the
+  overlap cocycle support is nonempty and global exactness fails.
+- The repair statement must be component-complete and declared-predicate based,
+  not an automatic runtime repair claim.
+
+## 追加メタデータ
+
+```text
+planned_theorem_names:
+  HandoffCechCover
+  handoffCech_globalExact_iff_localExact_and_overlapSupportEmpty
+  handoffCech_overlapSupport_nonempty_iff_notGlobalExact_of_local
+  handoffCech_repairObligation_iff_overlapRepairTransversal_of_componentComplete
+  locallyExact_not_faithful_without_overlapCocycle
+  handoffCechExactness_package
+visible_projection:
+  all local charts green / pairwise visible conformance / no local chart failure
+protected_structure:
+  overlap-indexed source-ref handoff obstruction support and component repair transversal
+exactness_or_minimality_claim:
+  global exactness iff local exactness plus empty protected overlap support; under component completeness, declared overlap repair clearance iff repair support hits overlap support
+nonfaithfulness_or_failure_mode:
+  locally exact chart surfaces are not faithful to global handoff exactness when the overlap cocycle support is hidden
+previous_cycle_delta:
+  Cycle 60-64 built loop-level handoff holonomy, order-independent locus, component support, and repair transversals; this cycle lifts them to a finite local-to-global exactness package.
+genius_potential:
+  no
+genius_target:
+  none
+genius_support_role:
+  none
+```
+
+## 審判メモ
+
+- 厳密性: initial revise, base 68.  Required explicit chart/overlap separation,
+  overlap support not defined as complement of global exactness, finite
+  local-green/global-failing witness, and component-complete declared repair
+  iff.  After one revision, accepted with base 82 and `genius_eligibility: no`.
+- 研究価値: accept, base 88, `genius_eligibility: no`.  Strong compression of
+  local chart exactness, hidden overlap obstruction, and repair necessity into
+  a finite local-to-global obstruction geometry.
+- repo 全体価値: accept, base 82, `genius_eligibility: no`.  Useful for Lean,
+  Research, paper/website surface, and tooling drill-down rationale, but score
+  should stay below 92 because Cycle 60-64 already provide much of the local
+  exactness/locus/transversal substrate.
+- ライバル比較: accept, base 88, `genius_eligibility: no`.  The correct ADL
+  comparison is not that ADL cannot handle views, but that AAT preserves overlap
+  failure as atom-supported obstruction plus source-ref trace plus repair
+  transversal.
+- G4 SCORE 監査: confirm, base 84, evidence multiplier 2.0, penalty 0,
+  final score 168.  The running total becomes 8658/10000 and
+  `proved-in-research` artifacts become 65.  The nonempty local-green witness
+  imports standard `Quot.sound` from existing aligned chart exactness, but G4
+  confirmed `x2.0` because the dependency is disclosed and localized, and the
+  core cover/support/repair definitions remain `Quot.sound`-free.
+
+## 関連
+
+- `research/reports/G-aat-quality-surface-01.md`
+- `research/ideas/g-aat-quality-surface-01-component-support-transversal-handoff-repairs.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-handoff-component-support-bitset.md`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 65 G1 候補 pool から作成。
+- 2026-06-21: G2-A revise を一巡だけ反映し、G2 四審判 accept。
+- 2026-06-21: `HandoffCechExactness.lean` で Lean 証拠を固定。
+- 2026-06-21: G3 形式化品質 revise に応じて witness を非空 exact chart
+  `alignedSourceRefHandoffAtlas` に強化。
+- 2026-06-21: G4 SCORE 監査で +168 を confirm。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 8490
+- total SCORE: 8658
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -69,8 +69,9 @@
   - repair-potential / certificate-transport / obstruction / traceability / quality-surface: 140
   - obstruction / computability / traceability / certificate-transport / invariance: 160
   - repair-potential / obstruction / traceability / computability / invariance / certificate-transport: 164
+  - obstruction / certificate-transport / traceability / quality-surface / computability / invariance / repair-potential: 168
 - evidence portfolio:
-  - proved-in-research: 64
+  - proved-in-research: 65
 
 ## Phase synthesis
 
@@ -86,7 +87,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-64 件の Lean-proved research artifacts は、次の paper seed を形成している。
+65 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -133,9 +134,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 64 後の total SCORE は 8490 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 65 後の total SCORE は 8658 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 64 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 65 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -2987,13 +2988,61 @@ declared component-level repair predicate に相対化される。runtime repair
 source extraction completeness、ArchMap correctness、arbitrary route enumeration、実コード全体の品質判定は結論しない。
 G2 四審判はいずれも `genius_eligibility: no` を返し、G4 は通常 SCORE として base 82 を confirm した。
 
+## Cycle 65: Finite Cech-style handoff obstruction exactness package
+
+```text
+candidate: Finite Cech-style handoff obstruction exactness package
+candidate_type: bridge
+evidence_stage: proved-in-research
+base_score: 84
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 168
+category: obstruction / certificate-transport / traceability / quality-surface / computability / invariance / repair-potential
+goal_delta: Cycle 60-64 の handoff atlas / obstruction locus / component support / repair transversal 系列を、chart atlas と overlap cocycle atlas を分けた finite local-to-global exactness package へ持ち上げた。
+project_value_delta: Quality Surface を local chart dashboard ではなく、hidden overlap support と declared repair obligation を持つ certificate geometry として読ませる paper-seed theorem package を追加した。
+rival_delta: ADL / conformance surface の view-local green status や mismatch list に対し、AAT は overlap failure を atom-supported obstruction support、source-ref handoff trace、component-complete repair transversal として保存する。
+formalization_quality: pass。`lake env lean`、`lake env lean Formal/AG/Research.lean`、`lake build FormalAGResearch`、full `lake build` は pass。full build の警告は既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter 警告のみである。core cover / support / repair definitions と repair equivalence は `Quot.sound`-free。exactness iff results は標準 `propext`、nonempty local-green witness / package は既存 `alignedSourceRefHandoffAtlas_interactionExact` 由来の標準 `propext` / `Quot.sound` に依存する。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はない。G4 はこの標準公理依存を開示したうえで `x2.0` を confirm した。
+open_questions: refinement-invariant Cech overlap support、finite overlap obstruction basis/minimality、law-refinement commutator curvature、repair basin exchange obstruction。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/HandoffCechExactness.lean` は、finite Cech-style
+handoff cover を定義する。cover は chart atlases の有限リストと、そこから独立した overlap cocycle atlas を持つ。
+overlap support は `Not HandoffCechGlobalExact` から定義されるのではなく、overlap cocycle atlas の
+`HandoffComponentSupport` から直接読まれる。
+
+Lean 証拠は次を固定する。
+
+- `HandoffCechCover`: finite chart atlases plus a separate overlap cocycle atlas。
+- `HandoffCechLocalExact`: every chart atlas is interaction exact。
+- `HandoffCechGlobalExact`: local chart exactness plus overlap cocycle vanishing。
+- `HandoffCechOverlapSupport`: protected component support read from the overlap cocycle。
+- `handoffCech_globalExact_iff_localExact_and_overlapSupportEmpty`: global exactness は local exactness と empty overlap support に同値である。
+- `handoffCech_overlapSupport_nonempty_iff_notGlobalExact_of_local`: local exactness の下で、nonempty overlap support は global exactness failure と同値である。
+- `handoffCech_repairObligation_iff_overlapRepairTransversal_of_componentComplete`: component-complete declared repair では、overlap repair clearance と overlap repair transversal が同値である。
+- `locallyExactOverlapObstructedCover`: nonempty exact chart `alignedSourceRefHandoffAtlas` と distinct support-law deletion overlap cocycle を持つ finite witness。
+- `locallyExact_not_faithful_without_overlapCocycle`: overlap cocycle support を隠すと、local chart exactness は global handoff exactness に faithful ではない。
+- `handoffCechExactness_package`: exactness、repair-transversal、local-green / overlap-obstructed witness を束ねる。
+
+この結果により、Quality Surface は local chart の green status や ADL / conformance surface の view-local result を超えて、
+hidden overlap support を持つ local-to-global certificate geometry として読める。local chart が exact でも、
+別の overlap cocycle atlas に protected support が残れば global handoff exactness は失敗し、component-complete
+declared repair はその overlap component support を hit しなければならない。
+ただし主張は selected finite source-ref handoff atlases、supplied finite chart and overlap data、
+bounded handoff laws、finite `BridgeComponent` vocabulary、declared component-level repair predicate に相対化される。
+source extraction completeness、ArchMap correctness、runtime repair synthesis、arbitrary route enumeration、
+global sheaf completeness、実コード全体の品質判定は結論しない。G2 四審判はいずれも `genius_eligibility: no` を返し、
+G4 は通常 SCORE として base 84 を confirm した。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 10000 であり、cycle 64 後の total SCORE は 8490 である。
-threshold 10000 までは残り 1510 SCORE である。
+次フェーズの tracking Issue active threshold は 10000 であり、cycle 65 後の total SCORE は 8658 である。
+threshold 10000 までは残り 1342 SCORE である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
-finite grid phenomena、related-work separation を備えた。
-threshold 10000 には未達であるため、次 cycle では handoff atlas refinement invariance、
-component support hitting under atlas refinement、finite handoff holonomy-obstruction basis theorem、
-finite Cech-style holonomy-obstruction exactness package、または law-refinement commutator curvature を狙う。
+finite grid phenomena、related-work separation、handoff local-to-global overlap obstruction を備えた。
+threshold 10000 には未達であるため、次 cycle では refinement-invariant Cech overlap support、
+finite overlap obstruction basis/minimality、law-refinement commutator curvature、
+repair basin exchange obstruction、または component support hitting under atlas refinement を狙う。


### PR DESCRIPTION
## 概要

- Cycle 65 の研究成果として finite Cech-style handoff exactness package を追加
- `HandoffCechCover` で chart atlases と distinct overlap cocycle atlas を分離
- overlap support / global exactness / component-complete declared repair obligation を Lean 証明で固定
- `G-aat-quality-surface-01` report を +168、total 8658/10000、proved artifacts 65 に更新

## 対象 Issue

Refs #2348

## 検証

- `lake env lean Formal/AG/Research/QualitySurface/HandoffCechExactness.lean`
- `lake env lean Formal/AG/Research.lean`
- `lake build FormalAGResearch`
- `lake build`
- `lake env lean .tmp/handoff_cech_exactness_axioms.lean`
- `git diff --check`
- `git diff --cached --check`
- hidden/bidi Unicode scan
- local/private path scan

`lake build` の警告は既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning のみ。

## SCORE

- base_score: 84
- evidence_multiplier: 2.0
- penalty: 0
- final_score: +168
- total_score: 8658 / 10000
- genius: not applicable; G2 四審判はいずれも `genius_eligibility: no`
