### PR TITLE
研究: repair-transport Cech commutator curvature を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -63,3 +63,4 @@ import Formal.AG.Research.QualitySurface.SourceRefHandoffComponentSupport
 import Formal.AG.Research.QualitySurface.HandoffRepairTransversal
 import Formal.AG.Research.QualitySurface.HandoffCechExactness
 import Formal.AG.Research.QualitySurface.OverlapObstructionBasis
+import Formal.AG.Research.QualitySurface.RepairTransportCechCommutatorCurvature

--- a/Formal/AG/Research/QualitySurface/RepairTransportCechCommutatorCurvature.lean
+++ b/Formal/AG/Research/QualitySurface/RepairTransportCechCommutatorCurvature.lean
@@ -1,0 +1,372 @@
+import Formal.AG.Research.QualitySurface.OverlapObstructionBasis
+import Formal.AG.Research.QualitySurface.RepairTransportHandoffObstructionBridge
+
+/-!
+Cycle 67 evidence for `G-aat-quality-surface-01`.
+
+This file packages a selected repair/transport Cech commutator cell.  The
+selected cell has a flat Cech path and a curved Cech path with the same visible
+repair/transport endpoint surface and the same locally exact chart cover.  The
+flat path has empty overlap support, while the curved path uses the selected
+visible repair/transport handoff atlas as its overlap cocycle and carries an
+exact nonempty Cech overlap basis.
+
+The claim is relative to selected finite source-ref handoff covers, the visible
+repair/transport endpoint witness, the finite `BridgeComponent` vocabulary, and
+declared component-level repair predicates.  It does not assert canonical global
+curvature, runtime repair synthesis, source extraction completeness, ArchMap
+correctness, arbitrary route enumeration, global sheaf completeness, or
+whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace RepairTransportCechCommutatorCurvature
+
+open CodebaseTracePacket
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open RouteDefectSupportTheory
+open SourceRefHandoffBridge
+open SourceRefHandoffHolonomyCorrespondence
+open SourceRefHandoffObstructionLocus
+open SourceRefHandoffComponentSupport
+open HandoffRepairTransversalTheorem
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open RepairTransportHandoffObstructionBridge
+
+/-! ## Selected Cech paths for the repair/transport commutator -/
+
+/--
+A typed repair/transport Cech commutator cell.
+
+The visible endpoints and their visible surface are part of the same object as
+the flat and curved Cech paths.  The path fields are intentionally only covers:
+exactness, basis, and repair-transversal claims are proved below rather than
+stored as assumptions in the cell.
+-/
+structure RepairTransportCechCommutatorCell where
+  leftEndpoint : SourceRefPacket
+  rightEndpoint : SourceRefPacket
+  visibleSurface : supportSurfaceReading.Equivalent leftEndpoint rightEndpoint
+  flatPath : HandoffCechCover
+  curvedPath : HandoffCechCover
+
+/-- The flat Cech path uses the aligned source-ref handoff atlas as overlap. -/
+def repairTransportFlatCechCover : HandoffCechCover where
+  charts := [alignedSourceRefHandoffAtlas]
+  overlapCocycle := alignedSourceRefHandoffAtlas
+
+/--
+The curved Cech path keeps the same local chart but uses the selected visible
+repair/transport handoff atlas as overlap cocycle.
+-/
+def repairTransportCurvedCechCover : HandoffCechCover where
+  charts := [alignedSourceRefHandoffAtlas]
+  overlapCocycle := visibleRepairTransportHandoffBridge.toAtlas
+
+/-- The selected repair/transport Cech commutator cell. -/
+def selectedRepairTransportCechCommutatorCell :
+    RepairTransportCechCommutatorCell where
+  leftEndpoint := visibleRouteLeft
+  rightEndpoint := visibleRouteRight
+  visibleSurface :=
+    VisibleRepairTransportCommutator.repairTransport_visiblePacketSurface_commutes
+  flatPath := repairTransportFlatCechCover
+  curvedPath := repairTransportCurvedCechCover
+
+/--
+The visible/local projection seen by the selected Cech cell: same visible
+repair/transport endpoint surface, local exactness on both paths, and the same
+chart cover.
+-/
+def SameVisibleLocalRepairTransportProjection
+    (cell : RepairTransportCechCommutatorCell) : Prop :=
+  supportSurfaceReading.Equivalent cell.leftEndpoint cell.rightEndpoint /\
+    HandoffCechLocalExact cell.flatPath /\
+    HandoffCechLocalExact cell.curvedPath /\
+    cell.flatPath.charts = cell.curvedPath.charts
+
+/-- The flat Cech path has locally exact charts. -/
+theorem repairTransportFlatCechCover_localExact :
+    HandoffCechLocalExact repairTransportFlatCechCover := by
+  intro chart hmem
+  simp [repairTransportFlatCechCover] at hmem
+  subst chart
+  exact alignedSourceRefHandoffAtlas_interactionExact
+
+/-- The curved Cech path has the same locally exact chart cover. -/
+theorem repairTransportCurvedCechCover_localExact :
+    HandoffCechLocalExact repairTransportCurvedCechCover := by
+  intro chart hmem
+  simp [repairTransportCurvedCechCover] at hmem
+  subst chart
+  exact alignedSourceRefHandoffAtlas_interactionExact
+
+/-- The selected flat and curved paths share their visible/local projection. -/
+theorem repairTransport_paths_same_visibleLocal :
+    SameVisibleLocalRepairTransportProjection
+      selectedRepairTransportCechCommutatorCell := by
+  refine
+    ⟨selectedRepairTransportCechCommutatorCell.visibleSurface,
+      repairTransportFlatCechCover_localExact,
+      repairTransportCurvedCechCover_localExact,
+      ?_⟩
+  rfl
+
+/-! ## Flat path: empty generated overlap support -/
+
+/-- The flat path has empty protected overlap support. -/
+theorem flatPath_overlapSupportEmpty :
+    HandoffCechOverlapSupportEmpty
+      selectedRepairTransportCechCommutatorCell.flatPath := by
+  intro hnonempty
+  rcases hnonempty with ⟨component, hsupport⟩
+  have hempty :
+      HandoffComponentSupportEmpty alignedSourceRefHandoffAtlas :=
+    (handoffComponentSupport_empty_iff_locusEmpty
+      alignedSourceRefHandoffAtlas).mpr
+      alignedSourceRefHandoffAtlas_locusEmpty
+  exact hempty
+    ⟨component, by
+      simpa [selectedRepairTransportCechCommutatorCell,
+        repairTransportFlatCechCover, HandoffCechOverlapSupport]
+        using hsupport⟩
+
+/-- The empty predicate is an exact overlap basis for the flat path. -/
+theorem flatPath_overlapBasis_empty :
+    OverlapObstructionBasis
+      selectedRepairTransportCechCommutatorCell.flatPath
+      (fun _ : BridgeComponent => False) := by
+  constructor
+  · intro component hfalse
+    cases hfalse
+  · intro component hsupport
+    exact False.elim
+      (flatPath_overlapSupportEmpty ⟨component, hsupport⟩)
+
+/-! ## Curved path: exact nonempty overlap basis -/
+
+/--
+The selected repair/transport curvature basis consists of the trace and
+repair-frontier handoff components exposed by the visible-only commutator.
+-/
+def repairTransportCurvatureBasis
+    (component : BridgeComponent) : Prop :=
+  component = BridgeComponent.trace \/
+    component = BridgeComponent.repairFrontier
+
+/-- The trace component of the selected commutator is curved overlap support. -/
+theorem curvedPath_traceOverlapSupport :
+    HandoffCechOverlapSupport
+      selectedRepairTransportCechCommutatorCell.curvedPath
+      BridgeComponent.trace := by
+  let point :=
+    visibleRepairTransport_tableDefect_to_handoffTraceObstructionPoint
+  exact ⟨point.loop, point.loop_mem, point.support⟩
+
+/--
+The repair-frontier component of the selected commutator is curved overlap
+support.
+-/
+theorem curvedPath_repairFrontierOverlapSupport :
+    HandoffCechOverlapSupport
+      selectedRepairTransportCechCommutatorCell.curvedPath
+      BridgeComponent.repairFrontier := by
+  let point :=
+    visibleRepairTransport_repairFrontier_to_handoffObstructionPoint
+  exact ⟨point.loop, point.loop_mem, point.support⟩
+
+/--
+The curved path has an exact selected overlap basis: precisely the trace and
+repair-frontier components of the visible repair/transport handoff overlap.
+-/
+theorem curvedPath_overlapBasis :
+    OverlapObstructionBasis
+      selectedRepairTransportCechCommutatorCell.curvedPath
+      repairTransportCurvatureBasis := by
+  constructor
+  · intro component hbasis
+    rcases hbasis with htrace | hrepair
+    · subst component
+      exact curvedPath_traceOverlapSupport
+    · subst component
+      exact curvedPath_repairFrontierOverlapSupport
+  · intro component hsupport
+    rcases hsupport with ⟨loop, hmem, hfailure⟩
+    simp [selectedRepairTransportCechCommutatorCell,
+      repairTransportCurvedCechCover,
+      RepairTransportHandoffBridge.toAtlas] at hmem
+    subst loop
+    cases component with
+    | support =>
+        have hlaw :
+            visibleRepairTransportHandoff.ComponentLaw
+              BridgeComponent.support :=
+          visibleRepairTransportHandoff.supportCertified_iff.mp rfl
+        exact False.elim (hfailure hlaw)
+    | trace =>
+        exact Or.inl rfl
+    | repairFrontier =>
+        exact Or.inr rfl
+
+/-- The curved path has nonempty overlap support generated by its exact basis. -/
+theorem curvedPath_overlapBasis_nonempty :
+    OverlapObstructionBasis
+        selectedRepairTransportCechCommutatorCell.curvedPath
+        repairTransportCurvatureBasis /\
+      HandoffCechOverlapSupportNonempty
+        selectedRepairTransportCechCommutatorCell.curvedPath := by
+  exact
+    ⟨curvedPath_overlapBasis,
+      ⟨BridgeComponent.trace, curvedPath_traceOverlapSupport⟩⟩
+
+/--
+Under local chart exactness, the curved path's nonempty overlap basis obstructs
+global handoff exactness.
+-/
+theorem curvedPath_notGlobalExact_of_local
+    (hlocal :
+      HandoffCechLocalExact
+        selectedRepairTransportCechCommutatorCell.curvedPath) :
+    Not (HandoffCechGlobalExact
+      selectedRepairTransportCechCommutatorCell.curvedPath) :=
+  (handoffCech_overlapSupport_nonempty_iff_notGlobalExact_of_local
+    hlocal).mp
+    curvedPath_overlapBasis_nonempty.2
+
+/--
+Component-complete declared repair clears the curved path exactly when it hits
+the selected curvature basis.
+-/
+theorem curvedPath_declaredClearance_iff_hitsCurvatureBasis
+    {plan : HandoffRepairPlan}
+    (hcomplete :
+      ComponentCompleteHandoffRepairPlan
+        selectedRepairTransportCechCommutatorCell.curvedPath.overlapCocycle
+        plan) :
+    HandoffCechRepairObligation
+        selectedRepairTransportCechCommutatorCell.curvedPath plan <->
+      OverlapBasisTransversal repairTransportCurvatureBasis plan.touched :=
+  declaredClearance_iff_hitsEveryOverlapBasis_of_componentComplete
+    (cover := selectedRepairTransportCechCommutatorCell.curvedPath)
+    (basis := repairTransportCurvatureBasis)
+    (plan := plan)
+    curvedPath_overlapBasis
+    hcomplete
+
+/-! ## Cech curvature package -/
+
+/--
+A repair/transport Cech commutator cell carries Cech curvature when its visible
+local projection is shared, the flat path has empty overlap basis, and the
+curved path has exact nonempty overlap basis that obstructs global exactness.
+-/
+def CommutatorCechCurvature
+    (cell : RepairTransportCechCommutatorCell) : Prop :=
+  SameVisibleLocalRepairTransportProjection cell /\
+    OverlapObstructionBasis cell.flatPath (fun _ : BridgeComponent => False) /\
+    OverlapObstructionBasis cell.curvedPath repairTransportCurvatureBasis /\
+    HandoffCechOverlapSupportEmpty cell.flatPath /\
+    HandoffCechOverlapSupportNonempty cell.curvedPath /\
+    Not (HandoffCechGlobalExact cell.curvedPath) /\
+    (forall {plan : HandoffRepairPlan},
+      ComponentCompleteHandoffRepairPlan cell.curvedPath.overlapCocycle plan ->
+        (HandoffCechRepairObligation cell.curvedPath plan <->
+          OverlapBasisTransversal repairTransportCurvatureBasis plan.touched))
+
+/-- The selected repair/transport Cech commutator cell carries Cech curvature. -/
+theorem selectedRepairTransportCechCommutator_hasCurvature :
+    CommutatorCechCurvature
+      selectedRepairTransportCechCommutatorCell := by
+  exact
+    ⟨repairTransport_paths_same_visibleLocal,
+      flatPath_overlapBasis_empty,
+      curvedPath_overlapBasis,
+      flatPath_overlapSupportEmpty,
+      curvedPath_overlapBasis_nonempty.2,
+      curvedPath_notGlobalExact_of_local
+        repairTransportCurvedCechCover_localExact,
+      fun {plan} hcomplete =>
+        curvedPath_declaredClearance_iff_hitsCurvatureBasis
+          (plan := plan) hcomplete⟩
+
+/--
+The shared visible/local repair-transport projection is not faithful to the
+protected Cech overlap curvature: the selected cell has the same visible/local
+surface on both paths, while its flat and curved paths separate empty overlap
+support from nonempty exact overlap basis.
+-/
+theorem visibleRepairTransport_not_faithful_to_cechCurvature :
+    SameVisibleLocalRepairTransportProjection
+        selectedRepairTransportCechCommutatorCell /\
+      HandoffCechOverlapSupportEmpty
+        selectedRepairTransportCechCommutatorCell.flatPath /\
+      OverlapObstructionBasis
+        selectedRepairTransportCechCommutatorCell.flatPath
+        (fun _ : BridgeComponent => False) /\
+      OverlapObstructionBasis
+        selectedRepairTransportCechCommutatorCell.curvedPath
+        repairTransportCurvatureBasis /\
+      HandoffCechOverlapSupportNonempty
+        selectedRepairTransportCechCommutatorCell.curvedPath /\
+      Not (HandoffCechGlobalExact
+        selectedRepairTransportCechCommutatorCell.curvedPath) := by
+  exact
+    ⟨repairTransport_paths_same_visibleLocal,
+      flatPath_overlapSupportEmpty,
+      flatPath_overlapBasis_empty,
+      curvedPath_overlapBasis,
+      curvedPath_overlapBasis_nonempty.2,
+      curvedPath_notGlobalExact_of_local
+        repairTransportCurvedCechCover_localExact⟩
+
+/--
+Cycle-67 theorem package: a selected repair/transport Cech commutator cell has
+the same visible/local projection on flat and curved paths, empty flat overlap
+support, exact nonempty curved overlap basis, local-to-global exactness failure
+on the curved path, and declared-repair clearance exactly when the repair plan
+hits the curvature basis.
+-/
+theorem repairTransportCechCommutatorCurvature_package :
+    SameVisibleLocalRepairTransportProjection
+        selectedRepairTransportCechCommutatorCell /\
+      OverlapObstructionBasis
+        selectedRepairTransportCechCommutatorCell.flatPath
+        (fun _ : BridgeComponent => False) /\
+      OverlapObstructionBasis
+        selectedRepairTransportCechCommutatorCell.curvedPath
+        repairTransportCurvatureBasis /\
+      HandoffCechOverlapSupportEmpty
+        selectedRepairTransportCechCommutatorCell.flatPath /\
+      HandoffCechOverlapSupportNonempty
+        selectedRepairTransportCechCommutatorCell.curvedPath /\
+      Not (HandoffCechGlobalExact
+        selectedRepairTransportCechCommutatorCell.curvedPath) /\
+      (forall {plan : HandoffRepairPlan},
+        ComponentCompleteHandoffRepairPlan
+            selectedRepairTransportCechCommutatorCell.curvedPath.overlapCocycle
+            plan ->
+          (HandoffCechRepairObligation
+              selectedRepairTransportCechCommutatorCell.curvedPath plan <->
+            OverlapBasisTransversal
+              repairTransportCurvatureBasis plan.touched)) /\
+      CommutatorCechCurvature
+        selectedRepairTransportCechCommutatorCell := by
+  exact
+    ⟨repairTransport_paths_same_visibleLocal,
+      flatPath_overlapBasis_empty,
+      curvedPath_overlapBasis,
+      flatPath_overlapSupportEmpty,
+      curvedPath_overlapBasis_nonempty.2,
+      curvedPath_notGlobalExact_of_local
+        repairTransportCurvedCechCover_localExact,
+      fun {plan} hcomplete =>
+        curvedPath_declaredClearance_iff_hitsCurvatureBasis
+          (plan := plan) hcomplete,
+      selectedRepairTransportCechCommutator_hasCurvature⟩
+
+end RepairTransportCechCommutatorCurvature
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-repair-transport-cech-commutator-curvature.md
+++ b/research/ideas/g-aat-quality-surface-01-repair-transport-cech-commutator-curvature.md
@@ -1,0 +1,214 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: bridge
+capability_category: profile-curvature / certificate-transport / obstruction / repair-potential / quality-surface / traceability
+expected_base_score: 88
+expected_evidence_multiplier: 2.0
+expected_final_score: 176
+evidence_stage: proved-in-research
+rival_advantage: ADL and conformance tools can report route/order or refinement mismatches, but they do not usually package a visible-flat repair/transport commutator as protected Cech overlap support with an exact obstruction basis and repair obligation.
+origin: research-loop-cycle-67
+tags: [quality-surface, handoff, cech, overlap, commutator-curvature, profile-curvature]
+created: 2026-06-21
+cycle: 67
+lean: proved-in-research
+---
+
+# Repair-transport Cech commutator curvature of overlap support
+
+## 主張
+
+A selected finite repair-transport Cech commutator cell can be read as Cech
+overlap curvature.  The cell has two typed paths: a flat path and a curved
+path.  They share the same visible/local commutator projection, but the flat
+path has empty generated overlap support while the curved path has an exact
+nonempty overlap basis.  The curved path therefore fails global handoff
+exactness under local exactness, and component-complete declared repair clears
+it exactly when it hits the curvature basis.  The claim is relative to selected
+finite source-ref handoff covers, existing finite repair/transport commutator
+witnesses, finite `BridgeComponent` vocabulary, and declared component-level
+repair predicates.
+
+It does not assert canonical global curvature, runtime repair synthesis,
+source extraction completeness, ArchMap correctness, arbitrary route
+enumeration, global sheaf completeness, or whole-codebase quality.
+
+## 候補種別
+
+`bridge`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/HandoffCechExactness.lean`
+- `Formal/AG/Research/QualitySurface/OverlapObstructionBasis.lean`
+- `Formal/AG/Research/QualitySurface/LawfulRepairTransportCommutator.lean`
+- `Formal/AG/Research/QualitySurface/FrontierLocalRepairTransportCommutator.lean`
+- `Formal/AG/Research/QualitySurface/LossAwareCommutatorAtlas.lean`
+- Cycle 62 repair/transport handoff obstruction bridge
+- Cycle 65 Cech overlap exactness
+- Cycle 66 overlap obstruction basis / repair-transversal duality
+
+## 非自明性
+
+Cycle 62 relates repair/transport endpoint order to handoff obstruction.
+Cycle 65-66 package Cech overlap support and selected overlap bases.  This
+candidate asks for the common geometry: one typed finite commutator cell whose
+two Cech paths share visible/local projection but differ in protected overlap
+support.  It is not just another component deletion witness; the theorem must
+connect commutator curvature, local-to-global exactness failure, exact overlap
+basis, and lossful visible projection in one package.
+
+## 数学的興味
+
+The result reads profile curvature as local-to-global overlap obstruction.
+Curvature is not a scalar bend or endpoint mismatch; it is a protected
+component-support class carried by the overlap cocycle of a selected finite
+commutator cell.
+
+## GOAL への前進
+
+It advances the `profile-curvature`, `certificate-transport`, `obstruction`,
+and `repair-potential` frontiers at once.  Quality Surface gains a theorem
+showing how repair/transport order can be visible-flat while still carrying a
+hidden overlap basis and declared repair obligation.
+
+## ライバルに対する有効性
+
+ADL / conformance checkers can display route/order mismatches or refined
+conformance differences.  This theorem package records the protected basis
+that a visible-flat commutator hides, and ties it to Cech global exactness and
+component-complete declared repair hitting.  That gives AAT a certificate
+geometry not reducible to a mismatch list or scalar dashboard.
+
+## SCORE 見込み
+
+- `score_reason`: High bridge value.  The candidate connects prior
+  repair/transport commutator evidence with the latest Cech overlap basis
+  calculus, creating a profile-curvature reading of protected overlap support.
+- `dullness_risk`: Medium.  It would be weak if it merely renamed an existing
+  visible commutator witness.  G3 must include a named curvature predicate,
+  visible/local projection equality from the same typed cell, protected overlap
+  basis discrepancy, and global exactness failure under local exactness.
+- `proof_or_evidence_plan`: Define a finite repair-transport Cech commutator
+  cell with a flat Cech path and a curved Cech path as fields of the same
+  object.  Prove that their visible/local projections agree, while the curved
+  path has exact nonempty overlap basis and the flat path has empty generated
+  support.  Use Cycle 65 exactness and Cycle 66 basis duality to turn nonempty
+  overlap basis into global exactness failure and repair obligation.
+- `G2_actual_score_band`: A requested revise with base 80; B accepted base 88;
+  C accepted base 90; D accepted base 90.  Revise requirement: choose one
+  commutator regime, type the cell, construct flat and curved Cech covers from
+  that same cell, and prove support-level basis discrepancy instead of
+  juxtaposing unrelated Cycle 62 and Cycle 65-66 facts.
+- `G2_after_revise`: A accepted base 84, genius no; B accepted base 88,
+  genius no; C accepted base 90, genius no; D accepted base 90, genius no.
+- `G3_evidence`: Lean proof in
+  `Formal/AG/Research/QualitySurface/RepairTransportCechCommutatorCurvature.lean`.
+  `lake env lean Formal/AG/Research/QualitySurface/RepairTransportCechCommutatorCurvature.lean`
+  and `lake build FormalAGResearch` passed.  Full `lake build` also passed;
+  the only warnings were pre-existing linter warnings in
+  `Formal/Arch/Extension/FeatureExtensionExamples.lean`.
+- `G3_synced_score_expectation`: expected base lowered to 88 before G4.  The
+  post-revise G2 band is A 84 / B 88 / C 90 / D 90, and 88 reflects the
+  conservative midpoint while preserving the x2.0 Lean evidence multiplier for
+  SCORE audit.
+
+## CS / SWE への帰結
+
+A viewer or report can distinguish "the same visible commutator surface" from
+"the same protected repair obligation."  A visible-flat repair/transport
+square may still carry a hidden overlap basis that determines which declared
+repair support must be touched.
+
+## 証明・根拠の見込み
+
+Lean declarations fixed in G3:
+
+- `RepairTransportCechCommutatorCell`
+- `CommutatorCechCurvature`
+- `repairTransport_paths_same_visibleLocal`
+- `flatPath_overlapBasis_empty`
+- `curvedPath_overlapBasis_nonempty`
+- `curvedPath_notGlobalExact_of_local`
+- `curvedPath_declaredClearance_iff_hitsCurvatureBasis`
+- `visibleRepairTransport_not_faithful_to_cechCurvature`
+- `repairTransportCechCommutatorCurvature_package`
+
+Evidence summary: the selected cell has `flatPath` and `curvedPath` fields.
+The flat path has empty overlap support and an exact empty basis.  The curved
+path has an exact nonempty basis
+`repairTransportCurvatureBasis = {trace, repairFrontier}`, fails global handoff
+exactness under local exactness, and component-complete declared repair clears
+it iff the repair support hits that basis.  `CommutatorCechCurvature` itself
+includes the repair-clearing iff, so the final package is stated through
+`selectedRepairTransportCechCommutatorCell.flatPath` and `.curvedPath`.
+
+G3 axiom summary: `RepairTransportCechCommutatorCell` and
+`CommutatorCechCurvature` are axiom-free.  `curvedPath_overlapBasis`,
+`curvedPath_overlapBasis_nonempty`, `curvedPath_notGlobalExact_of_local`, and
+`curvedPath_declaredClearance_iff_hitsCurvatureBasis` use standard `propext`.
+`repairTransport_paths_same_visibleLocal`, `flatPath_overlapBasis_empty`,
+`selectedRepairTransportCechCommutator_hasCurvature`,
+`visibleRepairTransport_not_faithful_to_cechCurvature`, and
+`repairTransportCechCommutatorCurvature_package` use standard `propext` plus
+existing `Quot.sound`.  No `sorryAx`, custom `axiom`, `admit`, or `unsafe`
+appears.  Independent G3 axiom check passed, and independent Lean
+formalization-quality audit passed after the package was revised to use selected
+cell fields.
+
+## 追加メタデータ
+
+```text
+planned_theorem_names:
+  RepairTransportCechCommutatorCell
+  CommutatorCechCurvature
+  repairTransport_paths_same_visibleLocal
+  flatPath_overlapBasis_empty
+  curvedPath_overlapBasis_nonempty
+  curvedPath_notGlobalExact_of_local
+  curvedPath_declaredClearance_iff_hitsCurvatureBasis
+  visibleRepairTransport_not_faithful_to_cechCurvature
+  repairTransportCechCommutatorCurvature_package
+visible_projection:
+  local chart exactness plus visible repair/transport commutator surface
+protected_structure:
+  Cech overlap cocycle support, selected overlap obstruction basis, source-ref handoff component identity, declared repair support
+exactness_or_minimality_claim:
+  the same typed repair-transport Cech commutator cell supplies both paths; flat path has empty generated overlap support; curved path has exact nonempty basis and fails global exactness under local exactness; component-complete declared repair clearance is equivalent to hitting the curvature basis; the final package is stated through the selected cell fields
+nonfaithfulness_or_failure_mode:
+  visible/local commutator equality is not faithful to protected Cech overlap curvature or repair obligation
+previous_cycle_delta:
+  Cycle 65-66 gave overlap exactness and basis duality for selected covers; this cycle connects them to repair/transport Cech commutator curvature.
+genius_potential:
+  no
+genius_target:
+  none
+genius_support_role:
+  none
+```
+
+## 審判メモ
+
+- 厳密性:
+  - initial revise required: choose repair-transport Cech commutator vocabulary, type the cell, and make flat/curved covers fields of the same object; avoid juxtaposing unrelated witnesses or claiming distinct exact bases on one cover.
+  - after revise: accept, base 84, genius no.  G3 must instantiate a non-vacuous concrete cell rather than store desired conclusions as assumptions.
+- 研究価値:
+  - accept, base 88, genius no. High compression from commutator flatness, Cech local-to-global failure, exact overlap basis, and repair-transversal semantics.
+- repo 全体価値:
+  - accept, base 90, genius no. Strong AAT/Lean/Research and future projection-rule value.
+- ライバル比較:
+  - accept, base 90, genius no. Moves rival comparison from visible conformance to protected support/basis/repair-transversal faithfulness.
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-overlap-obstruction-basis-repair-duality.md`
+- `research/ideas/g-aat-quality-surface-01-finite-cech-handoff-obstruction-exactness.md`
+- `research/ideas/g-aat-quality-surface-01-repair-transport-handoff-obstruction-bridge.md`
+- `research/reports/G-aat-quality-surface-01.md`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 67 G1 候補 pool から作成。
+- 2026-06-21: G2 A の revise を受け、`law-refinement / repair-transport` の曖昧さを `repair-transport Cech commutator cell` に絞り、flat / curved paths が同じ typed cell から出る要件を明記。
+- 2026-06-21: G2 四審判が accept。G3 で Lean proof を追加し、形式化品質監査の revise を受けて final package を selected cell fields 経由へ修正。G3 axiom check と formalization-quality audit が pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 8830
+- total SCORE: 9006
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -71,8 +71,9 @@
   - repair-potential / obstruction / traceability / computability / invariance / certificate-transport: 164
   - obstruction / certificate-transport / traceability / quality-surface / computability / invariance / repair-potential: 168
   - obstruction / computability / repair-potential / traceability / minimality / quality-surface / certificate-transport: 172
+  - profile-curvature / certificate-transport / obstruction / repair-potential / quality-surface / traceability: 176
 - evidence portfolio:
-  - proved-in-research: 66
+  - proved-in-research: 67
 
 ## Phase synthesis
 
@@ -88,7 +89,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-66 件の Lean-proved research artifacts は、次の paper seed を形成している。
+67 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -135,14 +136,15 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 66 後の total SCORE は 8830 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 67 後の total SCORE は 9006 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 66 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 67 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
 component support bitset / law minimality matrix、declared repair transversal theorem、
-finite overlap obstruction basis / repair-transversal duality theorem を含む。
+finite overlap obstruction basis / repair-transversal duality theorem、
+repair/transport Cech commutator curvature theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -3005,7 +3007,7 @@ goal_delta: Cycle 60-64 の handoff atlas / obstruction locus / component suppor
 project_value_delta: Quality Surface を local chart dashboard ではなく、hidden overlap support と declared repair obligation を持つ certificate geometry として読ませる paper-seed theorem package を追加した。
 rival_delta: ADL / conformance surface の view-local green status や mismatch list に対し、AAT は overlap failure を atom-supported obstruction support、source-ref handoff trace、component-complete repair transversal として保存する。
 formalization_quality: pass。`lake env lean`、`lake env lean Formal/AG/Research.lean`、`lake build FormalAGResearch`、full `lake build` は pass。full build の警告は既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter 警告のみである。core cover / support / repair definitions と repair equivalence は `Quot.sound`-free。exactness iff results は標準 `propext`、nonempty local-green witness / package は既存 `alignedSourceRefHandoffAtlas_interactionExact` 由来の標準 `propext` / `Quot.sound` に依存する。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はない。G4 はこの標準公理依存を開示したうえで `x2.0` を confirm した。
-open_questions: refinement-invariant Cech overlap support、finite overlap obstruction basis/minimality、law-refinement commutator curvature、repair basin exchange obstruction。
+open_questions: refinement-invariant Cech overlap support、finite overlap obstruction basis/minimality、repair basin exchange obstruction。
 ```
 
 ### Result
@@ -3086,13 +3088,63 @@ support singleton basis と trace singleton basis は同じ visible one-componen
 protected basis としては異なり、それぞれ別の selected deletion cover の irredundant repair obligation を担う。
 G2 四審判はいずれも `genius_eligibility: no` を返し、G4 は通常 SCORE として base 86 を confirm した。
 
+## Cycle 67: Repair-transport Cech commutator curvature of overlap support
+
+```text
+candidate: Repair-transport Cech commutator curvature of overlap support
+candidate_type: bridge
+evidence_stage: proved-in-research
+base_score: 88
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 176
+category: profile-curvature / certificate-transport / obstruction / repair-potential / quality-surface / traceability
+goal_delta: The Quality Surface gains a selected finite Cech commutator cell whose repair/transport paths share visible/local projection while separating empty flat overlap support from exact nonempty curved overlap basis. This makes profile curvature a protected Cech overlap obstruction with a declared repair obligation.
+project_value_delta: Adds a Lean-proved bridge from the repair/transport handoff obstruction frontier to the Cech overlap basis calculus. The result is paper/report material and a future projection-rule seed for visible-flat but protected-curved repair obligations.
+rival_delta: ADL and conformance tools can display route/order or refinement mismatches, but this theorem records the protected overlap basis hidden by a visible-flat commutator and proves repair clearance iff hitting that basis under component completeness.
+formalization_quality: pass。The selected cell stores endpoints, visible surface, `flatPath`, and `curvedPath` only; exactness, support, basis, global failure, repair iff, and nonfaithfulness are proved through selected cell fields. `lake env lean Formal/AG/Research/QualitySurface/RepairTransportCechCommutatorCurvature.lean`, `lake build FormalAGResearch`, and full `lake build` passed. Full build warnings were the pre-existing linter warnings in `Formal/Arch/Extension/FeatureExtensionExamples.lean`. No `sorryAx`; declarations use only standard `propext` and, for projection/package facts, existing `Quot.sound`.
+open_questions: refinement-invariant Cech overlap support transport、non-singleton curvature basis exchange、repair-basin exchange obstruction under atlas refinement、broader repair/transport curvature families beyond the selected witness。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/RepairTransportCechCommutatorCurvature.lean`
+は、selected finite repair/transport Cech commutator cell を定義する。
+cell は visible endpoint pair、visible surface、`flatPath`、`curvedPath` を持つが、
+exactness、basis、global failure、repair iff は field として仮定せず、後続 theorem で証明する。
+
+Lean 証拠は次を固定する。
+
+- `RepairTransportCechCommutatorCell`: visible repair/transport endpoint surface と flat / curved Cech paths を同じ typed object に置く。
+- `repairTransport_paths_same_visibleLocal`: selected cell の flat path と curved path は visible/local projection を共有する。
+- `flatPath_overlapBasis_empty`: selected cell の flat path は empty overlap support を持ち、empty predicate が exact overlap basis である。
+- `repairTransportCurvatureBasis`: curved path の selected curvature basis は `trace` と `repairFrontier` component である。
+- `curvedPath_overlapBasis_nonempty`: curved path は exact nonempty overlap basis を持つ。
+- `curvedPath_notGlobalExact_of_local`: local chart exactness の下で、curved path の nonempty overlap basis は global handoff exactness failure を与える。
+- `curvedPath_declaredClearance_iff_hitsCurvatureBasis`: component-complete declared repair は curvature basis を hit するとき、かつそのときに限り curved overlap を clear する。
+- `CommutatorCechCurvature`: same visible/local projection、empty flat basis、exact nonempty curved basis、global failure、repair iff を cell-level predicate として束ねる。
+- `visibleRepairTransport_not_faithful_to_cechCurvature`: visible/local repair-transport projection は protected Cech overlap curvature と repair obligation に faithful ではない。
+- `repairTransportCechCommutatorCurvature_package`: selected cell 経由の theorem package。
+
+この結果により、Quality Surface の profile curvature は endpoint mismatch や scalar bend ではなく、
+selected finite commutator cell の overlap cocycle が運ぶ protected component-support class として読める。
+ADL / conformance surface は visible route/order mismatch や refined conformance difference を表示できるが、
+この theorem package は、visible-flat な repair/transport commutator の背後に exact nonempty Cech overlap basis が残り、
+declared repair clearance がその basis への hitting condition と同値になることを Lean theorem として保持する。
+ただし主張は selected finite source-ref handoff covers、visible repair/transport endpoint witness、
+finite `BridgeComponent` vocabulary、declared component-level repair predicate に相対化される。
+canonical global curvature、runtime repair synthesis、source extraction completeness、ArchMap correctness、
+arbitrary route enumeration、global sheaf completeness、実コード全体の品質判定は結論しない。
+G2 四審判はいずれも `genius_eligibility: no` を返し、G4 は通常 SCORE として base 88 を confirm した。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 10000 であり、cycle 66 後の total SCORE は 8830 である。
-threshold 10000 までは残り 1170 SCORE である。
+次フェーズの tracking Issue active threshold は 10000 であり、cycle 67 後の total SCORE は 9006 である。
+threshold 10000 までは残り 994 SCORE である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
-finite grid phenomena、related-work separation、handoff local-to-global overlap obstruction を備えた。
+finite grid phenomena、related-work separation、handoff local-to-global overlap obstruction、
+repair/transport Cech commutator curvature を備えた。
 threshold 10000 には未達であるため、次 cycle では non-singleton overlap basis calculus、
-refinement-invariant Cech overlap support、law-refinement commutator curvature、
+refinement-invariant Cech overlap support、curvature basis exchange、
 repair basin exchange obstruction、または component support hitting under atlas refinement を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 67 として、selected repair/transport Cech commutator cell を Lean Research 側に追加した。flat path と curved path を同じ typed cell の field として持たせ、visible/local projection は同じだが、flat path は empty overlap basis、curved path は exact nonempty curvature basis を持つことを証明した。

G4 SCORE 監査は通常 SCORE として base 88、multiplier 2.0、penalty 0、final +176 を confirm した。report の total SCORE は 8830 から 9006、proved-in-research artifact は 66 から 67 に更新した。

## 証明した定理

- `RepairTransportCechCommutatorCell`
- `CommutatorCechCurvature`
- `repairTransport_paths_same_visibleLocal`
- `flatPath_overlapBasis_empty`
- `curvedPath_overlapBasis`
- `curvedPath_overlapBasis_nonempty`
- `curvedPath_notGlobalExact_of_local`
- `curvedPath_declaredClearance_iff_hitsCurvatureBasis`
- `selectedRepairTransportCechCommutator_hasCurvature`
- `visibleRepairTransport_not_faithful_to_cechCurvature`
- `repairTransportCechCommutatorCurvature_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-repair-transport-cech-commutator-curvature.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/RepairTransportCechCommutatorCurvature.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter 警告のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` for reported declarations

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
  - tracking Issue は研究状態の正本として閉じないため、`Refs #2348` とした。
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
