### PR TITLE
研究: naive refinement support counterexample を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -67,3 +67,4 @@ import Formal.AG.Research.QualitySurface.RepairTransportCechCommutatorCurvature
 import Formal.AG.Research.QualitySurface.RepairBasinExchangeObstruction
 import Formal.AG.Research.QualitySurface.AntichainOverlapBasisTransversal
 import Formal.AG.Research.QualitySurface.CurvatureBasisExchange
+import Formal.AG.Research.QualitySurface.NaiveRefinementSupportCounterexample

--- a/Formal/AG/Research/QualitySurface/NaiveRefinementSupportCounterexample.lean
+++ b/Formal/AG/Research/QualitySurface/NaiveRefinementSupportCounterexample.lean
@@ -1,0 +1,306 @@
+import Formal.AG.Research.QualitySurface.CurvatureBasisExchange
+
+/-!
+Cycle 71 evidence for `G-aat-quality-surface-01`.
+
+This file gives a selected finite no-go result for a too-weak refinement
+reading.  In the selected repair/refinement exchange cell, a naive reading can
+pair the refined trace and repair-frontier components into one refined branch.
+That reading preserves the visible component-union projection, but it does not
+reflect the refined repair-frontier singleton branch needed by the selected
+branch-transversal repair obligation.
+
+The result is only a selected finite branch-reflection failure and
+deletion/restoration witness.  It is not a global refinement transport theorem,
+global minimality theorem, canonical atlas refinement result, runtime repair
+synthesis claim, source extraction completeness claim, ArchMap correctness
+claim, arbitrary route enumeration, global sheaf completeness, or whole-codebase
+quality claim.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace NaiveRefinementSupportCounterexample
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffRepairTransversalTheorem
+open RepairBasinExchangeObstruction
+open AntichainOverlapBasisTransversal
+open CurvatureBasisExchange
+
+/-! ## Naive and reflected branch readings -/
+
+/-- The naive refined paired branch keeps the refined side but pairs trace and repair-frontier. -/
+def naiveRefinedPairExchangeBranch : ExchangeBranchSupport :=
+  liftBranchToExchangeSide ExchangeSide.refined traceRepairPairBranch
+
+/-- A naive finite refinement reading: coarse trace plus one refined paired branch. -/
+def naiveRefinementBranchFamily
+    (branch : ExchangeBranchSupport) : Prop :=
+  branch = coarseTraceExchangeBranch \/
+    branch = naiveRefinedPairExchangeBranch
+
+/-- The selected reflected reading is the Cycle 70 selected basis-exchange family. -/
+def reflectedSelectedBranchFamily : ExchangeBranchFamily :=
+  selectedBasisExchangeFamily
+
+/-- The reflected refined repair-frontier singleton branch. -/
+def reflectedRepairFrontierSingleton : ExchangeBranchSupport :=
+  refinedRepairFrontierExchangeBranch
+
+/--
+A branch is reflected by a reading when the reading contains exactly that
+path-indexed branch as an independent selected branch.
+-/
+def branchReflectedBy
+    (reading : ExchangeBranchFamily)
+    (branch : ExchangeBranchSupport) : Prop :=
+  reading branch
+
+/-- Dropping one path-indexed branch from an exchange branch family. -/
+def exchangeBranchFamilyDrops
+    (family : ExchangeBranchFamily)
+    (dropped : ExchangeBranchSupport) : ExchangeBranchFamily :=
+  fun branch => family branch /\ branch ≠ dropped
+
+/-! ## Visible preservation and branch-reflection failure -/
+
+/--
+The naive paired reading and reflected selected reading have the same visible
+component-union projection.
+-/
+theorem naiveRefinement_preserves_visibleUnion
+    (component : BridgeComponent) :
+    ExchangeVisibleUnion naiveRefinementBranchFamily component <->
+      ExchangeVisibleUnion reflectedSelectedBranchFamily component := by
+  constructor
+  · intro hunion
+    rcases hunion with ⟨branch, hfamily, side, hcomponent⟩
+    rcases hfamily with hbranch | hbranch
+    · subst branch
+      exact
+        ⟨coarseTraceExchangeBranch, Or.inl rfl,
+          side, hcomponent⟩
+    · subst branch
+      rcases hcomponent.2 with htrace | hrepair
+      · exact
+          ⟨refinedTraceExchangeBranch, Or.inr (Or.inl rfl),
+            ExchangeSide.refined, ⟨rfl, htrace⟩⟩
+      · exact
+          ⟨refinedRepairFrontierExchangeBranch,
+            Or.inr (Or.inr rfl),
+            ExchangeSide.refined, ⟨rfl, hrepair⟩⟩
+  · intro hunion
+    rcases hunion with ⟨branch, hfamily, side, hcomponent⟩
+    rcases hfamily with hbranch | hbranch
+    · subst branch
+      exact
+        ⟨coarseTraceExchangeBranch, Or.inl rfl,
+          side, hcomponent⟩
+    · rcases hbranch with hbranch | hbranch
+      · subst branch
+        exact
+          ⟨naiveRefinedPairExchangeBranch, Or.inr rfl,
+            ExchangeSide.refined, ⟨rfl, Or.inl hcomponent.2⟩⟩
+      · subst branch
+        exact
+          ⟨naiveRefinedPairExchangeBranch, Or.inr rfl,
+            ExchangeSide.refined, ⟨rfl, Or.inr hcomponent.2⟩⟩
+
+/-- The reflected selected reading contains the refined repair-frontier singleton. -/
+theorem reflectedSelected_reflects_repairFrontierSingleton :
+    branchReflectedBy reflectedSelectedBranchFamily
+      reflectedRepairFrontierSingleton := by
+  exact Or.inr (Or.inr rfl)
+
+/-- The naive paired reading does not reflect the repair-frontier singleton as an independent branch. -/
+theorem naiveReading_not_reflects_repairFrontierSingleton :
+    Not
+      (branchReflectedBy naiveRefinementBranchFamily
+        reflectedRepairFrontierSingleton) := by
+  intro hreflect
+  rcases hreflect with hbranch | hbranch
+  · have hfrontier :
+        reflectedRepairFrontierSingleton
+          (ExchangeSide.refined, BridgeComponent.repairFrontier) := by
+      exact ⟨rfl, rfl⟩
+    have hbad :
+        coarseTraceExchangeBranch
+          (ExchangeSide.refined, BridgeComponent.repairFrontier) := by
+      simpa [hbranch] using hfrontier
+    exact
+      (by
+        rcases hbad with ⟨hside, _hcomponent⟩
+        cases hside)
+  · have hnaive :
+        naiveRefinedPairExchangeBranch
+          (ExchangeSide.refined, BridgeComponent.trace) := by
+      exact ⟨rfl, Or.inl rfl⟩
+    have hleft :
+        reflectedRepairFrontierSingleton
+          (ExchangeSide.refined, BridgeComponent.trace) := by
+      simpa [hbranch] using hnaive
+    exact
+      (by
+        rcases hleft with ⟨_hside, hcomponent⟩
+        cases hcomponent)
+
+/-! ## Trace-only transversal separation -/
+
+/-- The trace-only plan hits the naive paired refinement reading. -/
+theorem traceOnly_hits_naiveRefinementBranches :
+    ExchangeBranchRepairTransversal
+      naiveRefinementBranchFamily traceOnlyRepairPlan.touched := by
+  intro branch hfamily
+  rcases hfamily with hbranch | hbranch
+  · subst branch
+    exact
+      ⟨(ExchangeSide.coarse, BridgeComponent.trace),
+        ⟨rfl, rfl⟩,
+        rfl⟩
+  · subst branch
+    exact
+      ⟨(ExchangeSide.refined, BridgeComponent.trace),
+        ⟨rfl, Or.inl rfl⟩,
+        rfl⟩
+
+/-- The trace-only plan does not hit the reflected selected reading. -/
+theorem traceOnly_not_hits_reflectedSelectedBranches :
+    Not
+      (ExchangeBranchRepairTransversal
+        reflectedSelectedBranchFamily traceOnlyRepairPlan.touched) := by
+  exact traceOnly_not_hits_selectedBasisExchange
+
+/-- The reflected repair-frontier singleton is the selected missed branch. -/
+theorem reflectedRepairFrontier_minimal_obstruction :
+    branchReflectedBy reflectedSelectedBranchFamily
+        reflectedRepairFrontierSingleton /\
+      ExchangeBranchMissedBySupport reflectedRepairFrontierSingleton
+        traceOnlyRepairPlan.touched /\
+      Not
+        (branchReflectedBy naiveRefinementBranchFamily
+          reflectedRepairFrontierSingleton) := by
+  exact
+    ⟨reflectedSelected_reflects_repairFrontierSingleton,
+      traceOnly_misses_refinedRepairFrontierExchangeBranch,
+      naiveReading_not_reflects_repairFrontierSingleton⟩
+
+/--
+Deleting the reflected repair-frontier singleton restores trace-only
+transversality for the selected finite family.
+-/
+theorem dropRefinedRepairFrontier_restores_traceOnlyTransversal :
+    ExchangeBranchRepairTransversal
+      (exchangeBranchFamilyDrops reflectedSelectedBranchFamily
+        reflectedRepairFrontierSingleton)
+      traceOnlyRepairPlan.touched := by
+  intro branch hfamily
+  rcases hfamily.1 with hbranch | hbranch
+  · subst branch
+    exact
+      ⟨(ExchangeSide.coarse, BridgeComponent.trace),
+        ⟨rfl, rfl⟩,
+        rfl⟩
+  · rcases hbranch with hbranch | hbranch
+    · subst branch
+      exact
+        ⟨(ExchangeSide.refined, BridgeComponent.trace),
+          ⟨rfl, rfl⟩,
+          rfl⟩
+    · exact False.elim (hfamily.2 hbranch)
+
+/--
+The selected finite branch-reflection failure: visible union is preserved, but
+the naive paired reading does not reflect the refined repair-frontier singleton
+and therefore accepts trace-only transversality where the reflected selected
+reading rejects it.
+-/
+theorem selectedBranchReflectionFailure :
+    (forall component,
+      ExchangeVisibleUnion naiveRefinementBranchFamily component <->
+        ExchangeVisibleUnion reflectedSelectedBranchFamily component) /\
+      Not
+        (branchReflectedBy naiveRefinementBranchFamily
+          reflectedRepairFrontierSingleton) /\
+      branchReflectedBy reflectedSelectedBranchFamily
+        reflectedRepairFrontierSingleton /\
+      ExchangeBranchRepairTransversal
+        naiveRefinementBranchFamily traceOnlyRepairPlan.touched /\
+      Not
+        (ExchangeBranchRepairTransversal
+          reflectedSelectedBranchFamily traceOnlyRepairPlan.touched) /\
+      ExchangeBranchRepairTransversal
+        (exchangeBranchFamilyDrops reflectedSelectedBranchFamily
+          reflectedRepairFrontierSingleton)
+        traceOnlyRepairPlan.touched := by
+  exact
+    ⟨naiveRefinement_preserves_visibleUnion,
+      naiveReading_not_reflects_repairFrontierSingleton,
+      reflectedSelected_reflects_repairFrontierSingleton,
+      traceOnly_hits_naiveRefinementBranches,
+      traceOnly_not_hits_reflectedSelectedBranches,
+      dropRefinedRepairFrontier_restores_traceOnlyTransversal⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-71 theorem package: a selected finite naive refinement reading can
+preserve visible component union while failing to reflect the refined
+repair-frontier singleton branch required by branch-transversal repair.
+-/
+theorem naiveRefinementCounterexample_package :
+    (forall component,
+      ExchangeVisibleUnion naiveRefinementBranchFamily component <->
+        ExchangeVisibleUnion reflectedSelectedBranchFamily component) /\
+      ExchangeBranchRepairTransversal
+        naiveRefinementBranchFamily traceOnlyRepairPlan.touched /\
+      Not
+        (ExchangeBranchRepairTransversal
+          reflectedSelectedBranchFamily traceOnlyRepairPlan.touched) /\
+      branchReflectedBy reflectedSelectedBranchFamily
+        reflectedRepairFrontierSingleton /\
+      Not
+        (branchReflectedBy naiveRefinementBranchFamily
+          reflectedRepairFrontierSingleton) /\
+      (branchReflectedBy reflectedSelectedBranchFamily
+          reflectedRepairFrontierSingleton /\
+        ExchangeBranchMissedBySupport reflectedRepairFrontierSingleton
+          traceOnlyRepairPlan.touched /\
+        Not
+          (branchReflectedBy naiveRefinementBranchFamily
+            reflectedRepairFrontierSingleton)) /\
+      ExchangeBranchRepairTransversal
+        (exchangeBranchFamilyDrops reflectedSelectedBranchFamily
+          reflectedRepairFrontierSingleton)
+        traceOnlyRepairPlan.touched /\
+      ((forall component,
+        ExchangeVisibleUnion naiveRefinementBranchFamily component <->
+          ExchangeVisibleUnion reflectedSelectedBranchFamily component) /\
+        Not
+          (branchReflectedBy naiveRefinementBranchFamily
+            reflectedRepairFrontierSingleton) /\
+        branchReflectedBy reflectedSelectedBranchFamily
+          reflectedRepairFrontierSingleton /\
+        ExchangeBranchRepairTransversal
+          naiveRefinementBranchFamily traceOnlyRepairPlan.touched /\
+        Not
+          (ExchangeBranchRepairTransversal
+            reflectedSelectedBranchFamily traceOnlyRepairPlan.touched) /\
+        ExchangeBranchRepairTransversal
+          (exchangeBranchFamilyDrops reflectedSelectedBranchFamily
+            reflectedRepairFrontierSingleton)
+          traceOnlyRepairPlan.touched) := by
+  exact
+    ⟨naiveRefinement_preserves_visibleUnion,
+      traceOnly_hits_naiveRefinementBranches,
+      traceOnly_not_hits_reflectedSelectedBranches,
+      reflectedSelected_reflects_repairFrontierSingleton,
+      naiveReading_not_reflects_repairFrontierSingleton,
+      reflectedRepairFrontier_minimal_obstruction,
+      dropRefinedRepairFrontier_restores_traceOnlyTransversal,
+      selectedBranchReflectionFailure⟩
+
+end NaiveRefinementSupportCounterexample
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-naive-refinement-support-counterexample.md
+++ b/research/ideas/g-aat-quality-surface-01-naive-refinement-support-counterexample.md
@@ -1,0 +1,182 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: orientation
+capability_category: obstruction / invariance / minimality / certificate-transport / quality-surface
+expected_base_score: 68
+expected_evidence_multiplier: 2.0
+expected_final_score: 136
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance refinement views can preserve visible component unions while missing whether branch reflection preserved path-indexed repair obligations.
+origin: G1-cycle71
+tags: [quality-surface, refinement, cech, branch-transversal, counterexample]
+created: 2026-06-21
+cycle: 71
+lean: Formal/AG/Research/QualitySurface/NaiveRefinementSupportCounterexample.lean
+genius_potential: no
+genius_target: none
+genius_support_role: none
+---
+
+# Selected branch-reflection failure for naive refinement readings
+
+## 主張
+
+In the selected finite repair/refinement exchange cell, preserving visible
+component-union data is not enough to preserve branch-transversal repair
+obligations.  A naive refinement reading can keep the coarse trace branch and
+pair the refined trace / repair-frontier components into one refined branch.
+That reading has the same visible component-union projection as the reflected
+selected branch reading, and the trace-only repair support hits the naive
+paired reading.  But the reflected selected reading separates the refined
+repair-frontier singleton branch, and trace-only repair misses it.
+
+The obstruction is minimal only in the selected finite deletion/restoration
+sense: deleting the reflected refined repair-frontier singleton branch restores
+trace-only transversality for the selected branch family.  This is not a global
+minimality theorem, and it does not claim that the visible union remains
+unchanged after deletion.  The point is narrower: visible-union preservation
+does not encode the branch-reflection datum needed by repair transversality.
+
+This is a selected finite no-go theorem for a too-weak refinement reading.  It
+does not define or prove a positive atlas-refinement transport theorem,
+canonical refinement, runtime repair synthesis, source extraction completeness,
+ArchMap correctness, arbitrary route enumeration, global sheaf completeness,
+or whole-codebase quality.
+
+## 候補種別
+
+`orientation`: before proving a positive refinement-invariant support
+transport theorem, this cycle fixes a selected finite failure mode of the
+naive visible-union-preserving reading.
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/AntichainOverlapBasisTransversal.lean`
+- `Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean`
+- Cycle 69 antichain branch-transversal nonfaithfulness.
+- Cycle 70 path-indexed curvature basis exchange.
+
+## 非自明性
+
+This is not just another trace-only failure.  The point is to separate three
+levels:
+
+1. visible component-union preservation,
+2. naive side-indexed paired branch reading, and
+3. reflected selected branch reading with the refined repair-frontier singleton
+   branch.
+
+The theorem should show that level 1 and even a paired level-2 reading are not
+enough for branch-transversal preservation.  The missing datum is exactly the
+reflected refined repair-frontier singleton branch.  The refinement language is
+therefore represented by a selected finite `branch reflection` reading, not by
+a global atlas-refinement morphism.
+
+## 数学的興味
+
+The result turns a prospective refinement theorem into a necessary-hypothesis
+problem.  It identifies branch reflection, not visible component support, as
+the datum that must be preserved by a future refinement map if
+repair-transversal semantics are to be invariant.
+
+## GOAL への前進
+
+This advances the refinement-invariant support frontier by preventing a false
+invariance theorem and isolating the minimal protected structure needed for
+the positive theorem.
+
+## ライバルに対する有効性
+
+ADL, conformance tools, and dashboards can compare refined views and component
+sets.  They do not by themselves prove that refinement preserves the
+path-indexed branch-transversal class.  This candidate makes the failure of
+that inference Lean-checkable.
+
+## SCORE 見込み
+
+- `score_reason`: moderate orientation value because it prevents a too-weak refinement theorem and isolates branch reflection as the missing hypothesis, while reusing Cycle 70's selected finite setting.
+- `dullness_risk`: real.  If it only repeats Cycle 70 trace-only nonfaithfulness, the score should drop.  The Lean evidence must explicitly introduce a selected finite branch-reflection reading, a naive refined-pair reading, and deletion/restoration of the reflected repair-frontier singleton.
+- `proof_or_evidence_plan`: completed in `Formal/AG/Research/QualitySurface/NaiveRefinementSupportCounterexample.lean`.
+
+## Lean evidence
+
+Lean proves:
+
+- `naiveRefinedPairExchangeBranch`: a refined-side paired trace / repair-frontier branch.
+- `naiveRefinementBranchFamily`: coarse trace plus the naive refined paired branch.
+- `reflectedSelectedBranchFamily`: the selected Cycle 70 branch family, read as a selected branch-reflection target.
+- `branchReflectedBy`: a selected finite predicate saying a reflected branch is represented by a source branch under the reading.
+- `naiveReading_not_reflects_repairFrontierSingleton`: the naive paired reading does not reflect the refined repair-frontier singleton as a separate branch.
+- `naiveRefinement_preserves_visibleUnion`: naive and reflected readings have the same visible component union.
+- `traceOnly_hits_naiveRefinementBranches`: trace-only support is a transversal for the naive paired reading.
+- `traceOnly_not_hits_reflectedSelectedBranches`: trace-only support is not a transversal for the reflected selected reading.
+- `reflectedRepairFrontier_minimal_obstruction`: the refined repair-frontier singleton branch is the exact missed branch that breaks transversality.
+- `dropRefinedRepairFrontier_restores_traceOnlyTransversal`: deleting that singleton restores trace-only transversality in the selected finite family.
+- `selectedBranchReflectionFailure`: visible-union preservation, branch-reflection failure, trace-only separation, and deletion/restoration in one statement.
+- `naiveRefinementCounterexample_package`: visible preservation, before/after transversal separation, and minimal obstruction.
+
+Local checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/NaiveRefinementSupportCounterexample.lean`: pass.
+- `lake build FormalAGResearch`: pass.
+- `lake build`: pass, with only existing `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warnings.
+- `#print axioms`: all reported declarations are axiom-free.  No `sorryAx`, custom axiom, `propext`, `Classical.choice`, `Quot.sound`, or `unsafe` appears in the reported declarations.
+
+## 可視 projection
+
+The visible projection forgets the difference between a refined paired branch
+and the two reflected refined singleton branches, remembering only the
+component union.
+
+## protected_structure
+
+The protected structure is branch reflection: refined trace and refined
+repair-frontier must remain separate selected branches when the repair
+obligation depends on branch transversality.
+
+## exactness_or_minimality_claim
+
+The exactness input is inherited from Cycle 70: selected exchange branches are
+grounded in exact coarse and refined Cech overlap bases, and
+component-complete common clearance is equivalent to hitting those selected
+exchange branches.  This cycle's new selected finite minimality claim is only
+deletion/restoration: dropping the reflected repair-frontier singleton restores
+trace-only transversality for the selected family.
+
+## nonfaithfulness_or_failure_mode
+
+Naive visible refinement preserves the visible component-union projection, but
+it is nonfaithful to the branch-transversal class because it pairs away the
+refined repair-frontier singleton obstruction.
+
+## previous_cycle_delta
+
+Cycle 70 showed that a collapsed visible exchange family and the selected
+path-indexed family can have the same visible union while differing on
+transversality.  This cycle sharpens that into a refinement-invariance no-go:
+branch reflection, not visible union preservation, is the missing hypothesis.
+
+## 審判メモ
+
+- 厳密性: G2 で判定する。特に「最小反例」が selected finite deletion/restoration として十分に定式化されているかを確認する。
+- 研究価値: G2 で判定する。
+- repo 全体価値: G2 で判定する。
+- ライバル比較: G2 で判定する。
+- G2 revise 対応: 厳密性審判の指摘を受け、global refinement theorem ではなく selected finite branch-reflection failure に縮約し、expected base score を 88 から 68 に下げた。`minimal` は deletion/restoration に限定し、削除後も visible union が同一であるとは主張しない。
+- G2: revised card 後、厳密性 accept / base 68 / genius no、研究価値 accept / base 82 / genius no、repo 全体価値 accept / base 84 / genius no、ライバル比較 accept / base 68 / genius no。
+- G3 公理検査: pass。報告対象9 theorem はすべて axiom-free。
+- G3 形式化品質監査: pass。ただし `branchReflectedBy` は selected finite witness には十分だが、将来の一般 refinement API としては弱い。この cycle では一般 API として扱わない。
+- G4 SCORE 監査: confirm / base 68 / multiplier 2.0 / penalty 0 / final +136。Total は 9498 から 9634 へ進む。G2 全員が genius no のため genius scoring は not-applicable。
+
+## 関連
+
+- `g-aat-quality-surface-01-antichain-overlap-basis-transversal-exactness.md`
+- `g-aat-quality-surface-01-curvature-basis-exchange.md`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 71 の picked 候補として作成。G2 へ進める。
+- 2026-06-21: G2 A revise を受け、主張境界と SCORE 見込みを保守的に改訂。
+- 2026-06-21: `NaiveRefinementSupportCounterexample.lean` を追加し、selected finite branch-reflection failure として Lean 検証済みに同期。
+- 2026-06-21: G4 SCORE 監査で final +136 を confirm。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 9498
+- total SCORE: 9634
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -75,8 +75,9 @@
   - repair-potential / profile-curvature / certificate-transport / obstruction / quality-surface / traceability: 156
   - obstruction / minimality / repair-potential / certificate-transport / quality-surface / computability: 168
   - profile-curvature / certificate-transport / repair-potential / obstruction / minimality / quality-surface / unification: 168
+  - obstruction / invariance / minimality / certificate-transport / quality-surface: 136
 - evidence portfolio:
-  - proved-in-research: 70
+  - proved-in-research: 71
 
 ## Phase synthesis
 
@@ -141,16 +142,17 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 70 後の total SCORE は 9498 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 71 後の total SCORE は 9634 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 70 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 71 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
 component support bitset / law minimality matrix、declared repair transversal theorem、
 finite overlap obstruction basis / repair-transversal duality theorem、
 repair/transport Cech commutator curvature theorem、repair-basin exchange obstruction theorem、
-antichain Cech overlap branch-transversal theorem、curvature basis exchange theorem を含む。
+antichain Cech overlap branch-transversal theorem、curvature basis exchange theorem、
+selected branch-reflection failure theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -3297,3 +3299,58 @@ path-indexed branch obligation を失うことを Lean-proved な projection los
 threshold 10000 にはまだ未達であるため、次 cycle では refinement-invariant Cech overlap support、
 general exchange-cell family、path-indexed viewer projection rule、または genius target に近い
 atlas-refinement invariant support transport theorem を狙う。
+
+## Cycle 71: Selected branch-reflection failure for naive refinement readings
+
+```text
+candidate: Selected branch-reflection failure for naive refinement readings
+candidate_type: orientation
+evidence_stage: proved-in-research
+base_score: 68
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 136
+category: obstruction / invariance / minimality / certificate-transport / quality-surface
+goal_delta: refinement-invariant support transport gains a necessary-hypothesis counterexample: visible component-union preservation does not encode the branch-reflection datum needed by repair transversality.
+project_value_delta: Turns Cycle 70 projection loss into a selected finite no-go theorem for too-weak refinement readings, while keeping global atlas-refinement transport out of scope.
+rival_delta: ADL / conformance refinement views can preserve visible component sets, but they do not by themselves preserve or reflect the refined repair-frontier singleton branch required by branch-transversal repair obligations.
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/NaiveRefinementSupportCounterexample.lean`, `lake build FormalAGResearch`, and full `lake build` passed. Full build warning is the pre-existing `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning only. All reported Cycle 71 declarations are axiom-free; no `sorryAx`, custom axiom, `propext`, `Classical.choice`, `Quot.sound`, or `unsafe` appears in the reported declarations.
+open_questions: positive atlas-refinement support transport theorem; stronger non-tautological branch-reflection API; viewer projection kernel rule; general exchange-cell family theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/NaiveRefinementSupportCounterexample.lean`
+adds a selected finite branch-reflection failure for naive refinement readings.
+The naive reading keeps the coarse trace branch and pairs the refined trace /
+repair-frontier components into one refined branch.  The reflected selected
+reading keeps the refined repair-frontier singleton branch as an independent
+selected branch.
+
+Lean proves:
+
+- `naiveRefinement_preserves_visibleUnion`: the naive paired reading and reflected selected reading have the same visible component-union projection.
+- `reflectedSelected_reflects_repairFrontierSingleton`: the reflected selected reading contains the refined repair-frontier singleton.
+- `naiveReading_not_reflects_repairFrontierSingleton`: the naive paired reading does not reflect that singleton as an independent branch.
+- `traceOnly_hits_naiveRefinementBranches`: trace-only support is a transversal for the naive paired reading.
+- `traceOnly_not_hits_reflectedSelectedBranches`: trace-only support is not a transversal for the reflected selected reading.
+- `reflectedRepairFrontier_minimal_obstruction`: the selected missing datum is the reflected repair-frontier singleton.
+- `dropRefinedRepairFrontier_restores_traceOnlyTransversal`: deleting that singleton restores trace-only transversality for the selected finite family.
+- `selectedBranchReflectionFailure`: visible-union preservation, branch-reflection failure, trace-only separation, and deletion/restoration.
+- `naiveRefinementCounterexample_package`: the selected finite no-go package.
+
+This cycle does not define a global refinement morphism or prove a positive
+atlas-refinement transport theorem.  The `branchReflectedBy` predicate is
+membership-level and fit only for this selected finite witness; a future
+positive theorem will need a stronger refinement-map / branch-reflection API.
+The claim also does not assert global minimality, runtime repair synthesis,
+source extraction completeness, ArchMap correctness, arbitrary route
+enumeration, global sheaf completeness, or whole-codebase quality. G2 四審判は
+いずれも `genius_eligibility: no` を返し、G3 は Lean proof と独立監査を通った。
+
+### Next Frontier
+
+Cycle 71 後の total SCORE は 9634 であり、threshold 10000 までは残り 366 SCORE である。
+この cycle は positive refinement transport theorem ではなく、その前提不足を固定する no-go result である。
+次 cycle では positive atlas-refinement support transport theorem、viewer projection kernel rule、
+または general exchange-cell family theorem を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 71 として、selected finite branch-reflection failure for naive refinement readings を追加しました。naive reading は refined trace / repair-frontier を一つの refined paired branch に潰しても visible component-union projection を保存しますが、reflected selected reading が持つ refined repair-frontier singleton branch を独立 branch として反映しないため、trace-only repair support の branch-transversal 判定が分離します。

SCORE は G4 監査で base 68 × multiplier 2.0 = +136 として confirm 済みです。total は 9498 から 9634 へ進み、active threshold 10000 までは残り 366 です。tracking Issue は研究状態の正本なので、この PR では close しません。

## 証明した定理

- `naiveRefinement_preserves_visibleUnion`
- `reflectedSelected_reflects_repairFrontierSingleton`
- `naiveReading_not_reflects_repairFrontierSingleton`
- `traceOnly_hits_naiveRefinementBranches`
- `traceOnly_not_hits_reflectedSelectedBranches`
- `reflectedRepairFrontier_minimal_obstruction`
- `dropRefinedRepairFrontier_restores_traceOnlyTransversal`
- `selectedBranchReflectionFailure`
- `naiveRefinementCounterexample_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-naive-refinement-support-counterexample.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/NaiveRefinementSupportCounterexample.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` for reported declarations

## チェックリスト

- [x] tracking Issue を `Refs #2348` 形式で本文に記載した
- [x] Lean status は `proved-in-research`
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
