### PR TITLE
研究: curvature basis exchange を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -66,3 +66,4 @@ import Formal.AG.Research.QualitySurface.OverlapObstructionBasis
 import Formal.AG.Research.QualitySurface.RepairTransportCechCommutatorCurvature
 import Formal.AG.Research.QualitySurface.RepairBasinExchangeObstruction
 import Formal.AG.Research.QualitySurface.AntichainOverlapBasisTransversal
+import Formal.AG.Research.QualitySurface.CurvatureBasisExchange

--- a/Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean
+++ b/Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean
@@ -1,0 +1,509 @@
+import Formal.AG.Research.QualitySurface.AntichainOverlapBasisTransversal
+
+/-!
+Cycle 70 evidence for `G-aat-quality-surface-01`.
+
+This file reads the selected repair/refinement exchange cell as a
+path-indexed Cech branch exchange object.  The protected datum is not merely
+the visible union of bridge components; it is a branch family over
+`ExchangeSide × BridgeComponent`.  The construction remains relative to the
+selected finite repair/refinement cell, exact selected Cech overlap bases, and
+declared repair predicates.  It does not assert global matroid basis exchange,
+canonical atlas refinement, runtime repair synthesis, source extraction
+completeness, ArchMap correctness, arbitrary route enumeration, global sheaf
+completeness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace CurvatureBasisExchange
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffRepairTransversalTheorem
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open RepairTransportCechCommutatorCurvature
+open RepairBasinExchangeObstruction
+open AntichainOverlapBasisTransversal
+
+/-! ## Path-indexed exchange branches -/
+
+/-- Which side of the selected repair/refinement exchange cell a branch belongs to. -/
+inductive ExchangeSide where
+  | coarse
+  | refined
+deriving DecidableEq
+
+/-- A protected exchange component remembers both path side and bridge component. -/
+abbrev ExchangeComponent := ExchangeSide × BridgeComponent
+
+/-- A selected path-indexed exchange branch. -/
+abbrev ExchangeBranchSupport := ExchangeComponent -> Prop
+
+/-- A selected family of path-indexed exchange branches. -/
+abbrev ExchangeBranchFamily := ExchangeBranchSupport -> Prop
+
+/-- Lift an existing bridge-component branch onto one exchange side. -/
+def liftBranchToExchangeSide
+    (side : ExchangeSide)
+    (branch : BranchSupport) : ExchangeBranchSupport :=
+  fun component => component.1 = side /\ branch component.2
+
+/-- The coarse trace exchange branch. -/
+def coarseTraceExchangeBranch : ExchangeBranchSupport :=
+  liftBranchToExchangeSide ExchangeSide.coarse traceBranch
+
+/-- The refined trace exchange branch. -/
+def refinedTraceExchangeBranch : ExchangeBranchSupport :=
+  liftBranchToExchangeSide ExchangeSide.refined traceBranch
+
+/-- The refined repair-frontier exchange branch. -/
+def refinedRepairFrontierExchangeBranch : ExchangeBranchSupport :=
+  liftBranchToExchangeSide ExchangeSide.refined repairFrontierBranch
+
+/--
+The selected path-indexed basis-exchange family: one coarse trace branch and
+two refined branches.
+-/
+def selectedBasisExchangeFamily
+    (branch : ExchangeBranchSupport) : Prop :=
+  branch = coarseTraceExchangeBranch \/
+    branch = refinedTraceExchangeBranch \/
+      branch = refinedRepairFrontierExchangeBranch
+
+/--
+The coarser visible exchange family forgets the path side and remembers one
+paired branch over trace and repair-frontier components.
+-/
+def collapsedVisibleExchangeBranch
+    (component : ExchangeComponent) : Prop :=
+  component.2 = BridgeComponent.trace \/
+    component.2 = BridgeComponent.repairFrontier
+
+/-- A singleton visible family containing the collapsed trace / repair-frontier branch. -/
+def collapsedVisibleExchangeFamily
+    (branch : ExchangeBranchSupport) : Prop :=
+  branch = collapsedVisibleExchangeBranch
+
+/-- The component-union projection of an exchange branch family forgets `ExchangeSide`. -/
+def ExchangeVisibleUnion
+    (family : ExchangeBranchFamily)
+    (component : BridgeComponent) : Prop :=
+  exists branch,
+    family branch /\ exists side, branch (side, component)
+
+/-- A declared repair support hits every selected path-indexed exchange branch. -/
+def ExchangeBranchRepairTransversal
+    (family : ExchangeBranchFamily)
+    (support : HandoffRepairSupport) : Prop :=
+  forall branch,
+    family branch -> exists component, branch component /\ support component.2
+
+/-- A selected exchange branch is missed by a declared component repair support. -/
+def ExchangeBranchMissedBySupport
+    (branch : ExchangeBranchSupport)
+    (support : HandoffRepairSupport) : Prop :=
+  forall component, branch component -> Not (support component.2)
+
+/-- Declared residual exchange-branch support after a repair plan. -/
+def DeclaredResidualExchangeBranchSupport
+    (family : ExchangeBranchFamily)
+    (plan : HandoffRepairPlan)
+    (branch : ExchangeBranchSupport) : Prop :=
+  family branch /\
+    forall component, branch component -> Not (plan.clears component.2)
+
+/-- Common clearance of the selected repair/refinement exchange cell. -/
+def CommonExchangeClearance
+    (plan : HandoffRepairPlan) : Prop :=
+  CommonRepairBasinClearance selectedRepairRefinementBasinCell plan
+
+/-! ## Exact side bases grounding the exchange family -/
+
+/-- The coarse side has a singleton trace branch family. -/
+def coarseTraceBranchFamily
+    (branch : BranchSupport) : Prop :=
+  branch = traceBranch
+
+theorem coarseTraceBranchFamily_antichain :
+    BranchFamilyAntichain coarseTraceBranchFamily := by
+  intro left right hleft hright _hsubset component hrightComponent
+  subst left
+  subst right
+  exact hrightComponent
+
+theorem coarseTraceBranchFamily_nonempty
+    (branch : BranchSupport)
+    (hbranch : coarseTraceBranchFamily branch) :
+    BranchNonempty branch := by
+  subst branch
+  exact ⟨BridgeComponent.trace, rfl⟩
+
+theorem coarseTraceBranchFamily_sound :
+    BranchFamilySound repairRefinementCoarseBasis
+      coarseTraceBranchFamily := by
+  intro branch hbranch component hcomponent
+  subst branch
+  simpa [repairRefinementCoarseBasis, traceBranch] using hcomponent
+
+theorem coarseTraceBranchFamily_generates :
+    BranchFamilyUnionGenerates repairRefinementCoarseBasis
+      coarseTraceBranchFamily := by
+  intro component hbasis
+  exact
+    ⟨traceBranch, rfl,
+      by simpa [repairRefinementCoarseBasis, traceBranch] using hbasis⟩
+
+/-- The selected coarse Cech overlap basis grounds the coarse trace branch. -/
+theorem coarseTrace_antichainCechOverlapBasis :
+    AntichainCechOverlapBasis
+      selectedRepairRefinementBasinCell.coarsePath
+      repairRefinementCoarseBasis
+      coarseTraceBranchFamily := by
+  exact
+    ⟨coarsePath_overlapBasis,
+      coarseTraceBranchFamily_antichain,
+      coarseTraceBranchFamily_nonempty,
+      coarseTraceBranchFamily_sound,
+      coarseTraceBranchFamily_generates⟩
+
+/-- The selected refined Cech overlap basis grounds the two singleton branches. -/
+theorem refinedTwoSingleton_antichainCechOverlapBasis :
+    AntichainCechOverlapBasis
+      selectedRepairRefinementBasinCell.refinedPath
+      repairRefinementRefinedBasis
+      twoSingletonBranchFamily := by
+  simpa [selectedRepairRefinementBasinCell, repairRefinementRefinedBasis]
+    using twoSingleton_antichainCechOverlapBasis
+
+/-- The selected basis-exchange branches are grounded side-wise in exact Cech bases. -/
+theorem selectedBasisExchange_exact :
+    AntichainCechOverlapBasis
+        selectedRepairRefinementBasinCell.coarsePath
+        repairRefinementCoarseBasis
+        coarseTraceBranchFamily /\
+      AntichainCechOverlapBasis
+        selectedRepairRefinementBasinCell.refinedPath
+        repairRefinementRefinedBasis
+        twoSingletonBranchFamily := by
+  exact
+    ⟨coarseTrace_antichainCechOverlapBasis,
+      refinedTwoSingleton_antichainCechOverlapBasis⟩
+
+/--
+Every selected exchange branch is the side lift of a branch grounded on either
+the coarse trace basis or the refined two-singleton basis.
+-/
+theorem selectedBasisExchangeFamily_sideGrounded
+    {branch : ExchangeBranchSupport}
+    (hbranch : selectedBasisExchangeFamily branch) :
+    (exists baseBranch,
+      coarseTraceBranchFamily baseBranch /\
+        branch = liftBranchToExchangeSide ExchangeSide.coarse baseBranch) \/
+      (exists baseBranch,
+        twoSingletonBranchFamily baseBranch /\
+          branch = liftBranchToExchangeSide ExchangeSide.refined baseBranch) := by
+  rcases hbranch with hbranch | hbranch
+  · subst branch
+    exact Or.inl ⟨traceBranch, rfl, rfl⟩
+  · rcases hbranch with hbranch | hbranch
+    · subst branch
+      exact Or.inr ⟨traceBranch, Or.inl rfl, rfl⟩
+    · subst branch
+      exact Or.inr ⟨repairFrontierBranch, Or.inr rfl, rfl⟩
+
+/-! ## Exchange clearance and visible-projection loss -/
+
+/--
+For component-complete repair plans, common clearance of the selected
+repair/refinement exchange cell is equivalent to hitting every selected
+path-indexed exchange branch.
+-/
+theorem commonClearance_iff_hits_selectedBasisExchange
+    {plan : HandoffRepairPlan}
+    (hcoarseComplete :
+      ComponentCompleteHandoffRepairPlan
+        selectedRepairRefinementBasinCell.coarsePath.overlapCocycle plan)
+    (hrefinedComplete :
+      ComponentCompleteHandoffRepairPlan
+        selectedRepairRefinementBasinCell.refinedPath.overlapCocycle plan) :
+    CommonExchangeClearance plan <->
+      ExchangeBranchRepairTransversal
+        selectedBasisExchangeFamily plan.touched := by
+  constructor
+  · intro hclear branch hbranch
+    rcases hbranch with hbranch | hbranch
+    · subst branch
+      have hhit :
+          OverlapBasisTransversal repairRefinementCoarseBasis
+            plan.touched :=
+        (declaredClearance_iff_hitsEveryOverlapBasis_of_componentComplete
+          (cover := selectedRepairRefinementBasinCell.coarsePath)
+          (basis := repairRefinementCoarseBasis)
+          (plan := plan)
+          coarsePath_overlapBasis
+          hcoarseComplete).mp hclear.1
+      exact
+        ⟨(ExchangeSide.coarse, BridgeComponent.trace),
+          ⟨rfl, rfl⟩,
+          hhit BridgeComponent.trace rfl⟩
+    · rcases hbranch with hbranch | hbranch
+      · subst branch
+        have hhit :
+            OverlapBasisTransversal repairRefinementRefinedBasis
+              plan.touched :=
+          (declaredClearance_iff_hitsEveryOverlapBasis_of_componentComplete
+            (cover := selectedRepairRefinementBasinCell.refinedPath)
+            (basis := repairRefinementRefinedBasis)
+            (plan := plan)
+            refinedPath_overlapBasis
+            hrefinedComplete).mp hclear.2
+        exact
+          ⟨(ExchangeSide.refined, BridgeComponent.trace),
+            ⟨rfl, rfl⟩,
+            hhit BridgeComponent.trace (Or.inl rfl)⟩
+      · subst branch
+        have hhit :
+            OverlapBasisTransversal repairRefinementRefinedBasis
+              plan.touched :=
+          (declaredClearance_iff_hitsEveryOverlapBasis_of_componentComplete
+            (cover := selectedRepairRefinementBasinCell.refinedPath)
+            (basis := repairRefinementRefinedBasis)
+            (plan := plan)
+            refinedPath_overlapBasis
+            hrefinedComplete).mp hclear.2
+        exact
+          ⟨(ExchangeSide.refined, BridgeComponent.repairFrontier),
+            ⟨rfl, rfl⟩,
+            hhit BridgeComponent.repairFrontier (Or.inr rfl)⟩
+  · intro hhit
+    exact
+      (commonClearance_iff_hits_unionBasis
+        (plan := plan) hcoarseComplete hrefinedComplete).mpr
+        (by
+          intro component hbasis
+          rcases hbasis with hcoarse | hrefined
+          · rcases
+              hhit coarseTraceExchangeBranch (Or.inl rfl) with
+              ⟨exchangeComponent, hbranch, htouched⟩
+            rcases exchangeComponent with ⟨side, touchedComponent⟩
+            rcases hbranch with ⟨_hside, hcomponent⟩
+            subst component
+            have htouchedComponent :
+                touchedComponent = BridgeComponent.trace := by
+              simpa [traceBranch, singletonRepairSupport] using hcomponent
+            subst touchedComponent
+            simpa using htouched
+          · rcases hrefined with htrace | hrepair
+            · rcases
+                hhit refinedTraceExchangeBranch
+                  (Or.inr (Or.inl rfl)) with
+                ⟨exchangeComponent, hbranch, htouched⟩
+              rcases exchangeComponent with ⟨side, touchedComponent⟩
+              rcases hbranch with ⟨_hside, hcomponent⟩
+              subst component
+              have htouchedComponent :
+                  touchedComponent = BridgeComponent.trace := by
+                simpa [traceBranch, singletonRepairSupport] using hcomponent
+              subst touchedComponent
+              simpa using htouched
+            · rcases
+                hhit refinedRepairFrontierExchangeBranch
+                  (Or.inr (Or.inr rfl)) with
+                ⟨exchangeComponent, hbranch, htouched⟩
+              rcases exchangeComponent with ⟨side, touchedComponent⟩
+              rcases hbranch with ⟨_hside, hcomponent⟩
+              subst component
+              have htouchedComponent :
+                  touchedComponent = BridgeComponent.repairFrontier := by
+                simpa [repairFrontierBranch, singletonRepairSupport] using hcomponent
+              subst touchedComponent
+              simpa using htouched)
+
+/--
+The selected path-indexed family and the collapsed visible family have the
+same visible component-union projection.
+-/
+theorem selected_collapsed_same_visibleUnion
+    (component : BridgeComponent) :
+    ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+      ExchangeVisibleUnion collapsedVisibleExchangeFamily component := by
+  constructor
+  · intro hunion
+    rcases hunion with ⟨branch, hfamily, side, hcomponent⟩
+    rcases hfamily with hfamily | hfamily
+    · subst branch
+      exact
+        ⟨collapsedVisibleExchangeBranch, rfl, side,
+          Or.inl hcomponent.2⟩
+    · rcases hfamily with hfamily | hfamily
+      · subst branch
+        exact
+          ⟨collapsedVisibleExchangeBranch, rfl, side,
+            Or.inl hcomponent.2⟩
+      · subst branch
+        exact
+          ⟨collapsedVisibleExchangeBranch, rfl, side,
+            Or.inr hcomponent.2⟩
+  · intro hunion
+    rcases hunion with ⟨branch, hfamily, side, hcomponent⟩
+    subst branch
+    rcases hcomponent with htrace | hrepair
+    · exact
+        ⟨coarseTraceExchangeBranch, Or.inl rfl,
+          ExchangeSide.coarse, ⟨rfl, htrace⟩⟩
+    · exact
+        ⟨refinedRepairFrontierExchangeBranch,
+          Or.inr (Or.inr rfl),
+          ExchangeSide.refined, ⟨rfl, hrepair⟩⟩
+
+/-- The trace-only plan hits the collapsed visible exchange branch. -/
+theorem traceOnly_hits_collapsedVisibleExchange :
+    ExchangeBranchRepairTransversal
+      collapsedVisibleExchangeFamily traceOnlyRepairPlan.touched := by
+  intro branch hbranch
+  subst branch
+  exact
+    ⟨(ExchangeSide.coarse, BridgeComponent.trace),
+      Or.inl rfl,
+      rfl⟩
+
+/-- The trace-only plan misses the refined repair-frontier exchange branch. -/
+theorem traceOnly_misses_refinedRepairFrontierExchangeBranch :
+    ExchangeBranchMissedBySupport refinedRepairFrontierExchangeBranch
+      traceOnlyRepairPlan.touched := by
+  intro component hcomponent htouched
+  rcases component with ⟨side, component⟩
+  exact traceOnlyRepairPlan_misses_repairFrontier
+    (by
+      rcases hcomponent with ⟨_hside, hrepair⟩
+      have hrepairComponent :
+          component = BridgeComponent.repairFrontier := by
+        simpa [repairFrontierBranch, singletonRepairSupport] using hrepair
+      subst component
+      simpa using htouched)
+
+/-- The trace-only plan leaves the refined repair-frontier branch as residual support. -/
+theorem traceOnly_refinedRepairFrontierExchange_residual :
+    DeclaredResidualExchangeBranchSupport selectedBasisExchangeFamily
+      traceOnlyRepairPlan refinedRepairFrontierExchangeBranch := by
+  constructor
+  · exact Or.inr (Or.inr rfl)
+  · intro component hcomponent hclear
+    exact traceOnly_misses_refinedRepairFrontierExchangeBranch
+      component hcomponent
+      (traceOnlyRepairPlan.clears_only_if_touched component.2 hclear)
+
+/-- The trace-only plan does not hit every selected path-indexed exchange branch. -/
+theorem traceOnly_not_hits_selectedBasisExchange :
+    Not
+      (ExchangeBranchRepairTransversal
+        selectedBasisExchangeFamily traceOnlyRepairPlan.touched) := by
+  intro hhit
+  rcases
+      hhit refinedRepairFrontierExchangeBranch
+        (Or.inr (Or.inr rfl)) with
+    ⟨component, hcomponent, htouched⟩
+  exact traceOnly_misses_refinedRepairFrontierExchangeBranch
+    component hcomponent htouched
+
+/-- The trace-only plan fails common clearance of the selected exchange cell. -/
+theorem traceOnly_fails_commonExchangeClearance :
+    Not (CommonExchangeClearance traceOnlyRepairPlan) := by
+  intro hclear
+  exact traceOnlyRepairPlan_fails_refinedBasin hclear.2
+
+/--
+Visible component union is not faithful to path-indexed basis exchange:
+the selected and collapsed families have the same visible union, but the
+trace-only support is a transversal only for the collapsed family.
+-/
+theorem sameVisibleUnion_not_faithful_to_basisExchange :
+    (forall component,
+      ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+        ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+      ExchangeBranchRepairTransversal
+        collapsedVisibleExchangeFamily traceOnlyRepairPlan.touched /\
+      Not
+        (ExchangeBranchRepairTransversal
+          selectedBasisExchangeFamily traceOnlyRepairPlan.touched) := by
+  exact
+    ⟨selected_collapsed_same_visibleUnion,
+      traceOnly_hits_collapsedVisibleExchange,
+      traceOnly_not_hits_selectedBasisExchange⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-70 theorem package: the selected repair/refinement exchange cell carries
+side-indexed Cech branches; component-complete common clearance is exactly
+selected exchange-branch hitting; and forgetting the side index loses the
+branch-transversal class.
+-/
+theorem curvatureBasisExchange_package :
+    AntichainCechOverlapBasis
+        selectedRepairRefinementBasinCell.coarsePath
+        repairRefinementCoarseBasis
+        coarseTraceBranchFamily /\
+      AntichainCechOverlapBasis
+        selectedRepairRefinementBasinCell.refinedPath
+        repairRefinementRefinedBasis
+        twoSingletonBranchFamily /\
+      (forall {branch : ExchangeBranchSupport},
+        selectedBasisExchangeFamily branch ->
+          (exists baseBranch,
+            coarseTraceBranchFamily baseBranch /\
+              branch =
+                liftBranchToExchangeSide ExchangeSide.coarse baseBranch) \/
+            (exists baseBranch,
+              twoSingletonBranchFamily baseBranch /\
+                branch =
+                  liftBranchToExchangeSide ExchangeSide.refined baseBranch)) /\
+      (forall {plan : HandoffRepairPlan},
+        ComponentCompleteHandoffRepairPlan
+            selectedRepairRefinementBasinCell.coarsePath.overlapCocycle
+            plan ->
+          ComponentCompleteHandoffRepairPlan
+            selectedRepairRefinementBasinCell.refinedPath.overlapCocycle
+            plan ->
+          (CommonExchangeClearance plan <->
+            ExchangeBranchRepairTransversal
+              selectedBasisExchangeFamily plan.touched)) /\
+      (forall component,
+        ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+          ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+      ExchangeBranchRepairTransversal
+        collapsedVisibleExchangeFamily traceOnlyRepairPlan.touched /\
+      DeclaredResidualExchangeBranchSupport selectedBasisExchangeFamily
+        traceOnlyRepairPlan refinedRepairFrontierExchangeBranch /\
+      Not
+        (ExchangeBranchRepairTransversal
+          selectedBasisExchangeFamily traceOnlyRepairPlan.touched) /\
+      Not (CommonExchangeClearance traceOnlyRepairPlan) /\
+      ((forall component,
+        ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+          ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+        ExchangeBranchRepairTransversal
+          collapsedVisibleExchangeFamily traceOnlyRepairPlan.touched /\
+        Not
+          (ExchangeBranchRepairTransversal
+            selectedBasisExchangeFamily traceOnlyRepairPlan.touched)) := by
+  exact
+    ⟨coarseTrace_antichainCechOverlapBasis,
+      refinedTwoSingleton_antichainCechOverlapBasis,
+      fun {branch} hbranch =>
+        selectedBasisExchangeFamily_sideGrounded hbranch,
+      fun {plan} hcoarse hrefined =>
+        commonClearance_iff_hits_selectedBasisExchange
+          (plan := plan) hcoarse hrefined,
+      selected_collapsed_same_visibleUnion,
+      traceOnly_hits_collapsedVisibleExchange,
+      traceOnly_refinedRepairFrontierExchange_residual,
+      traceOnly_not_hits_selectedBasisExchange,
+      traceOnly_fails_commonExchangeClearance,
+      sameVisibleUnion_not_faithful_to_basisExchange⟩
+
+end CurvatureBasisExchange
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-curvature-basis-exchange.md
+++ b/research/ideas/g-aat-quality-surface-01-curvature-basis-exchange.md
@@ -1,0 +1,178 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: profile-curvature / certificate-transport / repair-potential / obstruction / minimality / quality-surface
+expected_base_score: 84
+expected_evidence_multiplier: 2.0
+expected_final_score: 168
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance surfaces can compare repair/refinement views, but this candidate records path-indexed branch exchange obligations hidden by the same visible/local projection and component union.
+origin: G1-cycle70
+tags: [quality-surface, cech, basis-exchange, repair-refinement, branch-transversal]
+created: 2026-06-21
+cycle: 70
+lean: Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean
+genius_potential: no
+genius_target: none
+genius_support_role: none
+---
+
+# Curvature basis exchange for repair/refinement exchange cells
+
+## 主張
+
+In a selected finite repair/refinement exchange cell, the coarse path and
+refined path carry exact Cech overlap bases.  The exchange datum is not only
+the component union of those bases, but the path-indexed branch obligation:
+which branch belongs to the coarse side and which branch belongs to the
+refined side.  Under component-complete declared repair, common clearance of
+the exchange cell is equivalent to hitting every path-indexed exchange branch.
+
+The selected witness uses the coarse trace basis and the refined
+trace / repair-frontier basis.  A visible component-union projection forgets
+the path index and cannot distinguish the selected exchange closure from a
+coarser paired visible branch.  The trace-only repair support can hit the
+paired visible branch, but it misses the refined repair-frontier exchange
+branch and therefore fails the protected exchange closure.
+
+This is a selected finite theorem package about Cech overlap bases,
+path-indexed branch incidence, and declared repair predicates.  It is not a
+global matroid basis-exchange theorem, a canonical atlas-refinement theorem,
+runtime repair synthesis, source extraction completeness, ArchMap correctness,
+arbitrary route enumeration, global sheaf completeness, or whole-codebase
+quality.
+
+## 候補種別
+
+`unification`: Cycle 67 Cech curvature, Cycle 68 repair/refinement exchange,
+and Cycle 69 antichain branch-transversal nonfaithfulness are compressed into
+one path-indexed basis-exchange calculus.
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/RepairTransportCechCommutatorCurvature.lean`
+- `Formal/AG/Research/QualitySurface/RepairBasinExchangeObstruction.lean`
+- `Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean`
+- Cycle 67 selected repair/transport Cech commutator curvature.
+- Cycle 68 selected repair-basin exchange obstruction.
+- Cycle 69 antichain Cech overlap basis and transversal exactness.
+
+## 非自明性
+
+The result is not just the union of two component bases.  The protected data is
+a path-indexed branch family.  The refined repair-frontier branch is a distinct
+exchange obligation even though the visible component-union projection only
+sees `{trace, repairFrontier}`.
+
+This prevents a common collapse: treating a repair/refinement exchange cell as
+if the only relevant data were the set of components that appear somewhere in
+the cell.  The theorem instead distinguishes visible union, path-indexed
+branch incidence, and declared repair transversality.
+
+## 数学的興味
+
+This gives a finite hypergraph-style basis exchange object without claiming a
+full matroid theory.  Profile curvature is read as a path-indexed obstruction
+in the exchange closure: clearing the exchange requires hitting the branches
+that appear on the relevant paths, not merely hitting the coarse visible
+component set.
+
+## GOAL への前進
+
+This advances the curvature-basis-exchange frontier and gives the Quality
+Surface a reusable finite criterion for repair/refinement exchange cells.
+
+## ライバルに対する有効性
+
+ADL, conformance tools, and dashboards can show two repair/refinement views and
+their component sets.  They generally do not provide a theorem-level condition
+stating which path-indexed protected branches must be hit for common declared
+clearance.  This candidate makes the loss of path-indexed exchange data
+Lean-checkable.
+
+## SCORE 見込み
+
+- `score_reason`: the Lean theorem package unifies the last three Cech/repair cycles and directly addresses curvature basis exchange, while staying inside the selected finite boundary.
+- `dullness_risk`: controlled.  The Lean statements keep `ExchangeSide × BridgeComponent` in the protected branch type, prove common clearance iff exchange-branch hitting, and prove visible-union nonfaithfulness.
+- `proof_or_evidence_plan`: completed in `Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean`.
+
+## Lean evidence
+
+Lean proves:
+
+- `ExchangeSide`: coarse and refined path indices.
+- `ExchangeBranchSupport`: a predicate on `(ExchangeSide × BridgeComponent)`.
+- `liftBranchToExchangeSide`: lift a branch into one side of the exchange cell.
+- `selectedBasisExchangeFamily`: the selected path-indexed coarse trace branch and refined trace / repair-frontier branches.
+- `collapsedVisibleExchangeFamily`: a coarser visible branch family with the same component-union projection.
+- `ExchangeBranchRepairTransversal`: a declared repair support hits every selected exchange branch.
+- `coarseTrace_antichainCechOverlapBasis` and `refinedTwoSingleton_antichainCechOverlapBasis`: coarse and refined path branches are grounded in exact selected Cech overlap bases.
+- `selectedBasisExchange_exact`: the side-wise exact branch bases are packaged together.
+- `selectedBasisExchangeFamily_sideGrounded`: every selected exchange branch is the side lift of a branch grounded on the coarse or refined exact basis.
+- `commonClearance_iff_hits_selectedBasisExchange`: component-complete common clearance iff hitting every selected exchange branch.
+- `selected_collapsed_same_visibleUnion`: selected and collapsed families have the same visible component-union projection.
+- `traceOnly_hits_collapsedVisibleExchange`: the trace-only plan hits the collapsed visible branch.
+- `traceOnly_misses_refinedRepairFrontierExchangeBranch` and `traceOnly_refinedRepairFrontierExchange_residual`: the trace-only plan misses the refined repair-frontier exchange branch, leaving residual exchange-branch support.
+- `traceOnly_not_hits_selectedBasisExchange`: the trace-only plan is not a transversal for the selected path-indexed family.
+- `traceOnly_fails_commonExchangeClearance`: trace-only support fails common clearance of the selected exchange cell.
+- `sameVisibleUnion_not_faithful_to_basisExchange`: visible component union cannot recover path-indexed branch-transversal class.
+- `curvatureBasisExchange_package`: exactness, exchange-branch hitting, trace-only failure, and nonfaithfulness.
+
+Local checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean`: pass.
+- `lake build FormalAGResearch`: pass.
+- `#print axioms`: `selectedBasisExchangeFamily_sideGrounded`, `selected_collapsed_same_visibleUnion`, `traceOnly_hits_collapsedVisibleExchange`, `traceOnly_misses_refinedRepairFrontierExchangeBranch`, `traceOnly_refinedRepairFrontierExchange_residual`, `traceOnly_not_hits_selectedBasisExchange`, and `sameVisibleUnion_not_faithful_to_basisExchange` are axiom-free.  Cech grounding, common-clearance, trace-only common-clearance failure, and the package use only standard `propext` inherited from existing Cech predicate-equality evidence.  No `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe` was reported in the new core evidence.
+
+## 可視 projection
+
+The visible projection forgets `ExchangeSide` and remembers only the component
+union that appears in some exchange branch.
+
+## protected_structure
+
+The protected structure is the path-indexed exchange branch family: a trace
+branch on the coarse side, and trace plus repair-frontier branches on the
+refined side.
+
+## exactness_or_minimality_claim
+
+Exactness means that the selected exchange branches are grounded in the exact
+coarse and refined Cech overlap bases, and component-complete common clearance
+is equivalent to hitting those selected exchange branches.  This cycle does
+not claim global least exchange closure or matroid basis exchange.
+
+## nonfaithfulness_or_failure_mode
+
+The selected exchange family and a coarser collapsed visible branch family
+have the same visible component union.  The trace-only support hits the
+collapsed visible branch but misses the selected refined repair-frontier
+exchange branch.
+
+## previous_cycle_delta
+
+Cycle 69 showed fixed-cover visible-union nonfaithfulness for antichain branch
+families.  This cycle moves the same phenomenon into the repair/refinement
+exchange cell: the forgotten datum is now path-indexed branch incidence.
+
+## 審判メモ
+
+- 厳密性: accept / base 84 / genius no.  Selected finite theorem package として進める。`ExchangeSide × BridgeComponent` が theorem の主対象に残る限り、component union の名前替えではない。
+- 研究価値: accept / base 90 / genius no.  Cycle 67 Cech curvature、Cycle 68 repair/refinement exchange、Cycle 69 branch-transversal nonfaithfulness を path-indexed exchange-branch calculus に圧縮する。
+- repo 全体価値: accept / base 88 / genius no.  Lean / paper / future projection-rule surface に価値があるが、project-level bridge ではなく phase-continuation theorem package。
+- ライバル比較: accept / base 88 / genius no.  ADL / conformance surface が持つ visible views や component sets では決まらない path-indexed branch-transversal class を Lean-checkable にする。
+- G3 形式化品質監査: pass.  `ExchangeSide` は protected theorem statements に残り、global matroid exchange、canonical refinement、runtime synthesis、tooling correctness などを主張していない。
+- G4 SCORE 監査: confirm / base 84 / multiplier 2.0 / penalty 0 / final +168.  Total は 9330 から 9498 へ進む。G2 全員が genius no のため genius scoring は not-applicable。
+
+## 関連
+
+- `g-aat-quality-surface-01-repair-transport-cech-commutator-curvature.md`
+- `g-aat-quality-surface-01-repair-basin-exchange-obstruction.md`
+- `g-aat-quality-surface-01-antichain-overlap-basis-transversal-exactness.md`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 70 の picked 候補として作成。G2 へ進める。
+- 2026-06-21: `CurvatureBasisExchange.lean` を追加し、selected finite path-indexed basis-exchange theorem package として Lean 検証済みに同期。
+- 2026-06-21: G4 SCORE 監査で final +168 を confirm。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 9330
+- total SCORE: 9498
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -74,8 +74,9 @@
   - profile-curvature / certificate-transport / obstruction / repair-potential / quality-surface / traceability: 176
   - repair-potential / profile-curvature / certificate-transport / obstruction / quality-surface / traceability: 156
   - obstruction / minimality / repair-potential / certificate-transport / quality-surface / computability: 168
+  - profile-curvature / certificate-transport / repair-potential / obstruction / minimality / quality-surface / unification: 168
 - evidence portfolio:
-  - proved-in-research: 69
+  - proved-in-research: 70
 
 ## Phase synthesis
 
@@ -140,16 +141,16 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 69 後の total SCORE は 9330 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 70 後の total SCORE は 9498 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 69 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 70 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
 component support bitset / law minimality matrix、declared repair transversal theorem、
 finite overlap obstruction basis / repair-transversal duality theorem、
 repair/transport Cech commutator curvature theorem、repair-basin exchange obstruction theorem、
-antichain Cech overlap branch-transversal theorem を含む。
+antichain Cech overlap branch-transversal theorem、curvature basis exchange theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -3243,3 +3244,56 @@ antichain Cech overlap branch-transversal calculus を備えた。
 threshold 10000 には未達であるため、次 cycle では non-singleton overlap basis calculus、
 refinement-invariant Cech overlap support、curvature basis exchange、
 general repair/refinement exchange cells、または component support hitting under atlas refinement を狙う。
+
+## Cycle 70: Curvature basis exchange for repair/refinement exchange cells
+
+```text
+candidate: Curvature basis exchange for repair/refinement exchange cells
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 84
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 168
+category: profile-curvature / certificate-transport / repair-potential / obstruction / minimality / quality-surface / unification
+goal_delta: selected repair/refinement exchange cells now carry a side-indexed Cech branch layer; common clearance is exact branch hitting over `ExchangeSide × BridgeComponent`, not merely component-union hitting.
+project_value_delta: Packages Cycle 67 Cech curvature, Cycle 68 repair-basin exchange, and Cycle 69 branch-transversal nonfaithfulness as a reusable finite basis-exchange calculus for Quality Surface projection rules.
+rival_delta: ADL / conformance surfaces can retain repair/refinement views and component sets, but they do not determine the path-indexed branch-transversal class; the Lean witness makes that projection loss explicit.
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean` and `lake build FormalAGResearch` passed. Core side-grounding, selected/collapsed visible-union nonfaithfulness, trace-only hit/miss, residual exchange branch, and selected-family nontransversal declarations are axiom-free; exact Cech grounding, common-clearance iff, trace-only common-clearance failure, and the package use only standard `propext` inherited from existing Cech predicate-equality evidence. No `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe` was reported.
+open_questions: global basis-exchange theory beyond the selected finite witness; refinement-invariant support transport; viewer projection rules for path-indexed branch incidence; external ADL related-work comparison; non-selected exchange-cell families.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean` adds a
+side-indexed exchange layer over the selected repair/refinement exchange cell.
+An `ExchangeBranchSupport` is a predicate on `ExchangeSide × BridgeComponent`,
+so the protected datum records whether a branch belongs to the coarse or
+refined path.
+
+Lean proves:
+
+- `coarseTrace_antichainCechOverlapBasis` and `refinedTwoSingleton_antichainCechOverlapBasis`: the selected coarse trace branch and refined trace / repair-frontier branches are grounded in exact selected Cech overlap bases.
+- `selectedBasisExchangeFamily_sideGrounded`: every selected exchange branch is the side lift of a branch grounded on the coarse or refined exact basis.
+- `commonClearance_iff_hits_selectedBasisExchange`: for component-complete plans, common clearance of the selected exchange cell is equivalent to hitting every selected path-indexed exchange branch.
+- `selected_collapsed_same_visibleUnion`: the selected side-indexed family and a collapsed visible family have the same visible component-union projection.
+- `traceOnly_hits_collapsedVisibleExchange`: the trace-only plan hits the collapsed visible branch.
+- `traceOnly_refinedRepairFrontierExchange_residual` and `traceOnly_not_hits_selectedBasisExchange`: the same trace-only plan misses the refined repair-frontier exchange branch, leaving residual exchange-branch support and failing selected exchange transversality.
+- `traceOnly_fails_commonExchangeClearance`: trace-only support fails common clearance of the selected repair/refinement exchange cell.
+- `sameVisibleUnion_not_faithful_to_basisExchange`: visible component union is not faithful to the path-indexed basis-exchange transversal class.
+- `curvatureBasisExchange_package`: the side-wise exactness, branch-hitting criterion, trace-only failure, and nonfaithfulness package.
+
+This cycle remains a selected finite theorem package. It does not assert
+global matroid basis exchange, canonical atlas refinement, runtime repair
+synthesis, source extraction completeness, ArchMap correctness, arbitrary route
+enumeration, global sheaf completeness, or whole-codebase quality. G2 四審判は
+いずれも `genius_eligibility: no` を返し、G3 は Lean proof と独立監査を通った。
+
+### Next Frontier
+
+Cycle 70 後の total SCORE は 9498 であり、threshold 10000 までは残り 502 SCORE である。
+このフェーズの report seed は、repair/refinement exchange cell の可視 projection が component union を保持しても
+path-indexed branch obligation を失うことを Lean-proved な projection loss として持った。
+threshold 10000 にはまだ未達であるため、次 cycle では refinement-invariant Cech overlap support、
+general exchange-cell family、path-indexed viewer projection rule、または genius target に近い
+atlas-refinement invariant support transport theorem を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 70 として、selected repair/refinement exchange cell を `ExchangeSide × BridgeComponent` 上の path-indexed Cech branch exchange object として形式化しました。common clearance は component union ではなく selected exchange branch hitting と同値であること、また visible component-union projection が branch-transversal class に faithful でないことを Lean で固定しています。

SCORE は G4 監査で base 84 × multiplier 2.0 = +168 として confirm 済みです。total は 9330 から 9498 へ進み、active threshold 10000 までは残り 502 です。tracking Issue は研究状態の正本なので、この PR では close しません。

## 証明した定理

- `coarseTrace_antichainCechOverlapBasis`
- `refinedTwoSingleton_antichainCechOverlapBasis`
- `selectedBasisExchange_exact`
- `selectedBasisExchangeFamily_sideGrounded`
- `commonClearance_iff_hits_selectedBasisExchange`
- `selected_collapsed_same_visibleUnion`
- `traceOnly_hits_collapsedVisibleExchange`
- `traceOnly_misses_refinedRepairFrontierExchangeBranch`
- `traceOnly_refinedRepairFrontierExchange_residual`
- `traceOnly_not_hits_selectedBasisExchange`
- `traceOnly_fails_commonExchangeClearance`
- `sameVisibleUnion_not_faithful_to_basisExchange`
- `curvatureBasisExchange_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-curvature-basis-exchange.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` for reported declarations

## チェックリスト

- [x] tracking Issue を `Refs #2348` 形式で本文に記載した
- [x] Lean status は `proved-in-research`
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
