### PR TITLE
研究: antichain Cech overlap branch calculus を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -65,3 +65,4 @@ import Formal.AG.Research.QualitySurface.HandoffCechExactness
 import Formal.AG.Research.QualitySurface.OverlapObstructionBasis
 import Formal.AG.Research.QualitySurface.RepairTransportCechCommutatorCurvature
 import Formal.AG.Research.QualitySurface.RepairBasinExchangeObstruction
+import Formal.AG.Research.QualitySurface.AntichainOverlapBasisTransversal

--- a/Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean
+++ b/Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean
@@ -1,0 +1,529 @@
+import Formal.AG.Research.QualitySurface.RepairBasinExchangeObstruction
+
+/-!
+Cycle 69 evidence for `G-aat-quality-surface-01`.
+
+This file adds a branch-incidence layer over an exact selected Cech overlap
+component basis.  Branch clearance is intentionally separate from the existing
+component-level `HandoffCechRepairObligation`: it is a declared branch predicate
+whose residual form records missed selected branches.  The construction is
+relative to selected finite Cech covers, selected overlap component bases, the
+finite `BridgeComponent` vocabulary, and declared repair predicates.  It does
+not assert runtime repair synthesis, canonical global minimality, source
+extraction completeness, ArchMap correctness, arbitrary route enumeration,
+global sheaf completeness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace AntichainOverlapBasisTransversal
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffRepairTransversalTheorem
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open RepairTransportCechCommutatorCurvature
+open RepairBasinExchangeObstruction
+
+/-! ## Branch incidence over exact Cech overlap bases -/
+
+/-- A protected branch is a predicate on finite bridge components. -/
+abbrev BranchSupport := BridgeComponent -> Prop
+
+/-- A branch family is a selected predicate on protected branches. -/
+abbrev BranchFamily := BranchSupport -> Prop
+
+/-- A branch has at least one protected component. -/
+def BranchNonempty
+    (branch : BranchSupport) : Prop :=
+  exists component, branch component
+
+/-- One branch is included in a selected component basis. -/
+def BranchSubsupport
+    (componentBasis : BridgeComponent -> Prop)
+    (branch : BranchSupport) : Prop :=
+  forall component, branch component -> componentBasis component
+
+/--
+A selected branch family is an antichain when a selected branch included in
+another selected branch must have the same component membership.
+-/
+def BranchFamilyAntichain
+    (family : BranchFamily) : Prop :=
+  forall left right,
+    family left ->
+      family right ->
+        (forall component, left component -> right component) ->
+          forall component, right component -> left component
+
+/-- The visible component-union projection of a branch family. -/
+def BranchFamilyUnion
+    (family : BranchFamily)
+    (component : BridgeComponent) : Prop :=
+  exists branch, family branch /\ branch component
+
+/-- Every selected branch lives inside the selected component basis. -/
+def BranchFamilySound
+    (componentBasis : BridgeComponent -> Prop)
+    (family : BranchFamily) : Prop :=
+  forall branch, family branch -> BranchSubsupport componentBasis branch
+
+/-- The selected branches generate the selected component basis by union. -/
+def BranchFamilyUnionGenerates
+    (componentBasis : BridgeComponent -> Prop)
+    (family : BranchFamily) : Prop :=
+  forall component,
+    componentBasis component -> BranchFamilyUnion family component
+
+/--
+An antichain Cech overlap basis is a branch layer grounded by an exact selected
+component overlap basis.
+-/
+def AntichainCechOverlapBasis
+    (cover : HandoffCechCover)
+    (componentBasis : BridgeComponent -> Prop)
+    (family : BranchFamily) : Prop :=
+  OverlapObstructionBasis cover componentBasis /\
+    BranchFamilyAntichain family /\
+    (forall branch, family branch -> BranchNonempty branch) /\
+    BranchFamilySound componentBasis family /\
+    BranchFamilyUnionGenerates componentBasis family
+
+/-- Drop one selected branch from a branch family. -/
+def branchFamilyDrops
+    (family : BranchFamily)
+    (dropped : BranchSupport) : BranchFamily :=
+  fun branch => family branch /\ branch ≠ dropped
+
+/-! ## Declared branch repair semantics -/
+
+/-- A selected branch is missed by a declared repair support. -/
+def BranchMissedBySupport
+    (branch : BranchSupport)
+    (support : HandoffRepairSupport) : Prop :=
+  forall component, branch component -> Not (support component)
+
+/-- Declared residual branch support after a repair plan. -/
+def DeclaredResidualBranchSupport
+    (family : BranchFamily)
+    (plan : HandoffRepairPlan)
+    (branch : BranchSupport) : Prop :=
+  family branch /\
+    forall component, branch component -> Not (plan.clears component)
+
+/--
+Branch-level clearance of every selected branch.
+
+This is not the component-level `HandoffCechRepairObligation`; it asks for a
+declared clear component inside each selected protected branch.
+-/
+def DeclaredBranchRepairClears
+    (family : BranchFamily)
+    (plan : HandoffRepairPlan) : Prop :=
+  forall branch,
+    family branch -> exists component, branch component /\ plan.clears component
+
+/-- A repair support is a transversal for selected branches. -/
+def BranchRepairTransversal
+    (family : BranchFamily)
+    (support : HandoffRepairSupport) : Prop :=
+  forall branch,
+    family branch -> exists component, branch component /\ support component
+
+/--
+A plan is branch-complete when every touched component inside a selected branch
+is declared clear.
+-/
+def BranchCompleteRepairPlan
+    (family : BranchFamily)
+    (plan : HandoffRepairPlan) : Prop :=
+  forall branch component,
+    family branch ->
+      branch component ->
+        plan.touched component -> plan.clears component
+
+/-- A selected missed branch remains as declared residual branch support. -/
+theorem missedBranch_survives_as_residual
+    {family : BranchFamily}
+    {plan : HandoffRepairPlan}
+    {branch : BranchSupport}
+    (hfamily : family branch)
+    (hmissed : BranchMissedBySupport branch plan.touched) :
+    DeclaredResidualBranchSupport family plan branch := by
+  constructor
+  · exact hfamily
+  · intro component hcomponent hclear
+    exact hmissed component hcomponent
+      (plan.clears_only_if_touched component hclear)
+
+/--
+In a selected antichain Cech branch basis and branch-complete repair regime,
+branch clearance is exactly branch transversality.
+-/
+theorem declaredBranchClearance_iff_hits_antichainOverlapBasis
+    {cover : HandoffCechCover}
+    {componentBasis : BridgeComponent -> Prop}
+    {family : BranchFamily}
+    {plan : HandoffRepairPlan}
+    (_hbasis : AntichainCechOverlapBasis cover componentBasis family)
+    (hcomplete : BranchCompleteRepairPlan family plan) :
+    DeclaredBranchRepairClears family plan <->
+      BranchRepairTransversal family plan.touched := by
+  constructor
+  · intro hclear branch hfamily
+    rcases hclear branch hfamily with ⟨component, hcomponent, hclears⟩
+    exact
+      ⟨component, hcomponent,
+        plan.clears_only_if_touched component hclears⟩
+  · intro hhit branch hfamily
+    rcases hhit branch hfamily with ⟨component, hcomponent, htouched⟩
+    exact
+      ⟨component, hcomponent,
+        hcomplete branch component hfamily hcomponent htouched⟩
+
+/-! ## Selected trace / repair-frontier branch bases -/
+
+/-- Singleton branch at the trace component. -/
+def traceBranch : BranchSupport :=
+  singletonRepairSupport BridgeComponent.trace
+
+/-- Singleton branch at the repair-frontier component. -/
+def repairFrontierBranch : BranchSupport :=
+  singletonRepairSupport BridgeComponent.repairFrontier
+
+/-- A paired branch containing trace and repair-frontier together. -/
+def traceRepairPairBranch
+    (component : BridgeComponent) : Prop :=
+  component = BridgeComponent.trace \/
+    component = BridgeComponent.repairFrontier
+
+/-- The selected two-singleton branch family. -/
+def twoSingletonBranchFamily
+    (branch : BranchSupport) : Prop :=
+  branch = traceBranch \/ branch = repairFrontierBranch
+
+/-- The selected one-pair branch family. -/
+def singlePairBranchFamily
+    (branch : BranchSupport) : Prop :=
+  branch = traceRepairPairBranch
+
+theorem twoSingletonBranchFamily_antichain :
+    BranchFamilyAntichain twoSingletonBranchFamily := by
+  intro left right hleft hright hsubset component hrightComponent
+  rcases hleft with hleft | hleft <;>
+    rcases hright with hright | hright <;>
+      subst left <;> subst right
+  · exact hrightComponent
+  · have hbad :
+        repairFrontierBranch BridgeComponent.trace :=
+      hsubset BridgeComponent.trace rfl
+    cases hbad
+  · have hbad :
+        traceBranch BridgeComponent.repairFrontier :=
+      hsubset BridgeComponent.repairFrontier rfl
+    cases hbad
+  · exact hrightComponent
+
+theorem singlePairBranchFamily_antichain :
+    BranchFamilyAntichain singlePairBranchFamily := by
+  intro left right hleft hright _hsubset component hrightComponent
+  subst left
+  subst right
+  exact hrightComponent
+
+theorem twoSingletonBranchFamily_nonempty
+    (branch : BranchSupport)
+    (hbranch : twoSingletonBranchFamily branch) :
+    BranchNonempty branch := by
+  rcases hbranch with hbranch | hbranch
+  · subst branch
+    exact ⟨BridgeComponent.trace, rfl⟩
+  · subst branch
+    exact ⟨BridgeComponent.repairFrontier, rfl⟩
+
+theorem singlePairBranchFamily_nonempty
+    (branch : BranchSupport)
+    (hbranch : singlePairBranchFamily branch) :
+    BranchNonempty branch := by
+  subst branch
+  exact ⟨BridgeComponent.trace, Or.inl rfl⟩
+
+theorem twoSingletonBranchFamily_sound :
+    BranchFamilySound repairTransportCurvatureBasis
+      twoSingletonBranchFamily := by
+  intro branch hbranch component hcomponent
+  rcases hbranch with hbranch | hbranch
+  · subst branch
+    exact Or.inl hcomponent
+  · subst branch
+    exact Or.inr hcomponent
+
+theorem singlePairBranchFamily_sound :
+    BranchFamilySound repairTransportCurvatureBasis
+      singlePairBranchFamily := by
+  intro branch hbranch component hcomponent
+  subst branch
+  exact hcomponent
+
+theorem twoSingletonBranchFamily_generates :
+    BranchFamilyUnionGenerates repairTransportCurvatureBasis
+      twoSingletonBranchFamily := by
+  intro component hbasis
+  rcases hbasis with htrace | hrepair
+  · subst component
+    exact
+      ⟨traceBranch, Or.inl rfl, rfl⟩
+  · subst component
+    exact
+      ⟨repairFrontierBranch, Or.inr rfl, rfl⟩
+
+theorem singlePairBranchFamily_generates :
+    BranchFamilyUnionGenerates repairTransportCurvatureBasis
+      singlePairBranchFamily := by
+  intro component hbasis
+  exact
+    ⟨traceRepairPairBranch, rfl, hbasis⟩
+
+/-- The selected curved Cech overlap basis supports two singleton branches. -/
+theorem twoSingleton_antichainCechOverlapBasis :
+    AntichainCechOverlapBasis
+      selectedRepairTransportCechCommutatorCell.curvedPath
+      repairTransportCurvatureBasis
+      twoSingletonBranchFamily := by
+  exact
+    ⟨curvedPath_overlapBasis,
+      twoSingletonBranchFamily_antichain,
+      twoSingletonBranchFamily_nonempty,
+      twoSingletonBranchFamily_sound,
+      twoSingletonBranchFamily_generates⟩
+
+/-- The same selected curved Cech overlap basis supports one paired branch. -/
+theorem singlePair_antichainCechOverlapBasis :
+    AntichainCechOverlapBasis
+      selectedRepairTransportCechCommutatorCell.curvedPath
+      repairTransportCurvatureBasis
+      singlePairBranchFamily := by
+  exact
+    ⟨curvedPath_overlapBasis,
+      singlePairBranchFamily_antichain,
+      singlePairBranchFamily_nonempty,
+      singlePairBranchFamily_sound,
+      singlePairBranchFamily_generates⟩
+
+/-! ## Branch deletion and visible-union nonfaithfulness -/
+
+/-- Deleting the selected trace branch breaks union generation. -/
+theorem dropTraceBranch_breaks_antichainGeneration :
+    Not
+      (BranchFamilyUnionGenerates repairTransportCurvatureBasis
+        (branchFamilyDrops twoSingletonBranchFamily traceBranch)) := by
+  intro hgenerates
+  rcases hgenerates BridgeComponent.trace (Or.inl rfl) with
+    ⟨branch, hdrop, hcomponent⟩
+  rcases hdrop.1 with hbranch | hbranch
+  · exact hdrop.2 hbranch
+  · subst branch
+    cases hcomponent
+
+/-- The two branch families have the same visible component-union projection. -/
+theorem twoSingleton_singlePair_same_visibleUnion
+    (component : BridgeComponent) :
+    BranchFamilyUnion twoSingletonBranchFamily component <->
+      BranchFamilyUnion singlePairBranchFamily component := by
+  constructor
+  · intro hunion
+    rcases hunion with ⟨branch, hfamily, hcomponent⟩
+    rcases hfamily with hbranch | hbranch
+    · subst branch
+      exact
+        ⟨traceRepairPairBranch, rfl, Or.inl hcomponent⟩
+    · subst branch
+      exact
+        ⟨traceRepairPairBranch, rfl, Or.inr hcomponent⟩
+  · intro hunion
+    rcases hunion with ⟨branch, hfamily, hcomponent⟩
+    subst branch
+    rcases hcomponent with htrace | hrepair
+    · subst component
+      exact
+        ⟨traceBranch, Or.inl rfl, rfl⟩
+    · subst component
+      exact
+        ⟨repairFrontierBranch, Or.inr rfl, rfl⟩
+
+/-- The trace-only plan hits the paired branch. -/
+theorem traceOnly_hits_singlePairBranch :
+    BranchRepairTransversal singlePairBranchFamily
+      traceOnlyRepairPlan.touched := by
+  intro branch hfamily
+  subst branch
+  exact ⟨BridgeComponent.trace, Or.inl rfl, rfl⟩
+
+/-- The trace-only plan misses the repair-frontier singleton branch. -/
+theorem traceOnly_misses_repairFrontierBranch :
+    BranchMissedBySupport repairFrontierBranch
+      traceOnlyRepairPlan.touched := by
+  intro component hcomponent htouched
+  subst component
+  cases htouched
+
+/-- The missed repair-frontier branch survives as residual branch support. -/
+theorem traceOnly_repairFrontierBranch_residual :
+    DeclaredResidualBranchSupport twoSingletonBranchFamily
+      traceOnlyRepairPlan repairFrontierBranch :=
+  missedBranch_survives_as_residual
+    (family := twoSingletonBranchFamily)
+    (plan := traceOnlyRepairPlan)
+    (branch := repairFrontierBranch)
+    (Or.inr rfl)
+    traceOnly_misses_repairFrontierBranch
+
+/-- The trace-only plan does not hit every singleton branch. -/
+theorem traceOnly_not_hits_twoSingletonBranch :
+    Not
+      (BranchRepairTransversal twoSingletonBranchFamily
+        traceOnlyRepairPlan.touched) := by
+  intro hhit
+  rcases hhit repairFrontierBranch (Or.inr rfl) with
+    ⟨component, hcomponent, htouched⟩
+  subst component
+  cases htouched
+
+/-- The trace-only plan is branch-complete for the paired-branch family. -/
+theorem traceOnly_branchComplete_singlePair :
+    BranchCompleteRepairPlan singlePairBranchFamily
+      traceOnlyRepairPlan := by
+  intro branch component hfamily _hcomponent htouched
+  subst branch
+  exact htouched
+
+/--
+The paired branch is clear for the trace-only plan, while the selected curved
+Cech component-level repair obligation still fails.
+-/
+theorem traceOnly_branchClearance_singlePair_not_componentCechObligation :
+    DeclaredBranchRepairClears singlePairBranchFamily traceOnlyRepairPlan /\
+      Not
+        (HandoffCechRepairObligation
+          selectedRepairTransportCechCommutatorCell.curvedPath
+          traceOnlyRepairPlan) := by
+  constructor
+  · exact
+      (declaredBranchClearance_iff_hits_antichainOverlapBasis
+        (cover := selectedRepairTransportCechCommutatorCell.curvedPath)
+        (componentBasis := repairTransportCurvatureBasis)
+        (family := singlePairBranchFamily)
+        (plan := traceOnlyRepairPlan)
+        singlePair_antichainCechOverlapBasis
+        traceOnly_branchComplete_singlePair).mpr
+        traceOnly_hits_singlePairBranch
+  · simpa [selectedRepairRefinementBasinCell] using
+      traceOnlyRepairPlan_fails_refinedBasin
+
+/--
+Visible component union is not faithful to protected branch-transversal class:
+the one-pair and two-singleton branch families have the same visible union, but
+the trace-only support is a transversal for only one of them.
+-/
+theorem sameVisibleUnion_not_faithful_to_branchTransversal :
+    (forall component,
+      BranchFamilyUnion twoSingletonBranchFamily component <->
+        BranchFamilyUnion singlePairBranchFamily component) /\
+      BranchRepairTransversal singlePairBranchFamily
+        traceOnlyRepairPlan.touched /\
+      Not
+        (BranchRepairTransversal twoSingletonBranchFamily
+          traceOnlyRepairPlan.touched) := by
+  exact
+    ⟨twoSingleton_singlePair_same_visibleUnion,
+      traceOnly_hits_singlePairBranch,
+      traceOnly_not_hits_twoSingletonBranch⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-69 theorem package: an exact selected Cech overlap component basis can
+carry antichain branch incidence; missed selected branches survive as residual
+branch support; branch-complete declared clearance is equivalent to branch
+transversality; deleting a selected branch breaks generation; and the visible
+component-union projection is not faithful to protected branch-transversal
+class or to component-level Cech repair obligation.
+-/
+theorem antichainOverlapBasisTransversal_package :
+    AntichainCechOverlapBasis
+        selectedRepairTransportCechCommutatorCell.curvedPath
+        repairTransportCurvatureBasis
+        twoSingletonBranchFamily /\
+      AntichainCechOverlapBasis
+        selectedRepairTransportCechCommutatorCell.curvedPath
+        repairTransportCurvatureBasis
+        singlePairBranchFamily /\
+      (forall {cover : HandoffCechCover}
+          {componentBasis : BridgeComponent -> Prop}
+          {family : BranchFamily}
+          {plan : HandoffRepairPlan},
+        AntichainCechOverlapBasis cover componentBasis family ->
+          BranchCompleteRepairPlan family plan ->
+            (DeclaredBranchRepairClears family plan <->
+              BranchRepairTransversal family plan.touched)) /\
+      (forall {family : BranchFamily}
+          {plan : HandoffRepairPlan}
+          {branch : BranchSupport},
+        family branch ->
+          BranchMissedBySupport branch plan.touched ->
+            DeclaredResidualBranchSupport family plan branch) /\
+      Not
+        (BranchFamilyUnionGenerates repairTransportCurvatureBasis
+          (branchFamilyDrops twoSingletonBranchFamily traceBranch)) /\
+      (forall component,
+        BranchFamilyUnion twoSingletonBranchFamily component <->
+          BranchFamilyUnion singlePairBranchFamily component) /\
+      DeclaredResidualBranchSupport twoSingletonBranchFamily
+        traceOnlyRepairPlan repairFrontierBranch /\
+      BranchRepairTransversal singlePairBranchFamily
+        traceOnlyRepairPlan.touched /\
+      Not
+        (BranchRepairTransversal twoSingletonBranchFamily
+          traceOnlyRepairPlan.touched) /\
+      (DeclaredBranchRepairClears singlePairBranchFamily
+          traceOnlyRepairPlan /\
+        Not
+          (HandoffCechRepairObligation
+            selectedRepairTransportCechCommutatorCell.curvedPath
+            traceOnlyRepairPlan)) /\
+      ((forall component,
+        BranchFamilyUnion twoSingletonBranchFamily component <->
+          BranchFamilyUnion singlePairBranchFamily component) /\
+        BranchRepairTransversal singlePairBranchFamily
+          traceOnlyRepairPlan.touched /\
+        Not
+          (BranchRepairTransversal twoSingletonBranchFamily
+            traceOnlyRepairPlan.touched)) := by
+  exact
+    ⟨twoSingleton_antichainCechOverlapBasis,
+      singlePair_antichainCechOverlapBasis,
+      fun {cover} {componentBasis} {family} {plan} hbasis hcomplete =>
+        declaredBranchClearance_iff_hits_antichainOverlapBasis
+          (cover := cover)
+          (componentBasis := componentBasis)
+          (family := family)
+          (plan := plan)
+          hbasis hcomplete,
+      fun {family} {plan} {branch} hfamily hmissed =>
+        missedBranch_survives_as_residual
+          (family := family)
+          (plan := plan)
+          (branch := branch)
+          hfamily hmissed,
+      dropTraceBranch_breaks_antichainGeneration,
+      twoSingleton_singlePair_same_visibleUnion,
+      traceOnly_repairFrontierBranch_residual,
+      traceOnly_hits_singlePairBranch,
+      traceOnly_not_hits_twoSingletonBranch,
+      traceOnly_branchClearance_singlePair_not_componentCechObligation,
+      sameVisibleUnion_not_faithful_to_branchTransversal⟩
+
+end AntichainOverlapBasisTransversal
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-antichain-overlap-basis-transversal-exactness.md
+++ b/research/ideas/g-aat-quality-surface-01-antichain-overlap-basis-transversal-exactness.md
@@ -1,0 +1,223 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: obstruction / minimality / repair-potential / certificate-transport / quality-surface / computability
+expected_base_score: 84
+expected_evidence_multiplier: 2.0
+expected_final_score: 168
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance surfaces can show mismatch component sets, but this candidate records non-singleton branch incidence and repair-transversal classes hidden by the same visible union.
+origin: G1-cycle69
+tags: [quality-surface, cech, overlap-basis, antichain, repair-transversal]
+created: 2026-06-21
+cycle: 69
+genius_potential: no
+genius_target: none
+genius_support_role: none
+---
+
+# Antichain Cech overlap basis and transversal exactness
+
+## 主張
+
+Finite Cech overlap support can be read not only as an exact component basis,
+but as a selected antichain of nonempty protected support branches whose union
+generates that component basis.  The branch layer is not identified with the
+existing component-level `HandoffCechRepairObligation`; it has its own declared
+branch-clearance and residual-branch predicates.  A missed selected branch
+survives as residual branch support, while in a branch-complete declared repair
+regime, clearing every branch is equivalent to the repair support hitting every
+selected branch.  Deleting a branch, or replacing a two-branch incidence basis
+by another basis with the same visible component-union projection, can change
+the repair-transversal class.  Thus non-singleton incidence is protected
+Quality Surface data, not merely a visible component bitset.
+
+This is a selected finite theorem package about `BridgeComponent` support
+branches grounded by an exact selected Cech overlap component basis.  It does
+not assert runtime repair synthesis, canonical global minimality, source
+extraction completeness, ArchMap correctness, arbitrary route enumeration,
+global sheaf completeness, or whole-codebase quality.
+
+## 候補種別
+
+`unification`: overlap basis exactness, selected branch-deletion failure,
+residual branch support, and repair-transversal duality are placed in one
+finite antichain calculus.
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/HandoffRepairTransversal.lean`
+- `Formal/AG/Research/QualitySurface/HandoffCechExactness.lean`
+- `Formal/AG/Research/QualitySurface/OverlapObstructionBasis.lean`
+- Cycle 64 component-support repair transversal.
+- Cycle 66 finite overlap obstruction basis and repair-transversal duality.
+- Cycle 68 selected repair-basin exchange obstruction.
+
+## 非自明性
+
+Cycle 66 handles exact overlap bases as predicates on components and repairs
+them through `HandoffCechRepairObligation`, a component-level clearance
+predicate.  This candidate adds a separate branch layer generated over such an
+exact component basis and separates three levels that a visible component
+bitset conflates:
+
+1. the union of all components that appear in some branch,
+2. the branch incidence relation itself, and
+3. the repair supports that hit every branch.
+
+The main nonfaithfulness claim fixes the visible projection to the component
+union only: two branch families can have the same visible union while requiring
+different protected repair transversals.
+
+## 数学的興味
+
+This imports hypergraph / antichain transversal duality into the Cech overlap
+obstruction calculus without claiming a full matroid theory.  It makes repair
+necessity depend on incidence, not just on component support membership.
+
+## GOAL への前進
+
+This advances the non-singleton overlap basis frontier and turns repair
+potential into a branch-incidence invariant of the Quality Surface.
+
+## ライバルに対する有効性
+
+ADL, architecture conformance checkers, and metric dashboards can surface
+component sets or mismatch counts.  They do not usually retain whether the same
+component union came from one two-component branch or from two singleton
+branches, nor whether the declared repair support hits each branch.  This
+candidate makes that loss a Lean-checkable finite theorem.
+
+## SCORE 見込み
+
+- `score_reason`: non-singleton branch incidence plus residual-branch and repair-transversal nonfaithfulness directly addresses the current frontier and gives a new repair-potential invariant, but remains a selected finite branch calculus rather than a global Cech theorem.
+- `dullness_risk`: If the result only defines a hypergraph and restates hitting, it is dull.  The Lean evidence must include exact branch generation, branch deletion failure, and same-visible-union / different-transversal witness.
+- `proof_or_evidence_plan`: Research-side Lean evidence now defines finite branch predicates grounded by a selected exact overlap component basis, residual branch semantics, `AntichainCechOverlapBasis`, branch transversal, branch-complete plans, selected two-singleton and one-pair bases, drop-branch failure, same union nonfaithfulness, and a theorem package.
+- `actual_evidence`: Implemented in `Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean` and imported by `Formal/AG/Research.lean`.
+
+## CS / SWE への帰結
+
+A repair view that only says "components trace and repairFrontier are involved"
+may hide whether a single repair action can cover one branch or must satisfy
+two separate branch obligations.  This gives a finite criterion for why a
+visible component set is insufficient as a repair dashboard.
+
+## Lean evidence
+
+Lean evidence is fixed in
+`Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean`.
+The main declarations are:
+
+- `BranchSupport`: a predicate on `BridgeComponent`.
+- `BranchNonempty` and `BranchSubsupport`.
+- `BranchFamilyUnionGenerates`: branch union generates a selected component basis.
+- `AntichainCechOverlapBasis`: an exact selected component overlap basis together with nonempty antichain branches whose union generates it.
+- `DeclaredResidualBranchSupport`: if no touched component lies in a selected branch, that branch remains as declared residual support.
+- `DeclaredBranchRepairClears`: branch-level clearance, intentionally separate from the existing component-level `HandoffCechRepairObligation`.
+- `BranchRepairTransversal`: a repair support hits every selected branch.
+- `BranchCompleteRepairPlan`: if a touched component lies in a selected branch, the declared branch is clear.
+- `missedBranch_survives_as_residual`: a selected missed branch remains as residual branch support.
+- `declaredBranchClearance_iff_hits_antichainOverlapBasis`: branch-complete plans clear all branches iff their support hits every branch.
+- `twoSingleton_antichainCechOverlapBasis` and `singlePair_antichainCechOverlapBasis`: selected finite branch bases with the same visible union.
+- `dropTraceBranch_breaks_antichainGeneration`: deleting the selected trace branch breaks branch generation.
+- `sameVisibleUnion_not_faithful_to_branchTransversal`: the same visible union can carry different protected transversal requirements.
+- `antichainOverlapBasisTransversal_package`: exactness, branch residual support, branch deletion, and nonfaithfulness.
+
+Actual declaration names:
+
+- `AntichainCechOverlapBasis`
+- `missedBranch_survives_as_residual`
+- `declaredBranchClearance_iff_hits_antichainOverlapBasis`
+- `twoSingleton_antichainCechOverlapBasis`
+- `singlePair_antichainCechOverlapBasis`
+- `dropTraceBranch_breaks_antichainGeneration`
+- `twoSingleton_singlePair_same_visibleUnion`
+- `traceOnly_repairFrontierBranch_residual`
+- `traceOnly_not_hits_twoSingletonBranch`
+- `traceOnly_branchClearance_singlePair_not_componentCechObligation`
+- `sameVisibleUnion_not_faithful_to_branchTransversal`
+- `antichainOverlapBasisTransversal_package`
+
+Build evidence:
+
+- `lake env lean Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean`: pass.
+- `lake build FormalAGResearch`: pass.
+- `lake build`: pass, with only pre-existing linter warnings in `Formal/Arch/Extension/FeatureExtensionExamples.lean`.
+
+Axiom audit:
+
+- No axioms: `AntichainCechOverlapBasis`, `missedBranch_survives_as_residual`,
+  `declaredBranchClearance_iff_hits_antichainOverlapBasis`,
+  `dropTraceBranch_breaks_antichainGeneration`,
+  `twoSingleton_singlePair_same_visibleUnion`,
+  `traceOnly_repairFrontierBranch_residual`,
+  `traceOnly_not_hits_twoSingletonBranch`,
+  `sameVisibleUnion_not_faithful_to_branchTransversal`.
+- `propext`: `twoSingleton_antichainCechOverlapBasis`,
+  `singlePair_antichainCechOverlapBasis`,
+  `traceOnly_branchClearance_singlePair_not_componentCechObligation`,
+  `antichainOverlapBasisTransversal_package`.
+- No `sorryAx`, `Classical.choice`, `Quot.sound`, custom axiom, or `unsafe` in reported declarations.
+
+The remaining `propext` comes through existing selected Cech overlap/refinement
+predicate-equality evidence such as `curvedPath_overlapBasis` and
+`traceOnlyRepairPlan_fails_refinedBasin`.  The new branch-layer residual,
+deletion, and same-visible-union nonfaithfulness witnesses are axiom-free.
+
+## 可視 projection
+
+The visible projection is only the union of components appearing in any branch.
+It deliberately forgets branch count and incidence.
+
+## protected_structure
+
+The protected structure is the branch family: whether trace and repairFrontier
+appear as two singleton branches or one paired branch changes transversal
+requirements.
+
+## exactness_or_minimality_claim
+
+Exactness means the branch union generates the selected exact Cech overlap
+component basis and each selected branch is nonempty.  This cycle proves branch
+deletion failure for the selected trace branch witness, not global all-branch
+indispensability or a matroid minimality theorem.
+
+## nonfaithfulness_or_failure_mode
+
+The same visible union `{trace, repairFrontier}` can have distinct branch
+transversal classes: hitting one paired branch differs from hitting two
+singleton branches.
+
+## previous_cycle_delta
+
+Cycle 68 showed that a selected trace-only repair plan can clear a coarse basin
+and fail a refined basin.  This cycle explains a more structural reason:
+branch-level repair obligation can depend on incidence among non-singleton
+overlap basis branches, not just on the visible component union or the existing
+component-level clearance predicate.
+
+## 審判メモ
+
+- 厳密性: A は初回 `revise`。任意 hypergraph の hitting lemma に落とさず、exact selected Cech overlap component basis への union-generation、residual branch semantics、component-level clearance との非同一性、projection を component-union に固定した nonfaithfulness を Lean evidence に入れるようカードを修正した。
+- 厳密性再審判: A は `accept`、base 82、genius no。`AntichainCechOverlapBasis` と component-basis grounding により任意 hypergraph 化から離れたと判定。ただし `BranchCompleteRepairPlan` が tautological に見えないよう、G4 では selected witness と residual branch semantics を重視する。
+- 研究価値: B は `accept`、base 88、genius no。
+- repo 全体価値: C は `accept`、base 84、genius no。arbitrary hypergraph 化のリスクにより expected base を 84 に下げた。
+- ライバル比較: D は `accept`、base 88、genius no。
+
+## G3 監査メモ
+
+- 公理検査: pass。build は pass。報告対象の core branch/residual/nonfaithfulness theorem は axiom-free。Cech component-basis grounding と component-level obligation 分離を含む package は既存 Cech evidence 由来の `propext` のみ。
+- Lean 形式化品質監査: pass。`AntichainCechOverlapBasis` は `OverlapObstructionBasis` に grounded されており、same component-union / different branch-transversal class、drop-trace failure、residual branch support、component-level `HandoffCechRepairObligation` との分離を表現している。
+- 残る unchecked: global all-branch deletion minimality、global Cech / sheaf completeness、runtime synthesis、whole-codebase quality、external ADL literature comparison。
+
+## 関連
+
+- `g-aat-quality-surface-01-overlap-obstruction-basis.md`
+- `g-aat-quality-surface-01-repair-basin-exchange-obstruction.md`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 69 の picked 候補として作成。G2 へ進める。
+- 2026-06-21: G2 A の revise を受け、branch-clearance と component-level `HandoffCechRepairObligation` の分離、residual branch semantics、exact overlap component basis への grounding、visible projection の固定を明記。
+- 2026-06-21: Lean evidence を追加し、`lake build FormalAGResearch` と full `lake build` を通過。G3 公理検査・形式化品質監査はいずれも pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 9162
+- total SCORE: 9330
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -73,8 +73,9 @@
   - obstruction / computability / repair-potential / traceability / minimality / quality-surface / certificate-transport: 172
   - profile-curvature / certificate-transport / obstruction / repair-potential / quality-surface / traceability: 176
   - repair-potential / profile-curvature / certificate-transport / obstruction / quality-surface / traceability: 156
+  - obstruction / minimality / repair-potential / certificate-transport / quality-surface / computability: 168
 - evidence portfolio:
-  - proved-in-research: 68
+  - proved-in-research: 69
 
 ## Phase synthesis
 
@@ -90,7 +91,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-68 件の Lean-proved research artifacts は、次の paper seed を形成している。
+69 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -101,6 +102,7 @@ certificate の基本単位は
 - source-ref handoff obstruction locus を component-indexed support と三 law minimality matrix として読める。
 - component support を declared repair clearance の transversal condition として読める。
 - repair/refinement exchange cell では、同じ visible/local projection の下でも coarse trace basin と refined trace-plus-repair-frontier basin の membership が分離しうる。
+- Cech overlap support は exact component basis だけでなく branch incidence を持ち、同じ visible component union でも branch-transversal class が分離しうる。
 
 ### Related-work separation
 
@@ -138,15 +140,16 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 68 後の total SCORE は 9162 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 69 後の total SCORE は 9330 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 68 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 69 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
 component support bitset / law minimality matrix、declared repair transversal theorem、
 finite overlap obstruction basis / repair-transversal duality theorem、
-repair/transport Cech commutator curvature theorem、repair-basin exchange obstruction theorem を含む。
+repair/transport Cech commutator curvature theorem、repair-basin exchange obstruction theorem、
+antichain Cech overlap branch-transversal theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -3181,14 +3184,62 @@ runtime repair generation, ArchMap correctness, source extraction completeness,
 arbitrary route enumeration, global sheaf completeness, or whole-codebase
 quality. G2 四審判はいずれも `genius_eligibility: no` を返し、G4 は通常 SCORE として base 78 を confirm した。
 
+## Cycle 69: Antichain Cech overlap basis and transversal exactness
+
+```text
+candidate: Antichain Cech overlap basis and transversal exactness
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 84
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 168
+category: obstruction / minimality / repair-potential / certificate-transport / quality-surface / computability
+goal_delta: selected finite Cech overlap support now carries a branch-incidence layer over an exact component basis, separating visible component union from protected branch-transversal class.
+project_value_delta: Adds a Lean-proved non-singleton overlap basis calculus seed and a future projection-rule witness for branch incidence in Quality Surface views.
+rival_delta: ADL / conformance views that retain component sets or mismatch counts do not determine whether the same visible union came from two singleton branches or one paired branch; the Lean witness makes that projection loss explicit.
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean`, `lake build FormalAGResearch`, and full `lake build` passed. Core residual / deletion / same-visible-union nonfaithfulness declarations are axiom-free; selected Cech grounding/package declarations use only standard `propext` inherited from existing Cech predicate-equality evidence. No `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe` in reported declarations.
+open_questions: global all-branch deletion minimality; refinement-invariant branch support transport; curvature basis exchange; external ADL related-work comparison; future viewer projection rules for branch incidence.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean`
+adds branch predicates over `BridgeComponent` and packages an
+`AntichainCechOverlapBasis`: an exact selected Cech overlap component basis
+together with nonempty antichain branches whose union generates that basis.
+Branch clearance is a separate declared predicate, not the existing
+component-level `HandoffCechRepairObligation`.
+
+Lean proves:
+
+- `missedBranch_survives_as_residual`: a selected branch missed by a declared repair support remains as residual branch support.
+- `declaredBranchClearance_iff_hits_antichainOverlapBasis`: in a branch-complete regime, clearing selected branches is equivalent to hitting every selected branch.
+- `twoSingleton_antichainCechOverlapBasis` and `singlePair_antichainCechOverlapBasis`: the selected curved Cech overlap basis supports both the two-singleton branch family and the one-pair branch family.
+- `dropTraceBranch_breaks_antichainGeneration`: deleting the selected trace branch breaks generation of the selected trace / repair-frontier component basis.
+- `traceOnly_repairFrontierBranch_residual`: the trace-only repair plan leaves the repair-frontier singleton branch as residual branch support.
+- `traceOnly_branchClearance_singlePair_not_componentCechObligation`: the trace-only plan clears the paired branch but still fails the component-level Cech repair obligation for the selected curved path.
+- `sameVisibleUnion_not_faithful_to_branchTransversal`: the two-singleton branch family and the one-pair branch family have the same visible component union, but the trace-only repair support is a transversal only for the one-pair family.
+- `antichainOverlapBasisTransversal_package`: the selected branch incidence, residual support, branch deletion, and nonfaithfulness package.
+
+This cycle is a selected finite branch calculus, not a global Cech minimality
+or matroid theorem.  The theorem package keeps the main claim inside exact
+selected overlap component bases, branch-level declared repair semantics, and
+lossful visible component-union projection.  It does not assert runtime repair
+synthesis, canonical global minimality, source extraction completeness,
+ArchMap correctness, arbitrary route enumeration, global sheaf completeness,
+or whole-codebase quality.  G2 四審判はいずれも `genius_eligibility: no` を返し、
+G4 は通常 SCORE として base 84 を confirm した。
+
 ### Next Frontier
 
-次フェーズの tracking Issue active threshold は 10000 であり、cycle 68 後の total SCORE は 9162 である。
-threshold 10000 までは残り 838 SCORE である。
+次フェーズの tracking Issue active threshold は 10000 であり、cycle 69 後の total SCORE は 9330 である。
+threshold 10000 までは残り 670 SCORE である。
 このフェーズの report seed は、atom-supported quality geometry の定義、
 Quality Surface as 2D profile slice、certificate tuple、comparison map / transport、
 finite grid phenomena、related-work separation、handoff local-to-global overlap obstruction、
-repair/transport Cech commutator curvature、repair-basin exchange obstruction を備えた。
+repair/transport Cech commutator curvature、repair-basin exchange obstruction、
+antichain Cech overlap branch-transversal calculus を備えた。
 threshold 10000 には未達であるため、次 cycle では non-singleton overlap basis calculus、
 refinement-invariant Cech overlap support、curvature basis exchange、
 general repair/refinement exchange cells、または component support hitting under atlas refinement を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 69 の research-loop 成果として、exact selected Cech overlap component basis の上に branch incidence layer を追加しました。同じ visible component union でも、two-singleton branch family と one-pair branch family では repair-transversal class が分離することを Lean で固定します。

SCORE は G4 監査で `+168` として確定し、tracking Issue の total は `9162 -> 9330 / 10000` になりました。tracking Issue は研究状態の正本なので、この PR では close しません。

## 証明した定理

- `AntichainCechOverlapBasis`
- `missedBranch_survives_as_residual`
- `declaredBranchClearance_iff_hits_antichainOverlapBasis`
- `twoSingleton_antichainCechOverlapBasis`
- `singlePair_antichainCechOverlapBasis`
- `dropTraceBranch_breaks_antichainGeneration`
- `twoSingleton_singlePair_same_visibleUnion`
- `traceOnly_repairFrontierBranch_residual`
- `traceOnly_not_hits_twoSingletonBranch`
- `traceOnly_branchClearance_singlePair_not_componentCechObligation`
- `sameVisibleUnion_not_faithful_to_branchTransversal`
- `antichainOverlapBasisTransversal_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-antichain-overlap-basis-transversal-exactness.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した。research-loop tracking Issue のため `Closes` は使わない。
- [x] Lean status を `proved-in-research` として候補カード・report に明記した。
- [x] `docs` の研究主張と Lean status が矛盾していない。
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない。
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている。
- [x] ArchSig と FieldSig の責務を混同していない。
