### PR TITLE
研究: branch-reflection adequacy kernel を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -69,3 +69,4 @@ import Formal.AG.Research.QualitySurface.AntichainOverlapBasisTransversal
 import Formal.AG.Research.QualitySurface.CurvatureBasisExchange
 import Formal.AG.Research.QualitySurface.NaiveRefinementSupportCounterexample
 import Formal.AG.Research.QualitySurface.BranchTransversalScanKernel
+import Formal.AG.Research.QualitySurface.BranchReflectionAdequacyKernel

--- a/Formal/AG/Research/QualitySurface/BranchReflectionAdequacyKernel.lean
+++ b/Formal/AG/Research/QualitySurface/BranchReflectionAdequacyKernel.lean
@@ -1,0 +1,315 @@
+import Formal.AG.Research.QualitySurface.BranchTransversalScanKernel
+
+/-!
+Cycle 73 evidence for `G-aat-quality-surface-01`.
+
+This file turns the selected branch-reflection failure and selected residual
+scan into a finite adequacy kernel for refinement support transport.  The
+positive condition is branch-local: a coarse hit witness must lift to a refined
+hit witness.  It does not assume refined transversality, a zero residual scan,
+or selected branch hitting as an input.
+
+The construction remains relative to selected finite exchange branch families,
+declared component repair supports, and the visible component-union projection.
+It does not assert global atlas refinement, canonical refinement transport,
+runtime repair synthesis, source extraction completeness, ArchMap correctness,
+global sheaf completeness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace BranchReflectionAdequacyKernel
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffRepairTransversalTheorem
+open RepairBasinExchangeObstruction
+open CurvatureBasisExchange
+open NaiveRefinementSupportCounterexample
+open BranchTransversalScanKernel
+
+/-! ## Branch-local support-lift adequacy -/
+
+/--
+A coarse branch hit can be transported to a refined branch hit by the declared
+support lift.
+
+This is deliberately weaker than, and distinct from, assuming the refined
+branch family is already transversal: it only consumes a concrete coarse hit
+witness and returns a concrete refined hit witness for the paired branch.
+-/
+def SupportLiftClosedForBranch
+    (coarseBranch refinedBranch : ExchangeBranchSupport)
+    (coarseSupport refinedSupport : HandoffRepairSupport) : Prop :=
+  forall coarseComponent,
+    coarseBranch coarseComponent ->
+      coarseSupport coarseComponent.2 ->
+        exists refinedComponent,
+          refinedBranch refinedComponent /\
+            refinedSupport refinedComponent.2
+
+/--
+A branch-reflection transport kernel is adequate when each refined branch has
+a reflected coarse branch whose hit witnesses lift through the declared support
+pair.
+-/
+def BranchReflectionTransportAdequate
+    (coarseFamily refinedFamily : ExchangeBranchFamily)
+    (coarseSupport refinedSupport : HandoffRepairSupport) : Prop :=
+  forall refinedBranch,
+    refinedFamily refinedBranch ->
+      exists coarseBranch,
+        coarseFamily coarseBranch /\
+          SupportLiftClosedForBranch
+            coarseBranch refinedBranch coarseSupport refinedSupport
+
+/--
+If the branch-reflection kernel is adequate, coarse branch-transversal
+clearance transports to the refined selected family by witness transport.
+-/
+theorem branchReflectionKernel_pass_preservesTransversal
+    {coarseFamily refinedFamily : ExchangeBranchFamily}
+    {coarseSupport refinedSupport : HandoffRepairSupport}
+    (hadequate :
+      BranchReflectionTransportAdequate
+        coarseFamily refinedFamily coarseSupport refinedSupport)
+    (hcoarse :
+      ExchangeBranchRepairTransversal coarseFamily coarseSupport) :
+    ExchangeBranchRepairTransversal refinedFamily refinedSupport := by
+  intro refinedBranch hrefined
+  rcases hadequate refinedBranch hrefined with
+    ⟨coarseBranch, hcoarseBranch, hlift⟩
+  rcases hcoarse coarseBranch hcoarseBranch with
+    ⟨coarseComponent, hcoarseComponent, hcoarseSupport⟩
+  exact hlift coarseComponent hcoarseComponent hcoarseSupport
+
+/-! ## Selected positive pass witness -/
+
+/-- The selected repair support that touches both trace and repair-frontier. -/
+def traceRepairFrontierRepairSupport : HandoffRepairSupport :=
+  fun component =>
+    component = BridgeComponent.trace \/
+      component = BridgeComponent.repairFrontier
+
+/-- The trace / repair-frontier support hits the collapsed visible branch. -/
+theorem traceRepairFrontierSupport_hits_collapsedVisible :
+    ExchangeBranchRepairTransversal
+      collapsedVisibleExchangeFamily traceRepairFrontierRepairSupport := by
+  intro branch hbranch
+  subst branch
+  exact
+    ⟨(ExchangeSide.coarse, BridgeComponent.trace),
+      Or.inl rfl,
+      Or.inl rfl⟩
+
+/--
+The collapsed visible branch is adequate for the selected reflected branch
+family when the declared support touches both trace and repair-frontier.
+-/
+theorem selectedAllExchangeAdequate :
+    BranchReflectionTransportAdequate
+      collapsedVisibleExchangeFamily selectedBasisExchangeFamily
+      traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport := by
+  intro refinedBranch hrefined
+  refine
+    ⟨collapsedVisibleExchangeBranch, rfl, ?_⟩
+  intro _coarseComponent _hcoarseBranch _hcoarseSupport
+  rcases hrefined with hrefined | hrefined
+  · subst refinedBranch
+    exact
+      ⟨(ExchangeSide.coarse, BridgeComponent.trace),
+        ⟨rfl, rfl⟩,
+        Or.inl rfl⟩
+  · rcases hrefined with hrefined | hrefined
+    · subst refinedBranch
+      exact
+        ⟨(ExchangeSide.refined, BridgeComponent.trace),
+          ⟨rfl, rfl⟩,
+          Or.inl rfl⟩
+    · subst refinedBranch
+      exact
+        ⟨(ExchangeSide.refined, BridgeComponent.repairFrontier),
+          ⟨rfl, rfl⟩,
+          Or.inr rfl⟩
+
+/--
+The positive selected pass case: collapsed visible clearance transports to the
+selected branch-reflection family only because the support-lift adequacy
+condition is supplied.
+-/
+theorem allExchangeSupport_transports_selectedReflection :
+    ExchangeBranchRepairTransversal
+      selectedBasisExchangeFamily traceRepairFrontierRepairSupport := by
+  exact
+    branchReflectionKernel_pass_preservesTransversal
+      selectedAllExchangeAdequate
+      traceRepairFrontierSupport_hits_collapsedVisible
+
+/-! ## Failure witness for missing branch reflection -/
+
+/-- A source reading fails to cover a reflected branch required by the target reading. -/
+def BranchReflectionCoverageFailure
+    (source target : ExchangeBranchFamily)
+    (branch : ExchangeBranchSupport) : Prop :=
+  target branch /\ Not (source branch)
+
+/-- The naive reading misses the reflected repair-frontier singleton branch. -/
+theorem reflectedRepairFrontier_coverageFailure :
+    BranchReflectionCoverageFailure
+      naiveRefinementBranchFamily reflectedSelectedBranchFamily
+      reflectedRepairFrontierSingleton := by
+  exact
+    ⟨reflectedSelected_reflects_repairFrontierSingleton,
+      naiveReading_not_reflects_repairFrontierSingleton⟩
+
+/--
+Trace-only support cannot be an adequate transport kernel from the naive
+reading to the reflected selected reading.
+-/
+theorem traceOnly_not_branchReflectionAdequate_naive_to_reflected :
+    Not
+      (BranchReflectionTransportAdequate
+        naiveRefinementBranchFamily reflectedSelectedBranchFamily
+        traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched) := by
+  intro hadequate
+  exact
+    traceOnly_not_hits_reflectedSelectedBranches
+      (branchReflectionKernel_pass_preservesTransversal
+        hadequate traceOnly_hits_naiveRefinementBranches)
+
+/--
+The failure branch is a reflected branch, is missed by trace-only support, and
+blocks adequacy transport from the naive reading.
+-/
+theorem branchReflectionKernel_fail_returnsMissingBranch :
+    BranchReflectionCoverageFailure
+        naiveRefinementBranchFamily reflectedSelectedBranchFamily
+        reflectedRepairFrontierSingleton /\
+      ExchangeBranchMissedBySupport reflectedRepairFrontierSingleton
+        traceOnlyRepairPlan.touched /\
+      Not
+        (BranchReflectionTransportAdequate
+          naiveRefinementBranchFamily reflectedSelectedBranchFamily
+          traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched) := by
+  exact
+    ⟨reflectedRepairFrontier_coverageFailure,
+      traceOnly_misses_refinedRepairFrontierExchangeBranch,
+      traceOnly_not_branchReflectionAdequate_naive_to_reflected⟩
+
+/--
+Visible preservation does not prevent a missing reflected branch from breaking
+transport adequacy.
+-/
+theorem missingReflection_witnessesTransportFailure :
+    (forall component,
+      ExchangeVisibleUnion naiveRefinementBranchFamily component <->
+        ExchangeVisibleUnion reflectedSelectedBranchFamily component) /\
+      BranchReflectionCoverageFailure
+        naiveRefinementBranchFamily reflectedSelectedBranchFamily
+        reflectedRepairFrontierSingleton /\
+      ExchangeBranchRepairTransversal
+        naiveRefinementBranchFamily traceOnlyRepairPlan.touched /\
+      Not
+        (ExchangeBranchRepairTransversal
+          reflectedSelectedBranchFamily traceOnlyRepairPlan.touched) /\
+      Not
+        (BranchReflectionTransportAdequate
+          naiveRefinementBranchFamily reflectedSelectedBranchFamily
+          traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched) := by
+  exact
+    ⟨naiveRefinement_preserves_visibleUnion,
+      reflectedRepairFrontier_coverageFailure,
+      traceOnly_hits_naiveRefinementBranches,
+      traceOnly_not_hits_reflectedSelectedBranches,
+      traceOnly_not_branchReflectionAdequate_naive_to_reflected⟩
+
+/--
+The visible component-union projection is not faithful to the branch-reflection
+adequacy kernel.
+-/
+theorem visibleUnion_not_faithful_to_reflectionAdequacy :
+    (forall component,
+      ExchangeVisibleUnion naiveRefinementBranchFamily component <->
+        ExchangeVisibleUnion reflectedSelectedBranchFamily component) /\
+      ExchangeBranchRepairTransversal
+        naiveRefinementBranchFamily traceOnlyRepairPlan.touched /\
+      Not
+        (ExchangeBranchRepairTransversal
+          reflectedSelectedBranchFamily traceOnlyRepairPlan.touched) /\
+      BranchReflectionCoverageFailure
+        naiveRefinementBranchFamily reflectedSelectedBranchFamily
+        reflectedRepairFrontierSingleton /\
+      Not
+        (BranchReflectionTransportAdequate
+          naiveRefinementBranchFamily reflectedSelectedBranchFamily
+          traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched) := by
+  exact
+    ⟨naiveRefinement_preserves_visibleUnion,
+      traceOnly_hits_naiveRefinementBranches,
+      traceOnly_not_hits_reflectedSelectedBranches,
+      reflectedRepairFrontier_coverageFailure,
+      traceOnly_not_branchReflectionAdequate_naive_to_reflected⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-73 theorem package: branch-reflection transport has a non-tautological
+support-lift pass criterion, while visible-equivalent naive readings still
+return a missing reflected repair-frontier branch.
+-/
+theorem branchReflectionAdequacyKernel_package :
+    (forall {coarseFamily refinedFamily : ExchangeBranchFamily}
+      {coarseSupport refinedSupport : HandoffRepairSupport},
+        BranchReflectionTransportAdequate
+          coarseFamily refinedFamily coarseSupport refinedSupport ->
+        ExchangeBranchRepairTransversal coarseFamily coarseSupport ->
+          ExchangeBranchRepairTransversal refinedFamily refinedSupport) /\
+      BranchReflectionTransportAdequate
+        collapsedVisibleExchangeFamily selectedBasisExchangeFamily
+        traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport /\
+      ExchangeBranchRepairTransversal
+        collapsedVisibleExchangeFamily traceRepairFrontierRepairSupport /\
+      ExchangeBranchRepairTransversal
+        selectedBasisExchangeFamily traceRepairFrontierRepairSupport /\
+      BranchReflectionCoverageFailure
+        naiveRefinementBranchFamily reflectedSelectedBranchFamily
+        reflectedRepairFrontierSingleton /\
+      ExchangeBranchMissedBySupport reflectedRepairFrontierSingleton
+        traceOnlyRepairPlan.touched /\
+      Not
+        (BranchReflectionTransportAdequate
+          naiveRefinementBranchFamily reflectedSelectedBranchFamily
+          traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched) /\
+      ((forall component,
+        ExchangeVisibleUnion naiveRefinementBranchFamily component <->
+          ExchangeVisibleUnion reflectedSelectedBranchFamily component) /\
+        ExchangeBranchRepairTransversal
+          naiveRefinementBranchFamily traceOnlyRepairPlan.touched /\
+        Not
+          (ExchangeBranchRepairTransversal
+            reflectedSelectedBranchFamily traceOnlyRepairPlan.touched) /\
+        BranchReflectionCoverageFailure
+          naiveRefinementBranchFamily reflectedSelectedBranchFamily
+          reflectedRepairFrontierSingleton /\
+        Not
+          (BranchReflectionTransportAdequate
+            naiveRefinementBranchFamily reflectedSelectedBranchFamily
+            traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched)) := by
+  exact
+    ⟨fun {coarseFamily refinedFamily coarseSupport refinedSupport} =>
+        branchReflectionKernel_pass_preservesTransversal
+          (coarseFamily := coarseFamily)
+          (refinedFamily := refinedFamily)
+          (coarseSupport := coarseSupport)
+          (refinedSupport := refinedSupport),
+      selectedAllExchangeAdequate,
+      traceRepairFrontierSupport_hits_collapsedVisible,
+      allExchangeSupport_transports_selectedReflection,
+      reflectedRepairFrontier_coverageFailure,
+      traceOnly_misses_refinedRepairFrontierExchangeBranch,
+      traceOnly_not_branchReflectionAdequate_naive_to_reflected,
+      visibleUnion_not_faithful_to_reflectionAdequacy⟩
+
+end BranchReflectionAdequacyKernel
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-branch-reflection-adequacy-kernel.md
+++ b/research/ideas/g-aat-quality-surface-01-branch-reflection-adequacy-kernel.md
@@ -1,0 +1,182 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: computability
+capability_category: computability / certificate-transport / invariance / repair-potential / obstruction / quality-surface
+expected_base_score: 88
+expected_evidence_multiplier: 2.0
+expected_final_score: 176
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance readings can preserve visible component unions, but they do not provide a branch-local support-lift adequacy kernel that decides when coarse repair transversality transports to refined selected branches.
+origin: cycle-73
+tags: [quality-surface, branch-reflection, repair-transport, adequacy-kernel]
+created: 2026-06-22
+cycle: 73
+lean: proved-in-research
+---
+
+# Branch-reflection adequacy kernel for refinement support transport
+
+## 主張
+
+有限の coarse / refined exchange branch family と declared repair support の組に対して、branch-local な
+support-lift closure を adequacy 条件として定義する。この条件が通るなら、coarse family の
+branch-transversal clearance は refined selected branch family へ transport する。条件が欠ける場合は、
+visible component-union projection が一致していても、reflected repair-frontier singleton を missing branch
+witness として返せる。
+
+ここで support-lift closure は、refined transversality を仮定しない。Lean では次の形で固定する。
+
+```text
+SupportLiftClosedForBranch coarseBranch refinedBranch coarseSupport refinedSupport :=
+  forall coarseComponent,
+    coarseBranch coarseComponent ->
+      coarseSupport coarseComponent.2 ->
+        exists refinedComponent,
+          refinedBranch refinedComponent /\ refinedSupport refinedComponent.2
+
+BranchReflectionTransportAdequate coarseFamily refinedFamily coarseSupport refinedSupport :=
+  forall refinedBranch,
+    refinedFamily refinedBranch ->
+      exists coarseBranch,
+        coarseFamily coarseBranch /\
+          SupportLiftClosedForBranch coarseBranch refinedBranch coarseSupport refinedSupport
+```
+
+したがって pass theorem は、coarse transversality から得た coarse hit witness を、branch-local closure で refined
+hit witness へ移す。refined family がすでに transversal であること、scan residual が none であること、
+selected-family hit が直接成り立つことは仮定しない。
+
+この主張は、選ばれた repair/refinement exchange cell、finite exchange branch family、declared repair support、
+branch-reflection relation に相対化する。global atlas refinement、canonical refinement theorem、runtime repair synthesis、
+source extraction completeness、ArchMap correctness、global sheaf completeness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`computability`
+
+## 依拠
+
+- Cycle 70: `CurvatureBasisExchange.lean` の selected path-indexed exchange branch family と
+  `ExchangeBranchRepairTransversal`。
+- Cycle 71: `NaiveRefinementSupportCounterexample.lean` の visible-union preservation と
+  reflected repair-frontier singleton failure。
+- Cycle 72: `BranchTransversalScanKernel.lean` の selector-relative residual scan と missing branch witness。
+
+## 非自明性
+
+単なる transversality の再命名ではなく、粗い branch の hit witness を refined branch へ移すための
+branch-local support-lift closure を別条件として切り出す。これにより、可視 projection の一致だけでは足りないという
+no-go を、正方向の transport theorem と失敗 witness を返す finite kernel に変える。
+
+## 数学的興味
+
+branch-transversal repair obligation は、component union ではなく branch incidence と repair support の相互作用で決まる。
+この候補は、refinement で何を保持すれば branch-transversal class が移植できるかを、有限 witness を通じて明示する。
+Cycle 71 の反例を「どの仮定が抜けたから失敗したか」に変換し、Cycle 72 の residual kernel を transport adequacy の判定面へ接続する。
+
+## GOAL への前進
+
+Quality Surface の repair/refinement transport 軸に、positive pass theorem と missing-branch failure theorem を持つ
+計算可能な adequacy kernel を追加し、support / repair / obstruction / traceability を一つの finite branch geometry で読む能力を増やす。
+
+## ライバルに対する有効性
+
+ADL、conformance checker、dashboard は refined component set や visible view の一致を扱えるが、branch ごとの repair-support lift
+がないと transversality が transport しないことを同じ artifact 内で証明しにくい。この候補は、可視一致を尊重しつつ、
+ADL view では落ちる branch-local support transport と missing reflected branch を明示的に返す。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 71 の no-go と Cycle 72 の scan kernel を、positive transport / negative witness の二相 kernel に統合するため、80-100 帯の computability / certificate-transport 成果として見込む。ただし selected finite exchange cell の延長なので、通常高得点の 88 点見込みに下げる。
+- `dullness_risk`: adequacy 条件を「refined family が transversal」と同値にしてしまうと自明化する。今回の改訂では、coarse hit witness を refined hit witness へ運ぶ branch-local support-lift closure と具体的 missing branch witness を Lean statement に分けて、このリスクを抑える。
+- `proof_or_evidence_plan`: Research 側 Lean ファイルで `SupportLiftClosedForBranch`、`BranchReflectionTransportAdequate`、pass theorem、selected all-exchange pass witness、naive/reflected failure witness、package theorem を証明する。
+
+## CS / SWE への帰結
+
+refinement 後の repair obligation が移植できるかを、可視 component set の一致ではなく、branch-local support lift と missing branch
+residual の有無として説明できる。これは、既存の構造ビューや conformance view が通っても repair frontier が失われるケースを、
+有限 certificate の判定面として扱うための下地になる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/BranchReflectionAdequacyKernel.lean` に固定した。
+
+- `SupportLiftClosedForBranch`
+- `BranchReflectionTransportAdequate`
+- `branchReflectionKernel_pass_preservesTransversal`
+- `traceRepairFrontierRepairSupport`
+- `traceRepairFrontierSupport_hits_collapsedVisible`
+- `selectedAllExchangeAdequate`
+- `allExchangeSupport_transports_selectedReflection`
+- `BranchReflectionCoverageFailure`
+- `reflectedRepairFrontier_coverageFailure`
+- `traceOnly_not_branchReflectionAdequate_naive_to_reflected`
+- `branchReflectionKernel_fail_returnsMissingBranch`
+- `missingReflection_witnessesTransportFailure`
+- `visibleUnion_not_faithful_to_reflectionAdequacy`
+- `branchReflectionAdequacyKernel_package`
+
+pass theorem は、coarse branch family の各 hit witness を branch-local lift closure で refined branch の hit witness に移す。
+failure theorem は、naive paired reading が visible union を保存して trace-only transversality を受け入れる一方で、
+reflected selected reading が repair-frontier singleton を missing branch として返す有限 witness を使う。
+この failure は既存 scan residual の単なる再掲ではなく、`BranchReflectionCoverageFailure` として
+source reading が reflected branch を含まないことを明示し、そのうえで trace-only support が source family では
+transversal、reflected family では non-transversal になることを同時に示す。
+
+## G2 審判結果
+
+- 厳密性: revise 後 accept。base 86。`SupportLiftClosedForBranch` が refined transversality を仮定しない形になったため非循環な sufficient condition として通る。
+- 研究価値: accept。base 88。no-go を positive adequacy に反転し、pass/fail 判定面を足す。
+- repo 全体価値: accept。base 88。Lean / paper / tooling / website surface に接続する。
+- ライバル比較: accept。base 92。ADL / conformance view が落とす branch-local support transport を示す。
+- genius: 四審判とも `genius_eligibility: no`。通常 SCORE として扱う。
+
+## G3 監査結果
+
+- `lake env lean Formal/AG/Research/QualitySurface/BranchReflectionAdequacyKernel.lean`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: 報告対象 14 declaration はすべて axiom-free。`sorryAx`、非標準公理、`propext`、`Classical.choice`、`Quot.sound`、`unsafe` なし。
+- Lean 形式化品質監査: pass。`BranchReflectionTransportAdequate` は refined transversality、zero residual scan、直接 selected-family hit を仮定していない。failure 側は Cycle 72 scan residual の再掲ではなく、`BranchReflectionCoverageFailure` と transport non-adequacy を追加している。
+
+## G4 SCORE 監査結果
+
+- score_verdict: confirm。
+- base_score: 88。
+- evidence_multiplier: 2.0。
+- penalty: 0。
+- final_score: 176。
+- category: computability / certificate-transport / invariance / repair-potential / obstruction / quality-surface。
+- genius_verdict: downgrade-to-normal。四審判すべて `genius_eligibility: no` なので genius scoring は採らない。
+- total_delta: 9794 -> 9970。active threshold 10000 にはまだ 30 SCORE 不足する。
+
+## 審判メモ
+
+- 厳密性: adequacy 条件が transversality 結論そのものを仮定していないかを確認する。
+- 研究価値: no-go を positive transport criterion へ反転できているかを確認する。
+- repo 全体価値: report の repair/refinement exchange frontier と自然に接続するかを確認する。
+- ライバル比較: ADL / conformance view の visible projection と branch-local support transport の差分が明確かを確認する。
+
+## 追加 required fields
+
+- `mathematical_interest`: branch incidence と repair support lift の相互作用を transport adequacy として切り出す点。
+- `goal_advancement`: repair/refinement transport の pass/fail kernel を finite branch geometry として追加する。
+- `planned_theorem_names`: `SupportLiftClosedForBranch`, `BranchReflectionTransportAdequate`, `branchReflectionKernel_pass_preservesTransversal`, `branchReflectionKernel_fail_returnsMissingBranch`, `visibleUnion_not_faithful_to_reflectionAdequacy`, `branchReflectionAdequacyKernel_package`
+- `visible_projection`: `ExchangeVisibleUnion`。これは preservation されても adequacy を決定しない。
+- `protected_structure`: path-indexed branch incidence, reflected repair-frontier singleton, branch-local support-lift closure。
+- `exactness_or_minimality_claim`: pass 側は branch-local lift closure が hit witness を保存する exact transport condition。fail 側は missing reflected singleton witness。
+- `nonfaithfulness_or_failure_mode`: visible component-union projection は branch-reflection adequacy と repair-transversal transport に faithful ではない。
+- `previous_cycle_delta`: Cycle 71 の selected branch-reflection failure と Cycle 72 の first-missed branch scanを、positive adequacy kernel へ統合する。
+- `genius_potential`: no
+- `genius_target`: none
+- `genius_support_role`: none
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-curvature-basis-exchange.md`
+- `research/ideas/g-aat-quality-surface-01-naive-refinement-support-counterexample.md`
+- `research/ideas/g-aat-quality-surface-01-branch-transversal-scan-kernel.md`
+
+## 進捗ログ
+
+- 2026-06-22: Cycle 73 候補として作成。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 9794
+- total SCORE: 9970
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -77,8 +77,9 @@
   - profile-curvature / certificate-transport / repair-potential / obstruction / minimality / quality-surface / unification: 168
   - obstruction / invariance / minimality / certificate-transport / quality-surface: 136
   - computability / repair-potential / certificate-transport / obstruction / quality-surface: 160
+  - computability / certificate-transport / invariance / repair-potential / obstruction / quality-surface: 176
 - evidence portfolio:
-  - proved-in-research: 72
+  - proved-in-research: 73
 
 ## Phase synthesis
 
@@ -94,7 +95,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-72 件の Lean-proved research artifacts は、次の paper seed を形成している。
+73 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -106,6 +107,7 @@ certificate の基本単位は
 - component support を declared repair clearance の transversal condition として読める。
 - repair/refinement exchange cell では、同じ visible/local projection の下でも coarse trace basin と refined trace-plus-repair-frontier basin の membership が分離しうる。
 - Cech overlap support は exact component basis だけでなく branch incidence を持ち、同じ visible component union でも branch-transversal class が分離しうる。
+- branch-reflection transport は、visible union preservation ではなく branch-local support-lift closure と missing reflected branch witness で判定される。
 
 ### Related-work separation
 
@@ -143,9 +145,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 72 後の total SCORE は 9794 である。
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 73 後の total SCORE は 9970 である。
 現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 72 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 73 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -153,7 +155,8 @@ component support bitset / law minimality matrix、declared repair transversal t
 finite overlap obstruction basis / repair-transversal duality theorem、
 repair/transport Cech commutator curvature theorem、repair-basin exchange obstruction theorem、
 antichain Cech overlap branch-transversal theorem、curvature basis exchange theorem、
-selected branch-reflection failure theorem を含む。
+selected branch-reflection failure theorem、selector-relative branch-transversal scan kernel、
+branch-reflection adequacy kernel を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -3411,3 +3414,58 @@ Cycle 72 後の total SCORE は 9794 であり、threshold 10000 までは残り
 この cycle で residual-producing scan kernel は得たが、positive atlas-refinement support transport theorem は未到達である。
 次 cycle では positive atlas-refinement support transport theorem、branch-reflection adequacy kernel、
 または selected scan prefix exactness / projection-kernel minimality を狙う。
+
+## Cycle 73: Branch-reflection adequacy kernel for refinement support transport
+
+```text
+candidate: Branch-reflection adequacy kernel for refinement support transport
+candidate_type: computability
+evidence_stage: proved-in-research
+base_score: 88
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 176
+category: computability / certificate-transport / invariance / repair-potential / obstruction / quality-surface
+goal_delta: repair/refinement transport gains a finite pass/fail adequacy kernel: branch-local support-lift closure transports coarse branch-transversal clearance to refined selected branches, while missing reflected branches block transport even under visible-union preservation.
+project_value_delta: Converts Cycle 71 branch-reflection no-go and Cycle 72 residual scan into a positive support-lift criterion plus a concrete non-adequacy witness for Quality Surface refinement projection.
+rival_delta: ADL / conformance views can preserve refined component sets and visible unions, but they do not determine branch-local repair-support lift or return the missing reflected repair-frontier branch that blocks repair-transversal transport.
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/BranchReflectionAdequacyKernel.lean` and `lake build FormalAGResearch` passed. The 14 reported declarations are axiom-free; no `sorryAx`, custom axiom, `propext`, `Classical.choice`, `Quot.sound`, or `unsafe` appears in the reported declarations. G3 formalization audit passed. G4 confirmed base 88, multiplier 2.0, penalty 0, final +176.
+open_questions: component-level refinement relation for stronger support lift; executable adequacy checking for arbitrary finite branch families; prefix exactness/minimality for selected residual scans; general atlas-refinement transport theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/BranchReflectionAdequacyKernel.lean`
+adds a branch-local support-lift adequacy condition for finite
+branch-reflection transport.  `SupportLiftClosedForBranch` consumes a concrete
+coarse branch hit witness and returns a concrete refined branch hit witness.
+`BranchReflectionTransportAdequate` pairs every refined branch with a coarse
+branch carrying that closure condition.
+
+Lean proves:
+
+- `branchReflectionKernel_pass_preservesTransversal`: adequate branch-reflection transport plus coarse branch transversality implies refined branch transversality.
+- `traceRepairFrontierSupport_hits_collapsedVisible`: trace / repair-frontier support hits the collapsed visible branch.
+- `selectedAllExchangeAdequate`: the collapsed visible family is adequate for the selected reflected family when support touches both trace and repair-frontier.
+- `allExchangeSupport_transports_selectedReflection`: the selected positive pass witness.
+- `BranchReflectionCoverageFailure`: a source reading can fail to cover a reflected branch required by the target reading.
+- `reflectedRepairFrontier_coverageFailure`: the naive reading misses the reflected repair-frontier singleton.
+- `traceOnly_not_branchReflectionAdequate_naive_to_reflected`: trace-only support cannot be an adequate transport kernel from naive to reflected selected reading.
+- `branchReflectionKernel_fail_returnsMissingBranch`: the reflected repair-frontier singleton is the missing branch witness blocking adequacy.
+- `missingReflection_witnessesTransportFailure`: visible preservation does not prevent missing branch reflection from breaking transport.
+- `visibleUnion_not_faithful_to_reflectionAdequacy`: visible component union is not faithful to branch-reflection adequacy.
+- `branchReflectionAdequacyKernel_package`: the pass/fail theorem package.
+
+This cycle remains a selected finite theorem package.  It does not claim
+global atlas refinement, canonical refinement transport, runtime repair
+synthesis, source extraction completeness, ArchMap correctness, global sheaf
+completeness, or whole-codebase quality.  G2 四審判はいずれも
+`genius_eligibility: no` を返し、G3 は Lean proof と独立監査を通った。
+G4 は通常 SCORE として base 88 を confirm し、genius は通常 SCORE へ戻した。
+
+### Next Frontier
+
+Cycle 73 後の total SCORE は 9970 であり、threshold 10000 までは残り 30 SCORE である。
+点数合わせの小補題ではフェーズ区切りの品質を落とすため、次 cycle では component-level refinement relation を持つ
+stronger support lift、selected residual scan の prefix exactness / minimality、
+または arbitrary finite branch family に近い executable adequacy checking を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 73 として、branch-reflection transport の finite adequacy kernel を追加します。`SupportLiftClosedForBranch` と `BranchReflectionTransportAdequate` を Research 側に置き、coarse branch-transversal clearance が branch-local support-lift closure によって refined selected branch family へ transport することを証明しました。

あわせて、visible component-union preservation だけでは transport adequacy を決められないことを、naive reading が missing reflected repair-frontier singleton を返す finite witness として固定しました。G4 SCORE は +176、total は 9970 / threshold 10000 です。

## 証明した定理

- `SupportLiftClosedForBranch`
- `BranchReflectionTransportAdequate`
- `branchReflectionKernel_pass_preservesTransversal`
- `traceRepairFrontierRepairSupport`
- `traceRepairFrontierSupport_hits_collapsedVisible`
- `selectedAllExchangeAdequate`
- `allExchangeSupport_transports_selectedReflection`
- `BranchReflectionCoverageFailure`
- `reflectedRepairFrontier_coverageFailure`
- `traceOnly_not_branchReflectionAdequate_naive_to_reflected`
- `branchReflectionKernel_fail_returnsMissingBranch`
- `missingReflection_witnessesTransportFailure`
- `visibleUnion_not_faithful_to_reflectionAdequacy`
- `branchReflectionAdequacyKernel_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-branch-reflection-adequacy-kernel.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/BranchReflectionAdequacyKernel.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] private / local path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` for 14 reported declarations: all axiom-free

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
  - tracking Issue のため `Refs #2348` とし、close しない。
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
