### PR TITLE
研究: branch-transversal scan kernel を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -68,3 +68,4 @@ import Formal.AG.Research.QualitySurface.RepairBasinExchangeObstruction
 import Formal.AG.Research.QualitySurface.AntichainOverlapBasisTransversal
 import Formal.AG.Research.QualitySurface.CurvatureBasisExchange
 import Formal.AG.Research.QualitySurface.NaiveRefinementSupportCounterexample
+import Formal.AG.Research.QualitySurface.BranchTransversalScanKernel

--- a/Formal/AG/Research/QualitySurface/BranchTransversalScanKernel.lean
+++ b/Formal/AG/Research/QualitySurface/BranchTransversalScanKernel.lean
@@ -1,0 +1,541 @@
+import Formal.AG.Research.QualitySurface.NaiveRefinementSupportCounterexample
+
+/-!
+Cycle 72 evidence for `G-aat-quality-surface-01`.
+
+This file turns the selected repair/refinement exchange branch obligation into
+a selector-relative finite scan kernel.  The returned residual is canonical
+only relative to the supplied selected branch-code order.  The construction is
+relative to the selected finite exchange family, declared repair support, and
+visible component-union projection.  It does not assert global minimal repair,
+runtime repair synthesis, source extraction completeness, ArchMap correctness,
+arbitrary route enumeration, global sheaf completeness, or whole-codebase
+quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace BranchTransversalScanKernel
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffRepairTransversalTheorem
+open RepairBasinExchangeObstruction
+open AntichainOverlapBasisTransversal
+open CurvatureBasisExchange
+open NaiveRefinementSupportCounterexample
+
+instance traceOnlyRepairPlan_touched_decidable :
+    DecidablePred traceOnlyRepairPlan.touched := by
+  intro component
+  cases component <;>
+    simp [traceOnlyRepairPlan, singletonRepairSupport] <;>
+    infer_instance
+
+/-! ## Selected branch-code scan -/
+
+/-- Selector codes for the selected path-indexed exchange branches. -/
+inductive SelectedScanBranch where
+  | coarseTrace
+  | refinedTrace
+  | refinedRepairFrontier
+deriving DecidableEq
+
+/-- Interpret a selected scan code as its path-indexed exchange branch. -/
+def SelectedScanBranch.branch : SelectedScanBranch -> ExchangeBranchSupport
+  | coarseTrace => coarseTraceExchangeBranch
+  | refinedTrace => refinedTraceExchangeBranch
+  | refinedRepairFrontier => refinedRepairFrontierExchangeBranch
+
+/-- The selected finite order used by the scan kernel. -/
+def selectedScanOrder : List SelectedScanBranch :=
+  [SelectedScanBranch.coarseTrace,
+    SelectedScanBranch.refinedTrace,
+    SelectedScanBranch.refinedRepairFrontier]
+
+/-- The selected branch codes cover exactly the selected exchange branch family. -/
+def selectedScanBranchFamily
+    (branch : ExchangeBranchSupport) : Prop :=
+  exists code,
+    code ∈ selectedScanOrder /\
+      SelectedScanBranch.branch code = branch
+
+/-- The selector-code family enumerates exactly the selected basis-exchange family. -/
+theorem selectedScanBranchFamily_complete
+    (branch : ExchangeBranchSupport) :
+    selectedScanBranchFamily branch <->
+      selectedBasisExchangeFamily branch := by
+  constructor
+  · intro hbranch
+    rcases hbranch with ⟨code, _hmem, hcode⟩
+    cases code <;> simp [SelectedScanBranch.branch] at hcode
+    · subst branch
+      exact Or.inl rfl
+    · subst branch
+      exact Or.inr (Or.inl rfl)
+    · subst branch
+      exact Or.inr (Or.inr rfl)
+  · intro hbranch
+    rcases hbranch with hbranch | hbranch
+    · subst branch
+      exact
+        ⟨SelectedScanBranch.coarseTrace,
+          by simp [selectedScanOrder],
+          rfl⟩
+    · rcases hbranch with hbranch | hbranch
+      · subst branch
+        exact
+          ⟨SelectedScanBranch.refinedTrace,
+            by simp [selectedScanOrder],
+            rfl⟩
+      · subst branch
+        exact
+          ⟨SelectedScanBranch.refinedRepairFrontier,
+            by simp [selectedScanOrder],
+            rfl⟩
+
+/-- The supplied selected scan order lists every selected branch code. -/
+theorem selectedScanOrder_covers
+    (code : SelectedScanBranch) :
+    code ∈ selectedScanOrder := by
+  cases code <;> simp [selectedScanOrder]
+
+/-- A selected scan branch is hit by a repair support. -/
+def selectedScanBranchHit
+    (support : HandoffRepairSupport) :
+    SelectedScanBranch -> Prop
+  | SelectedScanBranch.coarseTrace => support BridgeComponent.trace
+  | SelectedScanBranch.refinedTrace => support BridgeComponent.trace
+  | SelectedScanBranch.refinedRepairFrontier =>
+      support BridgeComponent.repairFrontier
+
+/-- Branch-code hit predicates are decidable when the component support is decidable. -/
+instance selectedScanBranchHit_decidable
+    (support : HandoffRepairSupport)
+    [DecidablePred support]
+    (code : SelectedScanBranch) :
+    Decidable (selectedScanBranchHit support code) := by
+  cases code <;>
+    simp [selectedScanBranchHit] <;>
+    infer_instance
+
+/-- Hitting the selected branch code is the same as hitting its exchange branch. -/
+theorem selectedScanBranchHit_iff_exchangeHit
+    (support : HandoffRepairSupport)
+    (code : SelectedScanBranch) :
+    selectedScanBranchHit support code <->
+      exists component,
+        SelectedScanBranch.branch code component /\ support component.2 := by
+  cases code
+  · constructor
+    · intro htrace
+      exact
+        ⟨(ExchangeSide.coarse, BridgeComponent.trace),
+          ⟨rfl, rfl⟩,
+          htrace⟩
+    · intro hhit
+      rcases hhit with ⟨component, hbranch, htouched⟩
+      rcases component with ⟨side, component⟩
+      rcases hbranch with ⟨_hside, hcomponent⟩
+      have hcomponentTrace :
+          component = BridgeComponent.trace := by
+        simpa [SelectedScanBranch.branch, coarseTraceExchangeBranch,
+          liftBranchToExchangeSide, traceBranch, singletonRepairSupport]
+          using hcomponent
+      subst component
+      exact htouched
+  · constructor
+    · intro htrace
+      exact
+        ⟨(ExchangeSide.refined, BridgeComponent.trace),
+          ⟨rfl, rfl⟩,
+          htrace⟩
+    · intro hhit
+      rcases hhit with ⟨component, hbranch, htouched⟩
+      rcases component with ⟨side, component⟩
+      rcases hbranch with ⟨_hside, hcomponent⟩
+      have hcomponentTrace :
+          component = BridgeComponent.trace := by
+        simpa [SelectedScanBranch.branch, refinedTraceExchangeBranch,
+          liftBranchToExchangeSide, traceBranch, singletonRepairSupport]
+          using hcomponent
+      subst component
+      exact htouched
+  · constructor
+    · intro hrepair
+      exact
+        ⟨(ExchangeSide.refined, BridgeComponent.repairFrontier),
+          ⟨rfl, rfl⟩,
+          hrepair⟩
+    · intro hhit
+      rcases hhit with ⟨component, hbranch, htouched⟩
+      rcases component with ⟨side, component⟩
+      rcases hbranch with ⟨_hside, hcomponent⟩
+      have hcomponentRepair :
+          component = BridgeComponent.repairFrontier := by
+        simpa [SelectedScanBranch.branch,
+          refinedRepairFrontierExchangeBranch,
+          liftBranchToExchangeSide, repairFrontierBranch,
+          singletonRepairSupport] using hcomponent
+      subst component
+      exact htouched
+
+/-- All listed selected branch codes are hit by the support. -/
+def ListedSelectedBranchesHit
+    (support : HandoffRepairSupport)
+    (codes : List SelectedScanBranch) : Prop :=
+  forall code, code ∈ codes -> selectedScanBranchHit support code
+
+/-- First missed selected branch code in the supplied order. -/
+def firstMissedSelectedBranch?
+    (support : HandoffRepairSupport)
+    [DecidablePred support] :
+    List SelectedScanBranch -> Option SelectedScanBranch
+  | [] => none
+  | code :: rest =>
+      if selectedScanBranchHit support code then
+        firstMissedSelectedBranch? support rest
+      else
+        some code
+
+/-- A returned selected residual is a member of the supplied order. -/
+theorem firstMissedSelectedBranch?_some_mem
+    (support : HandoffRepairSupport)
+    [DecidablePred support] :
+    forall {codes : List SelectedScanBranch} {code : SelectedScanBranch},
+      firstMissedSelectedBranch? support codes = some code ->
+        code ∈ codes
+  | [], _code, hsome => by
+      cases hsome
+  | head :: rest, code, hsome => by
+      by_cases hhead : selectedScanBranchHit support head
+      · have htail :
+            firstMissedSelectedBranch? support rest = some code := by
+          simpa [firstMissedSelectedBranch?, hhead] using hsome
+        exact List.mem_cons_of_mem head
+          (firstMissedSelectedBranch?_some_mem support htail)
+      · have hcode : code = head := by
+          simpa [firstMissedSelectedBranch?, hhead] using hsome.symm
+        subst hcode
+        simp
+
+/-- A returned selected residual is really missed by the supplied support. -/
+theorem firstMissedSelectedBranch?_some_missed
+    (support : HandoffRepairSupport)
+    [DecidablePred support] :
+    forall {codes : List SelectedScanBranch} {code : SelectedScanBranch},
+      firstMissedSelectedBranch? support codes = some code ->
+        Not (selectedScanBranchHit support code)
+  | [], _code, hsome => by
+      cases hsome
+  | head :: rest, code, hsome => by
+      by_cases hhead : selectedScanBranchHit support head
+      · have htail :
+            firstMissedSelectedBranch? support rest = some code := by
+          simpa [firstMissedSelectedBranch?, hhead] using hsome
+        exact firstMissedSelectedBranch?_some_missed support htail
+      · have hcode : code = head := by
+          simpa [firstMissedSelectedBranch?, hhead] using hsome.symm
+        subst hcode
+        exact hhead
+
+/-- The selected scan returns none exactly when all listed selected codes are hit. -/
+theorem firstMissedSelectedBranch?_none_iff_listedHits
+    (support : HandoffRepairSupport)
+    [DecidablePred support] :
+    forall codes,
+      firstMissedSelectedBranch? support codes = none <->
+        ListedSelectedBranchesHit support codes
+  | [] => by
+      constructor
+      · intro _ code hmem
+        cases hmem
+      · intro _
+        rfl
+  | head :: rest => by
+      constructor
+      · intro hnone code hmem
+        by_cases hhead : selectedScanBranchHit support head
+        · have htail :
+              firstMissedSelectedBranch? support rest = none := by
+            simpa [firstMissedSelectedBranch?, hhead] using hnone
+          cases hmem with
+          | head =>
+              exact hhead
+          | tail _ hlisted =>
+              exact
+                ((firstMissedSelectedBranch?_none_iff_listedHits
+                  support rest).mp htail) code hlisted
+        · have hsome :
+              firstMissedSelectedBranch? support (head :: rest) =
+                some head := by
+            simp [firstMissedSelectedBranch?, hhead]
+          rw [hsome] at hnone
+          cases hnone
+      · intro hall
+        have hhead : selectedScanBranchHit support head := hall head (by simp)
+        have htail :
+            ListedSelectedBranchesHit support rest := by
+          intro code hmem
+          exact hall code (by simp [hmem])
+        have htailNone :
+            firstMissedSelectedBranch? support rest = none :=
+          (firstMissedSelectedBranch?_none_iff_listedHits
+            support rest).mpr htail
+        simp [firstMissedSelectedBranch?, hhead, htailNone]
+
+/-! ## Exact residual criterion for selected exchange transversality -/
+
+/--
+The selected scan has no residual exactly when the selected exchange branch
+family is hit by the declared support.
+-/
+theorem firstMissedSelectedBranch?_none_iff_transversal
+    (support : HandoffRepairSupport)
+    [DecidablePred support] :
+    firstMissedSelectedBranch? support selectedScanOrder = none <->
+      ExchangeBranchRepairTransversal
+        selectedBasisExchangeFamily support := by
+  constructor
+  · intro hnone branch hbranch
+    have hall :
+        ListedSelectedBranchesHit support selectedScanOrder :=
+      (firstMissedSelectedBranch?_none_iff_listedHits
+        support selectedScanOrder).mp hnone
+    rcases hbranch with hbranch | hbranch
+    · subst branch
+      exact
+        (selectedScanBranchHit_iff_exchangeHit support
+          SelectedScanBranch.coarseTrace).mp
+          (hall SelectedScanBranch.coarseTrace
+            (by simp [selectedScanOrder]))
+    · rcases hbranch with hbranch | hbranch
+      · subst branch
+        exact
+          (selectedScanBranchHit_iff_exchangeHit support
+            SelectedScanBranch.refinedTrace).mp
+            (hall SelectedScanBranch.refinedTrace
+              (by simp [selectedScanOrder]))
+      · subst branch
+        exact
+          (selectedScanBranchHit_iff_exchangeHit support
+            SelectedScanBranch.refinedRepairFrontier).mp
+            (hall SelectedScanBranch.refinedRepairFrontier
+              (by simp [selectedScanOrder]))
+  · intro htransversal
+    apply
+      (firstMissedSelectedBranch?_none_iff_listedHits
+        support selectedScanOrder).mpr
+    intro code _hmem
+    cases code
+    · exact
+        (selectedScanBranchHit_iff_exchangeHit support
+          SelectedScanBranch.coarseTrace).mpr
+          (htransversal coarseTraceExchangeBranch (Or.inl rfl))
+    · exact
+        (selectedScanBranchHit_iff_exchangeHit support
+          SelectedScanBranch.refinedTrace).mpr
+          (htransversal refinedTraceExchangeBranch
+            (Or.inr (Or.inl rfl)))
+    · exact
+        (selectedScanBranchHit_iff_exchangeHit support
+          SelectedScanBranch.refinedRepairFrontier).mpr
+          (htransversal refinedRepairFrontierExchangeBranch
+            (Or.inr (Or.inr rfl)))
+
+/-- The trace-only support first misses the refined repair-frontier branch code. -/
+theorem traceOnly_firstMissedSelectedBranch :
+    firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+      selectedScanOrder =
+        some SelectedScanBranch.refinedRepairFrontier := by
+  simp [firstMissedSelectedBranch?, selectedScanOrder,
+    selectedScanBranchHit, traceOnlyRepairPlan, singletonRepairSupport]
+
+/-- The returned trace-only residual is a selected branch and is missed. -/
+theorem traceOnly_firstMissedSelectedBranch_residual :
+    selectedBasisExchangeFamily
+        (SelectedScanBranch.branch
+          SelectedScanBranch.refinedRepairFrontier) /\
+      ExchangeBranchMissedBySupport
+        (SelectedScanBranch.branch
+          SelectedScanBranch.refinedRepairFrontier)
+        traceOnlyRepairPlan.touched := by
+  constructor
+  · exact Or.inr (Or.inr rfl)
+  · exact traceOnly_misses_refinedRepairFrontierExchangeBranch
+
+/--
+Deleting the selector-relative first residual restores trace-only
+transversality for the selected finite family.
+-/
+theorem dropFirstMissed_restores_traceOnlyTransversal :
+    firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+        selectedScanOrder =
+          some SelectedScanBranch.refinedRepairFrontier /\
+      ExchangeBranchRepairTransversal
+        (exchangeBranchFamilyDrops selectedBasisExchangeFamily
+          (SelectedScanBranch.branch
+            SelectedScanBranch.refinedRepairFrontier))
+        traceOnlyRepairPlan.touched := by
+  exact
+    ⟨traceOnly_firstMissedSelectedBranch,
+      by
+        simpa [SelectedScanBranch.branch, reflectedSelectedBranchFamily,
+          reflectedRepairFrontierSingleton]
+          using dropRefinedRepairFrontier_restores_traceOnlyTransversal⟩
+
+/-! ## Visible-equivalent kernel pair -/
+
+/-- Selector code for the collapsed visible branch. -/
+inductive CollapsedVisibleScanBranch where
+  | collapsed
+deriving DecidableEq
+
+/-- Interpret the collapsed visible code as its exchange branch. -/
+def CollapsedVisibleScanBranch.branch :
+    CollapsedVisibleScanBranch -> ExchangeBranchSupport
+  | CollapsedVisibleScanBranch.collapsed => collapsedVisibleExchangeBranch
+
+/-- The singleton visible scan order for the collapsed reading. -/
+def collapsedVisibleScanOrder : List CollapsedVisibleScanBranch :=
+  [CollapsedVisibleScanBranch.collapsed]
+
+/-- The collapsed visible branch is hit when trace or repair-frontier is hit. -/
+def collapsedVisibleScanBranchHit
+    (support : HandoffRepairSupport) :
+    CollapsedVisibleScanBranch -> Prop
+  | CollapsedVisibleScanBranch.collapsed =>
+      support BridgeComponent.trace \/
+        support BridgeComponent.repairFrontier
+
+/-- Collapsed visible hit predicates are decidable when the support is decidable. -/
+instance collapsedVisibleScanBranchHit_decidable
+    (support : HandoffRepairSupport)
+    [DecidablePred support]
+    (code : CollapsedVisibleScanBranch) :
+    Decidable (collapsedVisibleScanBranchHit support code) := by
+  cases code
+  change
+    Decidable
+      (support BridgeComponent.trace \/
+        support BridgeComponent.repairFrontier)
+  infer_instance
+
+/-- First missed branch for the collapsed visible reading. -/
+def firstMissedCollapsedVisibleBranch?
+    (support : HandoffRepairSupport)
+    [DecidablePred support] :
+    List CollapsedVisibleScanBranch -> Option CollapsedVisibleScanBranch
+  | [] => none
+  | code :: rest =>
+      if collapsedVisibleScanBranchHit support code then
+        firstMissedCollapsedVisibleBranch? support rest
+      else
+        some code
+
+/-- The trace-only support has no residual for the collapsed visible reading. -/
+theorem collapsedVisible_firstMissedBranch_traceOnly :
+    firstMissedCollapsedVisibleBranch? traceOnlyRepairPlan.touched
+      collapsedVisibleScanOrder = none := by
+  simp [firstMissedCollapsedVisibleBranch?,
+    collapsedVisibleScanOrder, collapsedVisibleScanBranchHit,
+    traceOnlyRepairPlan, singletonRepairSupport]
+
+/--
+Selected and collapsed readings have the same visible component union, but the
+selector scan returns different residual behavior for trace-only repair.
+-/
+theorem visibleEquivalent_residualKernelPair :
+    (forall component,
+      ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+        ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+      firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+        selectedScanOrder =
+          some SelectedScanBranch.refinedRepairFrontier /\
+      firstMissedCollapsedVisibleBranch? traceOnlyRepairPlan.touched
+        collapsedVisibleScanOrder = none := by
+  exact
+    ⟨selected_collapsed_same_visibleUnion,
+      traceOnly_firstMissedSelectedBranch,
+      collapsedVisible_firstMissedBranch_traceOnly⟩
+
+/--
+The visible component-union projection is not faithful to the branch scan
+kernel: the visible-equivalent selected and collapsed readings differ on the
+trace-only residual scan.
+-/
+theorem visibleUnion_not_faithful_to_branchScanKernel :
+    (forall component,
+      ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+        ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+      firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+        selectedScanOrder =
+          some SelectedScanBranch.refinedRepairFrontier /\
+      firstMissedCollapsedVisibleBranch? traceOnlyRepairPlan.touched
+        collapsedVisibleScanOrder = none /\
+      Not
+        (ExchangeBranchRepairTransversal
+          selectedBasisExchangeFamily traceOnlyRepairPlan.touched) /\
+      ExchangeBranchRepairTransversal
+        collapsedVisibleExchangeFamily traceOnlyRepairPlan.touched := by
+  exact
+    ⟨selected_collapsed_same_visibleUnion,
+      traceOnly_firstMissedSelectedBranch,
+      collapsedVisible_firstMissedBranch_traceOnly,
+      traceOnly_not_hits_selectedBasisExchange,
+      traceOnly_hits_collapsedVisibleExchange⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-72 theorem package: selected path-indexed repair obligations have a
+selector-relative scan kernel, and visible component union cannot recover the
+kernel residual.
+-/
+theorem branchTransversalScanKernel_package :
+    (forall branch,
+      selectedScanBranchFamily branch <->
+        selectedBasisExchangeFamily branch) /\
+      (forall (support : HandoffRepairSupport) [DecidablePred support],
+        firstMissedSelectedBranch? support selectedScanOrder = none <->
+          ExchangeBranchRepairTransversal
+            selectedBasisExchangeFamily support) /\
+      (firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+        selectedScanOrder =
+          some SelectedScanBranch.refinedRepairFrontier) /\
+      (selectedBasisExchangeFamily
+          (SelectedScanBranch.branch
+            SelectedScanBranch.refinedRepairFrontier) /\
+        ExchangeBranchMissedBySupport
+          (SelectedScanBranch.branch
+            SelectedScanBranch.refinedRepairFrontier)
+          traceOnlyRepairPlan.touched) /\
+      ExchangeBranchRepairTransversal
+        (exchangeBranchFamilyDrops selectedBasisExchangeFamily
+          (SelectedScanBranch.branch
+            SelectedScanBranch.refinedRepairFrontier))
+        traceOnlyRepairPlan.touched /\
+      ((forall component,
+        ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+          ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+        firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+          selectedScanOrder =
+            some SelectedScanBranch.refinedRepairFrontier /\
+        firstMissedCollapsedVisibleBranch? traceOnlyRepairPlan.touched
+          collapsedVisibleScanOrder = none /\
+        Not
+          (ExchangeBranchRepairTransversal
+            selectedBasisExchangeFamily traceOnlyRepairPlan.touched) /\
+        ExchangeBranchRepairTransversal
+          collapsedVisibleExchangeFamily traceOnlyRepairPlan.touched) := by
+  exact
+    ⟨selectedScanBranchFamily_complete,
+      firstMissedSelectedBranch?_none_iff_transversal,
+      traceOnly_firstMissedSelectedBranch,
+      traceOnly_firstMissedSelectedBranch_residual,
+      dropFirstMissed_restores_traceOnlyTransversal.2,
+      visibleUnion_not_faithful_to_branchScanKernel⟩
+
+end BranchTransversalScanKernel
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-branch-transversal-scan-kernel.md
+++ b/research/ideas/g-aat-quality-surface-01-branch-transversal-scan-kernel.md
@@ -1,0 +1,214 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: computability
+capability_category: computability / repair-potential / certificate-transport / obstruction / quality-surface
+expected_base_score: 80
+expected_evidence_multiplier: 2.0
+expected_final_score: 160
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance checkers can report visible repair failures, but this candidate computes the selected path-indexed residual branch and deletion/restoration witness inside certificate geometry.
+origin: G1-cycle72
+tags: [quality-surface, computability, branch-transversal, residual, repair]
+created: 2026-06-21
+cycle: 72
+lean: Formal/AG/Research/QualitySurface/BranchTransversalScanKernel.lean
+genius_potential: no
+genius_target: none
+genius_support_role: none
+---
+
+# Selector-relative branch-transversal scan kernel
+
+## 主張
+
+For the selected finite repair/refinement exchange family, branch-transversal
+clearance can be read by a selector-code scan kernel.  The kernel scans a fixed
+ordered list of selected path-indexed branch codes against a declared repair
+support, returns an `Option` residual code for the first missed branch when one
+exists, and proves that the absence of a residual branch is equivalent to
+hitting every selected exchange branch.
+
+The selected trace-only witness has a concrete residual: the refined
+repair-frontier exchange branch.  Deleting that canonical residual from the
+selected finite family restores trace-only transversality.  This is a
+selector-relative finite deletion/restoration theorem, not a global minimality
+or canonical repair theorem.
+
+The same visible component-union projection that forgets branch incidence
+cannot recover the scan kernel residual.  The theorem package must include a
+kernel pair: two visible-equivalent finite readings whose scan residuals differ
+because one reading keeps the selected path-indexed branch codes and the other
+uses the collapsed visible branch.  The theorem package remains inside finite
+AAT certificate geometry: it does not assert runtime repair synthesis, source
+extraction completeness, ArchMap correctness, arbitrary route enumeration,
+global sheaf completeness, or whole-codebase quality.
+
+## 候補種別
+
+`computability`: Cycle 70/71 の branch-transversal nonfaithfulness を、失敗を計算して返す finite scan kernel に変える。
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/CurvatureBasisExchange.lean`
+- `Formal/AG/Research/QualitySurface/NaiveRefinementSupportCounterexample.lean`
+- Cycle 70 path-indexed curvature basis exchange.
+- Cycle 71 selected branch-reflection failure for naive refinement readings.
+
+## 非自明性
+
+This is not the definition of `ExchangeBranchRepairTransversal` unfolded.  It
+also is not just the route-slot scan pattern from Cycles 55/56 copied to a new
+type.  The new content is that the scan target is the selected
+repair/refinement exchange family, the returned object is a protected
+path-indexed branch residual, and the visible component-union projection is
+proved unable to recover that residual.  The candidate must expose an ordered
+computational object:
+
+1. selector codes that enumerate exactly the selected exchange branches,
+2. an ordered `Option` first-missed residual selector over those codes,
+3. an empty-residual iff theorem for branch transversality,
+4. a concrete trace-only residual, and
+5. deletion/restoration for the selected finite family,
+6. a visible-equivalent kernel pair with different residual behavior.
+
+The point is to turn the no-go examples into a residual-producing kernel that
+can be reused by later projection and refinement transport theorems.
+
+## 数学的興味
+
+The repair obligation becomes a finite obstruction scan rather than a bare
+proposition.  Obstruction, residual branch, deletion, restoration, and visible
+projection loss are represented in one finite certificate object.
+
+## GOAL への前進
+
+This adds a computability layer to atom-supported quality geometry: selected
+repair failure is not only detected but localized to a path-indexed residual
+branch.
+
+## ライバルに対する有効性
+
+ADL / conformance tools and metric dashboards can report violated constraints
+or component-level failures.  They do not, by default, return the selected
+path-indexed branch residual whose deletion/restoration explains the repair
+obligation inside certificate geometry.  This candidate makes that residual
+Lean-checkable.
+
+## SCORE 見込み
+
+- `score_reason`: computability result that converts Cycle 70/71 projection-loss and branch-reflection failures into a residual-producing finite kernel.  G2 strictness reduced the base from 88 to 80 because the repo already has generic ordered scan machinery; the score is carried by the branch-specific selector enumeration, concrete residual, deletion/restoration, and visible-equivalent kernel pair.
+- `dullness_risk`: real.  If the evidence only restates `ExchangeBranchRepairTransversal` or merely ports the earlier route-slot scan API, the score should drop.  The Lean proof must include selector-code enumeration, an `Option` first-missed selector, a concrete trace-only residual, deletion/restoration, and a visible-equivalent kernel pair whose residual behavior differs.
+- `proof_or_evidence_plan`: completed in `Formal/AG/Research/QualitySurface/BranchTransversalScanKernel.lean`.
+
+## CS / SWE への帰結
+
+This provides the mathematical form of a loss-aware repair diagnostic kernel:
+an external surface may display a compact view, but the AAT certificate layer
+can name the residual protected branch that blocks repair clearance.  Any
+tooling use would remain relative to an ArchMap / evidence contract and is not
+claimed here.
+
+## 証明・根拠
+
+Lean will reuse the selected exchange branch family from Cycle 70 and the
+trace-only witness from Cycle 71.  The proved statements are:
+
+- `SelectedScanBranch`: finite selector codes for the selected exchange branches.
+- `selectedScanBranchFamily_complete`: selector codes enumerate exactly the selected basis-exchange family.
+- `firstMissedSelectedBranch?`: ordered residual selector.
+- `firstMissedSelectedBranch?_none_iff_transversal`: no residual iff selected branch transversality.
+- `traceOnly_firstMissedSelectedBranch`: trace-only residual is the refined repair-frontier branch.
+- `dropFirstMissed_restores_traceOnlyTransversal`: deleting the residual restores trace-only transversality.
+- `collapsedVisible_firstMissedBranch_traceOnly`: the collapsed visible reading has no residual under trace-only repair.
+- `visibleEquivalent_residualKernelPair`: selected and collapsed readings have the same visible union but different scan residual behavior.
+- `visibleUnion_not_faithful_to_branchScanKernel`: visible union does not determine the scan residual.
+- `branchTransversalScanKernel_package`: theorem package.
+
+## Lean evidence
+
+Lean proves:
+
+- `SelectedScanBranch`: selector codes for the selected path-indexed exchange branches.
+- `SelectedScanBranch.branch`: interpretation of selector codes as exchange branches.
+- `selectedScanOrder`: the finite selected branch-code order.
+- `selectedScanBranchFamily_complete`: selector codes enumerate exactly `selectedBasisExchangeFamily`.
+- `selectedScanOrder_covers`: every selector code appears in the selected order.
+- `selectedScanBranchHit_iff_exchangeHit`: branch-code hit is equivalent to hitting the interpreted exchange branch.
+- `firstMissedSelectedBranch?`: ordered `Option` residual selector.
+- `firstMissedSelectedBranch?_some_mem`: returned residual codes are listed.
+- `firstMissedSelectedBranch?_some_missed`: returned residual codes are genuinely missed.
+- `firstMissedSelectedBranch?_none_iff_listedHits`: no residual iff all listed selector codes are hit.
+- `firstMissedSelectedBranch?_none_iff_transversal`: no selected residual iff selected exchange-branch transversality.
+- `traceOnly_firstMissedSelectedBranch`: trace-only repair first misses the refined repair-frontier selector code.
+- `traceOnly_firstMissedSelectedBranch_residual`: the returned residual is selected and missed.
+- `dropFirstMissed_restores_traceOnlyTransversal`: deleting the first missed selected residual restores trace-only transversality for the selected finite family.
+- `CollapsedVisibleScanBranch` and `firstMissedCollapsedVisibleBranch?`: collapsed visible reading and its residual selector.
+- `collapsedVisible_firstMissedBranch_traceOnly`: trace-only repair has no collapsed-visible residual.
+- `visibleEquivalent_residualKernelPair`: selected and collapsed readings have the same visible union but different residual behavior.
+- `visibleUnion_not_faithful_to_branchScanKernel`: visible union is not faithful to the branch scan kernel.
+- `branchTransversalScanKernel_package`: theorem package.
+
+Local checks:
+
+- `lake env lean Formal/AG/Research/QualitySurface/BranchTransversalScanKernel.lean`: pass.
+- `lake build FormalAGResearch`: pass.
+- `lake build`: pass, with only the pre-existing `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warnings.
+- `#print axioms`: selector type, branch interpretation, selected order, hit predicates, both scan functions, and concrete residual predicate are axiom-free.  Selector enumeration, list membership / none-iff proofs, trace-only concrete scan result, deletion/restoration, visible-equivalent kernel pair, nonfaithfulness, and the package use only standard `propext`.  No `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe` was reported.
+
+## 可視 projection
+
+The visible projection remembers the component union that appears somewhere in
+the selected exchange family, but forgets the ordered branch-incidence data
+used by the scan kernel.
+
+## protected_structure
+
+The protected structure is the selected path-indexed branch family together
+with the ordered selector and repair support.
+
+## exactness_or_minimality_claim
+
+Minimality is only selector-relative: the first missed branch in the selected
+ordered list is the canonical residual for that selector, and deleting it
+restores trace-only transversality for this selected finite family.  No global
+minimal repair set or global canonical order is claimed.
+
+## nonfaithfulness_or_failure_mode
+
+The visible component-union projection cannot recover whether the selected
+scan kernel has a residual branch.  Trace-only repair can look adequate after
+visible collapse while the protected scan returns the refined repair-frontier
+branch.
+
+## previous_cycle_delta
+
+Cycle 70 fixed path-indexed branch exchange and visible-union loss.  Cycle 71
+showed that a naive refinement reading can preserve visible union while
+missing branch reflection.  This cycle turns the protected failure into a
+computable residual selector.
+
+## 審判メモ
+
+- 厳密性: revise / base 76 / genius no。claim boundary は良好だが、既存 Cycle 70/71 と Cycles 55/56 の再包装に見えるリスクがある。selector code、`Option` residual、enumeration exactness、same-visible kernel pair を Lean statement に入れることを要求。
+- 研究価値: accept / base 88 / genius no。repair obligation を residual-producing certificate object に上げる点を評価。
+- repo 全体価値: accept / base 84 / genius no。future viewer projection rule の足場になるが、既存 scan 系との差分を明記する必要がある。
+- ライバル比較: accept / base 88 / genius no。ADL / dashboard 的 failure display ではなく path-indexed residual branch と deletion/restoration を証明対象にする点を評価。
+- G2 revise 対応: 候補カードを改訂し、selector-code enumeration、`Option` first-missed residual、visible-equivalent kernel pair、既存 route-slot scan との差分を主張と証明計画へ追加した。
+- G2 厳密性再審判: accept / base 80 / genius no。改訂で G3 へ進めるが、既存 ordered scan machinery があるため base 88 ではなく 80 とする。
+- G3 公理検査: pass。computational objects and concrete residual predicate are axiom-free; Prop-level list / iff wrappers use only standard `propext`.  No `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe`.
+- G3 形式化品質監査: pass。generic scan recursion の新規性は限定的だが、exact selector enumeration、selected transversality iff, concrete trace-only residual, deletion/restoration, and visible-equivalent selected/collapsed residual kernel pair が候補主張を十分に表している。
+- G4 SCORE 監査: confirm / base 80 / multiplier 2.0 / penalty 0 / final +160。Total は 9634 から 9794 へ進む。G2 全員が genius no のため genius scoring は not-applicable。
+
+## 関連
+
+- `g-aat-quality-surface-01-curvature-basis-exchange.md`
+- `g-aat-quality-surface-01-naive-refinement-support-counterexample.md`
+
+## 進捗ログ
+
+- 2026-06-21: Cycle 72 の picked 候補として作成。G2 へ進める。
+- 2026-06-21: G2 厳密性 revise を受け、ordered selector code と visible-equivalent residual kernel pair を必須証拠に追加。
+- 2026-06-21: `BranchTransversalScanKernel.lean` を追加し、selector-relative branch-transversal scan kernel として Lean 検証済みに同期。
+- 2026-06-21: G3 公理検査と形式化品質監査を通過。
+- 2026-06-21: G4 SCORE 監査で final +160 を confirm。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 9634
+- total SCORE: 9794
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -76,8 +76,9 @@
   - obstruction / minimality / repair-potential / certificate-transport / quality-surface / computability: 168
   - profile-curvature / certificate-transport / repair-potential / obstruction / minimality / quality-surface / unification: 168
   - obstruction / invariance / minimality / certificate-transport / quality-surface: 136
+  - computability / repair-potential / certificate-transport / obstruction / quality-surface: 160
 - evidence portfolio:
-  - proved-in-research: 71
+  - proved-in-research: 72
 
 ## Phase synthesis
 
@@ -93,7 +94,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-69 件の Lean-proved research artifacts は、次の paper seed を形成している。
+72 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -142,9 +143,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 71 後の total SCORE は 9634 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 72 後の total SCORE は 9794 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 71 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 72 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -3354,3 +3355,59 @@ Cycle 71 後の total SCORE は 9634 であり、threshold 10000 までは残り
 この cycle は positive refinement transport theorem ではなく、その前提不足を固定する no-go result である。
 次 cycle では positive atlas-refinement support transport theorem、viewer projection kernel rule、
 または general exchange-cell family theorem を狙う。
+
+## Cycle 72: Selector-relative branch-transversal scan kernel
+
+```text
+candidate: Selector-relative branch-transversal scan kernel
+candidate_type: computability
+evidence_stage: proved-in-research
+base_score: 80
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 160
+category: computability / repair-potential / certificate-transport / obstruction / quality-surface
+goal_delta: selected repair failure is now a residual-producing finite kernel: the first missed path-indexed branch code is computed and tied back to selected exchange transversality.
+project_value_delta: Converts Cycle 70/71 projection-loss and branch-reflection no-go results into a reusable finite scan object for later viewer projection and refinement transport criteria.
+rival_delta: ADL / conformance dashboards can display visible violations, but they do not determine the selected path-indexed residual branch or prove deletion/restoration inside certificate geometry.
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/BranchTransversalScanKernel.lean`, `lake build FormalAGResearch`, and full `lake build` passed. Full build warning is the pre-existing `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning only. Selector type, branch interpretation, selected order, hit predicates, scan functions, and the concrete residual predicate are axiom-free. Selector enumeration, list / iff wrappers, trace-only concrete scan theorem, deletion/restoration, visible-equivalent kernel pair, nonfaithfulness, and the package use only standard `propext`; no `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe` was reported. G3 formalization audit passed with the caveat that the generic scan recursion itself is not new. G4 confirmed base 80, multiplier 2.0, penalty 0, final +160.
+open_questions: positive atlas-refinement support transport theorem; prefix exactness for branch residual scans; projection kernel minimality beyond the selected pair; general exchange-cell scan family.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/BranchTransversalScanKernel.lean` adds a
+selector-code scan kernel for the selected repair/refinement exchange family.
+The kernel scans a fixed ordered list of selected path-indexed branch codes and
+returns an `Option` residual code for the first missed branch.
+
+Lean proves:
+
+- `selectedScanBranchFamily_complete`: selector codes enumerate exactly `selectedBasisExchangeFamily`.
+- `selectedScanBranchHit_iff_exchangeHit`: hitting a selector code is equivalent to hitting the interpreted exchange branch.
+- `firstMissedSelectedBranch?`: the ordered selected residual selector.
+- `firstMissedSelectedBranch?_some_mem` and `firstMissedSelectedBranch?_some_missed`: returned residual codes are listed and genuinely missed.
+- `firstMissedSelectedBranch?_none_iff_transversal`: no selected residual iff selected exchange-branch transversality.
+- `traceOnly_firstMissedSelectedBranch`: trace-only repair first misses the refined repair-frontier selector code.
+- `traceOnly_firstMissedSelectedBranch_residual`: the returned residual is a selected missed branch.
+- `dropFirstMissed_restores_traceOnlyTransversal`: deleting the first missed selected residual restores trace-only transversality for the selected finite family.
+- `collapsedVisible_firstMissedBranch_traceOnly`: trace-only repair has no residual for the collapsed visible reading.
+- `visibleEquivalent_residualKernelPair`: the selected and collapsed readings have the same visible component-union projection but different residual behavior.
+- `visibleUnion_not_faithful_to_branchScanKernel`: visible union is not faithful to the branch scan kernel.
+- `branchTransversalScanKernel_package`: the finite scan package.
+
+This cycle remains selector-relative.  It does not claim a global canonical
+repair order, global minimality, runtime repair synthesis, source extraction
+completeness, ArchMap correctness, arbitrary route enumeration, global sheaf
+completeness, or whole-codebase quality.  G2 strictness reduced the base score
+from the initial 88 to 80 because the repository already has generic ordered
+scan machinery; the value comes from the branch-specific selector enumeration,
+concrete residual, deletion/restoration, and visible-equivalent kernel pair.
+G2 四審判はいずれも `genius_eligibility: no` を返し、G3 は Lean proof と独立監査を通った。
+
+### Next Frontier
+
+Cycle 72 後の total SCORE は 9794 であり、threshold 10000 までは残り 206 SCORE である。
+この cycle で residual-producing scan kernel は得たが、positive atlas-refinement support transport theorem は未到達である。
+次 cycle では positive atlas-refinement support transport theorem、branch-reflection adequacy kernel、
+または selected scan prefix exactness / projection-kernel minimality を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 72 として、selected repair/refinement exchange family に対する selector-relative branch-transversal scan kernel を追加する。既存の visible-union / branch-reflection failure を、first missed path-indexed branch を返す finite residual kernel として固定する。

## 証明した定理

- `selectedScanBranchFamily_complete`
- `selectedScanOrder_covers`
- `selectedScanBranchHit_iff_exchangeHit`
- `firstMissedSelectedBranch?_some_mem`
- `firstMissedSelectedBranch?_some_missed`
- `firstMissedSelectedBranch?_none_iff_listedHits`
- `firstMissedSelectedBranch?_none_iff_transversal`
- `traceOnly_firstMissedSelectedBranch`
- `traceOnly_firstMissedSelectedBranch_residual`
- `dropFirstMissed_restores_traceOnlyTransversal`
- `collapsedVisible_firstMissedBranch_traceOnly`
- `visibleEquivalent_residualKernelPair`
- `visibleUnion_not_faithful_to_branchScanKernel`
- `branchTransversalScanKernel_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-branch-transversal-scan-kernel.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/BranchTransversalScanKernel.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` for reported declarations
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue #2348 は継続するため `Refs #2348` にした）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: `proved-in-research`。G4 SCORE 監査は base 80 / multiplier 2.0 / penalty 0 / final +160 を confirm。
