### PR TITLE
研究: selected residual scan prefix minimality を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -70,3 +70,4 @@ import Formal.AG.Research.QualitySurface.CurvatureBasisExchange
 import Formal.AG.Research.QualitySurface.NaiveRefinementSupportCounterexample
 import Formal.AG.Research.QualitySurface.BranchTransversalScanKernel
 import Formal.AG.Research.QualitySurface.BranchReflectionAdequacyKernel
+import Formal.AG.Research.QualitySurface.SelectedResidualScanPrefixMinimality

--- a/Formal/AG/Research/QualitySurface/SelectedResidualScanPrefixMinimality.lean
+++ b/Formal/AG/Research/QualitySurface/SelectedResidualScanPrefixMinimality.lean
@@ -1,0 +1,286 @@
+import Formal.AG.Research.QualitySurface.BranchReflectionAdequacyKernel
+
+/-!
+Cycle 74 evidence for `G-aat-quality-surface-01`.
+
+This file strengthens the selected residual scan with selector-relative prefix
+exactness and singleton-deletion minimality.  The result is relative to the
+selected finite scan order, trace-only declared repair support, and collapsed
+visible reading.  It does not assert a global canonical repair order, global
+minimal repair, runtime repair synthesis, source extraction completeness,
+ArchMap correctness, global sheaf completeness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SelectedResidualScanPrefixMinimality
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffRepairTransversalTheorem
+open RepairBasinExchangeObstruction
+open CurvatureBasisExchange
+open NaiveRefinementSupportCounterexample
+open BranchTransversalScanKernel
+
+/-! ## Selector-order prefix exactness -/
+
+/-- The strict prefix relation induced by the selected scan order. -/
+inductive selectedPrefixBefore :
+    SelectedScanBranch -> SelectedScanBranch -> Prop where
+  | coarse_before_refinedTrace :
+      selectedPrefixBefore
+        SelectedScanBranch.coarseTrace SelectedScanBranch.refinedTrace
+  | coarse_before_refinedRepairFrontier :
+      selectedPrefixBefore
+        SelectedScanBranch.coarseTrace
+        SelectedScanBranch.refinedRepairFrontier
+  | refinedTrace_before_refinedRepairFrontier :
+      selectedPrefixBefore
+        SelectedScanBranch.refinedTrace
+        SelectedScanBranch.refinedRepairFrontier
+
+/--
+If the selected scan returns `later`, every selected code before it in the
+selected order is hit by the support.
+-/
+theorem firstMissedSelectedBranch?_some_prefixHit
+    (support : HandoffRepairSupport)
+    [DecidablePred support]
+    {earlier later : SelectedScanBranch}
+    (hscan :
+      firstMissedSelectedBranch? support selectedScanOrder = some later)
+    (hprefix : selectedPrefixBefore earlier later) :
+    selectedScanBranchHit support earlier := by
+  cases hprefix with
+  | coarse_before_refinedTrace =>
+      by_cases hcoarse :
+        selectedScanBranchHit support SelectedScanBranch.coarseTrace
+      · exact hcoarse
+      · simp [selectedScanOrder, firstMissedSelectedBranch?, hcoarse] at hscan
+  | coarse_before_refinedRepairFrontier =>
+      by_cases hcoarse :
+        selectedScanBranchHit support SelectedScanBranch.coarseTrace
+      · exact hcoarse
+      · simp [selectedScanOrder, firstMissedSelectedBranch?, hcoarse] at hscan
+  | refinedTrace_before_refinedRepairFrontier =>
+      by_cases hcoarse :
+        selectedScanBranchHit support SelectedScanBranch.coarseTrace
+      · by_cases hrefined :
+          selectedScanBranchHit support SelectedScanBranch.refinedTrace
+        · exact hrefined
+        · simp [selectedScanOrder, firstMissedSelectedBranch?, hcoarse,
+            hrefined] at hscan
+      · simp [selectedScanOrder, firstMissedSelectedBranch?, hcoarse] at hscan
+
+/--
+For trace-only support, the selected first residual is the refined
+repair-frontier code, every earlier selected code is hit, and the residual is
+missed.
+-/
+theorem traceOnly_firstResidual_prefixExact :
+    firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+        selectedScanOrder =
+          some SelectedScanBranch.refinedRepairFrontier /\
+      (forall code,
+        selectedPrefixBefore code
+            SelectedScanBranch.refinedRepairFrontier ->
+          selectedScanBranchHit traceOnlyRepairPlan.touched code) /\
+      Not
+        (selectedScanBranchHit traceOnlyRepairPlan.touched
+          SelectedScanBranch.refinedRepairFrontier) := by
+  refine
+    ⟨traceOnly_firstMissedSelectedBranch, ?_, ?_⟩
+  · intro code hprefix
+    exact
+      firstMissedSelectedBranch?_some_prefixHit
+        traceOnlyRepairPlan.touched
+        traceOnly_firstMissedSelectedBranch hprefix
+  · exact
+      firstMissedSelectedBranch?_some_missed
+        traceOnlyRepairPlan.touched
+        traceOnly_firstMissedSelectedBranch
+
+/-! ## Singleton-deletion minimality for the selected trace-only witness -/
+
+/-- Drop the branch interpreted by one selected scan code. -/
+def dropSelectedScanBranch
+    (code : SelectedScanBranch) : ExchangeBranchFamily :=
+  exchangeBranchFamilyDrops selectedBasisExchangeFamily
+    (SelectedScanBranch.branch code)
+
+theorem refinedRepairFrontier_ne_coarseTraceBranch :
+    SelectedScanBranch.branch SelectedScanBranch.refinedRepairFrontier ≠
+      SelectedScanBranch.branch SelectedScanBranch.coarseTrace := by
+  intro hsame
+  have hfrontier :
+      SelectedScanBranch.branch SelectedScanBranch.refinedRepairFrontier
+        (ExchangeSide.refined, BridgeComponent.repairFrontier) := by
+    exact ⟨rfl, rfl⟩
+  have hcoarse :
+      SelectedScanBranch.branch SelectedScanBranch.coarseTrace
+        (ExchangeSide.refined, BridgeComponent.repairFrontier) := by
+    simpa [hsame] using hfrontier
+  rcases hcoarse with ⟨hside, _hcomponent⟩
+  cases hside
+
+theorem refinedRepairFrontier_ne_refinedTraceBranch :
+    SelectedScanBranch.branch SelectedScanBranch.refinedRepairFrontier ≠
+      SelectedScanBranch.branch SelectedScanBranch.refinedTrace := by
+  intro hsame
+  have hfrontier :
+      SelectedScanBranch.branch SelectedScanBranch.refinedRepairFrontier
+        (ExchangeSide.refined, BridgeComponent.repairFrontier) := by
+    exact ⟨rfl, rfl⟩
+  have htrace :
+      SelectedScanBranch.branch SelectedScanBranch.refinedTrace
+        (ExchangeSide.refined, BridgeComponent.repairFrontier) := by
+    simpa [hsame] using hfrontier
+  rcases htrace with ⟨_hside, hcomponent⟩
+  cases hcomponent
+
+/-- Dropping the earlier coarse trace branch does not restore trace-only transversality. -/
+theorem traceOnly_dropCoarseTrace_not_restore_selectedTransversal :
+    Not
+      (ExchangeBranchRepairTransversal
+        (dropSelectedScanBranch SelectedScanBranch.coarseTrace)
+        traceOnlyRepairPlan.touched) := by
+  intro htransversal
+  rcases
+      htransversal
+        (SelectedScanBranch.branch
+          SelectedScanBranch.refinedRepairFrontier)
+        ⟨Or.inr (Or.inr rfl),
+          refinedRepairFrontier_ne_coarseTraceBranch⟩ with
+    ⟨component, hcomponent, htouched⟩
+  exact traceOnly_misses_refinedRepairFrontierExchangeBranch
+    component hcomponent htouched
+
+/-- Dropping the earlier refined trace branch does not restore trace-only transversality. -/
+theorem traceOnly_dropRefinedTrace_not_restore_selectedTransversal :
+    Not
+      (ExchangeBranchRepairTransversal
+        (dropSelectedScanBranch SelectedScanBranch.refinedTrace)
+        traceOnlyRepairPlan.touched) := by
+  intro htransversal
+  rcases
+      htransversal
+        (SelectedScanBranch.branch
+          SelectedScanBranch.refinedRepairFrontier)
+        ⟨Or.inr (Or.inr rfl),
+          refinedRepairFrontier_ne_refinedTraceBranch⟩ with
+    ⟨component, hcomponent, htouched⟩
+  exact traceOnly_misses_refinedRepairFrontierExchangeBranch
+    component hcomponent htouched
+
+/--
+No selected singleton before the returned residual restores trace-only
+transversality.
+-/
+theorem traceOnly_noEarlierDeletionRestoresSelectedTransversal
+    (code : SelectedScanBranch)
+    (hprefix :
+      selectedPrefixBefore code
+        SelectedScanBranch.refinedRepairFrontier) :
+    Not
+      (ExchangeBranchRepairTransversal
+        (dropSelectedScanBranch code)
+        traceOnlyRepairPlan.touched) := by
+  cases hprefix with
+  | coarse_before_refinedRepairFrontier =>
+      exact traceOnly_dropCoarseTrace_not_restore_selectedTransversal
+  | refinedTrace_before_refinedRepairFrontier =>
+      exact traceOnly_dropRefinedTrace_not_restore_selectedTransversal
+
+/-- Dropping the returned residual branch restores trace-only transversality. -/
+theorem traceOnly_returnedDeletionRestoresSelectedTransversal :
+    ExchangeBranchRepairTransversal
+      (dropSelectedScanBranch SelectedScanBranch.refinedRepairFrontier)
+      traceOnlyRepairPlan.touched := by
+  exact dropFirstMissed_restores_traceOnlyTransversal.2
+
+/-! ## Visible contrast and theorem package -/
+
+/--
+The selected prefix-minimal residual is invisible to the collapsed visible scan.
+-/
+theorem selectedResidualPrefix_visibleContrast :
+    (forall component,
+      ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+        ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+      firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+        selectedScanOrder =
+          some SelectedScanBranch.refinedRepairFrontier /\
+      firstMissedCollapsedVisibleBranch? traceOnlyRepairPlan.touched
+        collapsedVisibleScanOrder = none /\
+      (forall code,
+        selectedPrefixBefore code
+            SelectedScanBranch.refinedRepairFrontier ->
+          selectedScanBranchHit traceOnlyRepairPlan.touched code) /\
+      Not
+        (selectedScanBranchHit traceOnlyRepairPlan.touched
+          SelectedScanBranch.refinedRepairFrontier) /\
+      (forall code,
+        selectedPrefixBefore code
+            SelectedScanBranch.refinedRepairFrontier ->
+          Not
+            (ExchangeBranchRepairTransversal
+              (dropSelectedScanBranch code)
+              traceOnlyRepairPlan.touched)) /\
+      ExchangeBranchRepairTransversal
+        (dropSelectedScanBranch SelectedScanBranch.refinedRepairFrontier)
+        traceOnlyRepairPlan.touched := by
+  exact
+    ⟨selected_collapsed_same_visibleUnion,
+      traceOnly_firstMissedSelectedBranch,
+      collapsedVisible_firstMissedBranch_traceOnly,
+      traceOnly_firstResidual_prefixExact.2.1,
+      traceOnly_firstResidual_prefixExact.2.2,
+      traceOnly_noEarlierDeletionRestoresSelectedTransversal,
+      traceOnly_returnedDeletionRestoresSelectedTransversal⟩
+
+/--
+Cycle-74 theorem package: the selected first residual is prefix-exact and
+selector-minimal for singleton deletion restoration in the selected trace-only
+witness, while the collapsed visible scan cannot recover it.
+-/
+theorem selectedResidualScanPrefixMinimality_package :
+    (firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+        selectedScanOrder =
+          some SelectedScanBranch.refinedRepairFrontier) /\
+      (forall code,
+        selectedPrefixBefore code
+            SelectedScanBranch.refinedRepairFrontier ->
+          selectedScanBranchHit traceOnlyRepairPlan.touched code) /\
+      Not
+        (selectedScanBranchHit traceOnlyRepairPlan.touched
+          SelectedScanBranch.refinedRepairFrontier) /\
+      (forall code,
+        selectedPrefixBefore code
+            SelectedScanBranch.refinedRepairFrontier ->
+          Not
+            (ExchangeBranchRepairTransversal
+              (dropSelectedScanBranch code)
+              traceOnlyRepairPlan.touched)) /\
+      ExchangeBranchRepairTransversal
+        (dropSelectedScanBranch SelectedScanBranch.refinedRepairFrontier)
+        traceOnlyRepairPlan.touched /\
+      ((forall component,
+        ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+          ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+        firstMissedSelectedBranch? traceOnlyRepairPlan.touched
+          selectedScanOrder =
+            some SelectedScanBranch.refinedRepairFrontier /\
+        firstMissedCollapsedVisibleBranch? traceOnlyRepairPlan.touched
+          collapsedVisibleScanOrder = none) := by
+  exact
+    ⟨traceOnly_firstResidual_prefixExact.1,
+      traceOnly_firstResidual_prefixExact.2.1,
+      traceOnly_firstResidual_prefixExact.2.2,
+      traceOnly_noEarlierDeletionRestoresSelectedTransversal,
+      traceOnly_returnedDeletionRestoresSelectedTransversal,
+      visibleEquivalent_residualKernelPair⟩
+
+end SelectedResidualScanPrefixMinimality
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-selected-residual-scan-prefix-minimality.md
+++ b/research/ideas/g-aat-quality-surface-01-selected-residual-scan-prefix-minimality.md
@@ -1,0 +1,149 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: computability / minimality / obstruction / repair-potential / certificate-transport / quality-surface
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance dashboards can show an ordered failure row, but they do not prove that the returned protected branch is prefix-exact, genuinely missed, and the minimal selected deletion that restores branch-transversal repair.
+origin: cycle-74
+tags: [quality-surface, residual-scan, prefix-exactness, minimality]
+created: 2026-06-22
+cycle: 74
+lean: proved-in-research
+---
+
+# Prefix-minimal residual scan theorem for selected branch diagnostics
+
+## 主張
+
+Cycle 72 の selected branch scan に、prefix exactness と selector-relative minimal restoration を追加する。
+`firstMissedSelectedBranch?` が residual code を返すとき、その code の前方 prefix はすべて hit 済みであり、
+returned code は genuinely missed である。選ばれた trace-only witness では、前方 branch を削除しても
+selected transversality は回復せず、returned residual branch を削除したときだけ trace-only transversality が回復する。
+
+この主張は、選ばれた finite selected scan order、path-indexed exchange branch family、trace-only declared support、
+collapsed visible reading に相対化する。global canonical repair order、global minimality、runtime repair synthesis、
+source extraction completeness、ArchMap correctness、global sheaf completeness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- Cycle 72: `BranchTransversalScanKernel.lean` の selected scan、first missed residual、selected/collapsed visible nonfaithfulness。
+- Cycle 73: `BranchReflectionAdequacyKernel.lean` の missing reflected branch と transport adequacy obstruction。
+
+## 非自明性
+
+単なる `some_mem` / `some_missed` の再掲ではなく、returned residual の前方 prefix がすべて hit 済みであること、
+そして selected trace-only witness で earlier deletion では restoration せず returned deletion で restoration することを
+同じ package にまとめる。これにより residual scan を viewer の first failure 表示ではなく、repair-transversal obstruction の
+prefix-minimal certificate として読める。
+
+## 数学的興味
+
+ordered finite branch family に対して、最初の residual は diagnostic order に相対化した境界点である。
+前方 prefix は clear 済み、returned branch は missed、returned branch の削除だけが selected trace-only transversality を戻す。
+この「prefix exactness + restoration minimality」が、branch scan を単なる list traversal から obstruction certificate に変える。
+
+## GOAL への前進
+
+Quality Surface の computability / repair-potential 軸に、selected residual scan の exact explanation を追加する。
+Cycle 72 の residual kernel と Cycle 73 の missing branch obstruction を、phase report で使える prefix-minimal diagnostic theorem として閉じる。
+
+## ライバルに対する有効性
+
+ADL / conformance / dashboard は failure list や first failing row を返せるが、その row が path-indexed branch obligation の
+prefix-minimal obstruction であり、前方 branches は hit 済みで、returned protected branch の deletion が restoration になることは
+通常 theorem として持たない。この候補は first failure display を AAT 側の証明付き repair-transversal diagnostic に持ち上げる。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 72/73 の scan / missing branch machineryを prefix exactness と restoration minimality で閉じる。G2 は prefix 性自体が既存 scan recursion に近いと見たため、通常 SCORE の base 60 見込みへ下げる。
+- `dullness_risk`: `firstMissedSelectedBranch?_some_mem` や `some_missed` の焼き直しに落ちると低価値。trace-only selected witness で earlier deletion non-restoration と returned deletion restoration を含め、residual の diagnostic 意味を強める。
+- `proof_or_evidence_plan`: Research 側 Lean ファイルで prefix-before predicate、generic prefix-hit theorem、trace-only prefix exactness、earlier deletion non-restoration、returned deletion restoration、visible collapsed contrast、package theorem を証明する。
+
+## CS / SWE への帰結
+
+UI や report で first residual marker を出すとき、それが単なる最初に見つかった行ではなく、selected order に相対化した
+prefix-exact obstruction certificate であると言える。visible collapsed reading では residual が消えるため、AAT 側で保つべき
+protected scan payload の意味も明確になる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SelectedResidualScanPrefixMinimality.lean` に固定した。
+
+- `selectedPrefixBefore`
+- `firstMissedSelectedBranch?_some_prefixHit`
+- `traceOnly_firstResidual_prefixExact`
+- `dropSelectedScanBranch`
+- `refinedRepairFrontier_ne_coarseTraceBranch`
+- `refinedRepairFrontier_ne_refinedTraceBranch`
+- `traceOnly_dropCoarseTrace_not_restore_selectedTransversal`
+- `traceOnly_dropRefinedTrace_not_restore_selectedTransversal`
+- `traceOnly_noEarlierDeletionRestoresSelectedTransversal`
+- `traceOnly_returnedDeletionRestoresSelectedTransversal`
+- `selectedResidualPrefix_visibleContrast`
+- `selectedResidualScanPrefixMinimality_package`
+
+## G2 審判結果
+
+- 厳密性: accept。base 60。境界は selected finite scan order と trace-only witness に相対化されている。prefix exactness 自体は recursion に近いため、no-earlier-deletion / returned-deletion restoration が価値の条件。
+- 研究価値: accept。base 52。主定理級ではないが、selected residual を prefix-exact obstruction certificate として閉じる診断意味論として有効。
+- repo 全体価値: accept。base 64。Lean / paper seed と future viewer projection rule に接続する。
+- ライバル比較: accept。base 72。dashboard の first-failing row ではなく、protected residual と deletion/restoration semantics を持つ点で有効。
+- genius: 四審判とも `genius_eligibility: no`。
+
+## G3 監査結果
+
+- `lake env lean Formal/AG/Research/QualitySurface/SelectedResidualScanPrefixMinimality.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SelectedResidualScanPrefixMinimality`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: `selectedPrefixBefore`, `dropSelectedScanBranch`, branch inequality lemmas、earlier deletion non-restoration、no-earlier-deletion theorem は axiom-free。`firstMissedSelectedBranch?_some_prefixHit`, `traceOnly_firstResidual_prefixExact`, `traceOnly_returnedDeletionRestoresSelectedTransversal`, `selectedResidualPrefix_visibleContrast`, `selectedResidualScanPrefixMinimality_package` は標準 `propext` のみ。`sorryAx`、custom axiom、`Classical.choice`、`Quot.sound`、`unsafe` なし。
+- Lean 形式化品質監査: pass。minimality は selector-relative singleton deletion に限定されており、global minimality は主張していない。`selectedPrefixBefore` は固定 selected order の inductive relation であり、将来の可変 scan order には別途 list-based predicate が必要。
+
+## G4 SCORE 監査結果
+
+- score_verdict: confirm。
+- base_score: 60。
+- evidence_multiplier: 2.0。
+- penalty: 0。
+- final_score: 120。
+- category: computability / minimality / obstruction / repair-potential / certificate-transport / quality-surface。
+- genius_verdict: downgrade-to-normal。四審判すべて `genius_eligibility: no` なので genius scoring は採らない。
+- total_delta: 9970 -> 10090。active threshold 10000 に到達する。
+
+## 審判メモ
+
+- 厳密性: prefix exactness が generic recursion の単なる再命名に落ちていないか。selected trace-only witness の restoration minimality が Lean statement に入っているか。
+- 研究価値: phase boundary 直前の小補題ではなく、residual scan の diagnostic 意味を強めているか。
+- repo 全体価値: report / future viewer projection rule に自然に接続するか。
+- ライバル比較: first failing row を返す dashboard との差分が theorem-level prefix/minimality にあるか。
+
+## 追加 required fields
+
+- `mathematical_interest`: ordered finite branch scan の returned residual を prefix-minimal obstruction certificate として読む点。
+- `goal_advancement`: residual-producing scan kernel を exact diagnostic theorem へ進める。
+- `planned_theorem_names`: `firstMissedSelectedBranch?_some_prefixHit`, `traceOnly_firstResidual_prefixExact`, `traceOnly_noEarlierDeletionRestoresSelectedTransversal`, `traceOnly_returnedDeletionRestoresSelectedTransversal`, `selectedResidualScanPrefixMinimality_package`
+- `visible_projection`: collapsed visible scan / visible component-union projection。これは selected prefix residual を復元しない。
+- `protected_structure`: selected scan order, path-indexed branch code, prefix hit certificate, first missed residual, deletion/restoration witness。
+- `exactness_or_minimality_claim`: selector-relative singleton deletion minimality。returned residual の前方 prefix は exact に hit 済みで、selected trace-only witness では前方 singleton deletion は restoration せず returned singleton deletion が restoration する。global minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: collapsed visible scan は residual none だが、selected protected scan は refined repair-frontier branch を prefix-minimal residual として返す。
+- `previous_cycle_delta`: Cycle 72 の selected residual scan と Cycle 73 の missing branch obstruction を、prefix-minimal diagnostic theorem として閉じる。
+- `genius_potential`: no
+- `genius_target`: none
+- `genius_support_role`: none
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-branch-transversal-scan-kernel.md`
+- `research/ideas/g-aat-quality-surface-01-branch-reflection-adequacy-kernel.md`
+
+## 進捗ログ
+
+- 2026-06-22: Cycle 74 候補として作成。
+- 2026-06-22: G2 四審判は accept。base は A=60, B=52, C=64, D=72。全員 `genius_eligibility: no`。期待値を base 60 / final 120 へ下方修正し、minimality scope を selector-relative singleton deletion に限定。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 9970
+- total SCORE: 10090
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -78,8 +78,9 @@
   - obstruction / invariance / minimality / certificate-transport / quality-surface: 136
   - computability / repair-potential / certificate-transport / obstruction / quality-surface: 160
   - computability / certificate-transport / invariance / repair-potential / obstruction / quality-surface: 176
+  - computability / minimality / obstruction / repair-potential / certificate-transport / quality-surface: 120
 - evidence portfolio:
-  - proved-in-research: 73
+  - proved-in-research: 74
 
 ## Phase synthesis
 
@@ -95,7 +96,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-73 件の Lean-proved research artifacts は、次の paper seed を形成している。
+74 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -108,6 +109,7 @@ certificate の基本単位は
 - repair/refinement exchange cell では、同じ visible/local projection の下でも coarse trace basin と refined trace-plus-repair-frontier basin の membership が分離しうる。
 - Cech overlap support は exact component basis だけでなく branch incidence を持ち、同じ visible component union でも branch-transversal class が分離しうる。
 - branch-reflection transport は、visible union preservation ではなく branch-local support-lift closure と missing reflected branch witness で判定される。
+- selected residual scan の returned branch は selector-relative prefix exactness と singleton-deletion restoration semantics を持つ。
 
 ### Related-work separation
 
@@ -145,9 +147,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 ### Phase result
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
-その後、tracking Issue の active threshold は 10000 に更新され、Cycle 73 後の total SCORE は 9970 である。
-現在の 10000 threshold には未達であり、tracking Issue は open のまま継続する。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 73 件持ち、
+その後、tracking Issue の active threshold は 10000 に更新され、Cycle 74 後の total SCORE は 10090 である。
+現在の 10000 threshold には到達した。tracking Issue は phase summary と人間判断のため open のまま残す。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 74 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -156,7 +158,7 @@ finite overlap obstruction basis / repair-transversal duality theorem、
 repair/transport Cech commutator curvature theorem、repair-basin exchange obstruction theorem、
 antichain Cech overlap branch-transversal theorem、curvature basis exchange theorem、
 selected branch-reflection failure theorem、selector-relative branch-transversal scan kernel、
-branch-reflection adequacy kernel を含む。
+branch-reflection adequacy kernel、selected residual scan prefix-minimality theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -3469,3 +3471,54 @@ Cycle 73 後の total SCORE は 9970 であり、threshold 10000 までは残り
 点数合わせの小補題ではフェーズ区切りの品質を落とすため、次 cycle では component-level refinement relation を持つ
 stronger support lift、selected residual scan の prefix exactness / minimality、
 または arbitrary finite branch family に近い executable adequacy checking を狙う。
+
+## Cycle 74: Prefix-minimal residual scan theorem for selected branch diagnostics
+
+```text
+candidate: Prefix-minimal residual scan theorem for selected branch diagnostics
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: computability / minimality / obstruction / repair-potential / certificate-transport / quality-surface
+goal_delta: selected residual scan gains prefix-exact diagnostic semantics: earlier selected branches are hit, earlier singleton deletions do not restore trace-only selected transversality, and deleting the returned residual branch does restore it.
+project_value_delta: Closes the Cycle 72/73 residual-scan frontier as a selector-relative minimal repair certificate for the phase report, while leaving general finite branch checking and component-level refinement to the next phase.
+rival_delta: ADL / conformance dashboards can show a first failing row, but this result proves a protected path-indexed residual with prefix-hit and deletion/restoration semantics that visible collapsed readings cannot recover.
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SelectedResidualScanPrefixMinimality.lean`, `lake build Formal.AG.Research.QualitySurface.SelectedResidualScanPrefixMinimality`, and `lake build FormalAGResearch` passed. Several core finite witness declarations are axiom-free; package/prefix declarations use standard `propext` only. No `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe` was reported. G3 formalization audit passed. G4 confirmed base 60, multiplier 2.0, penalty 0, final +120.
+open_questions: list-based prefix predicate for variable scan orders; executable adequacy checking for arbitrary finite branch families; component-level refinement relation / stronger support lift theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SelectedResidualScanPrefixMinimality.lean`
+adds selector-relative prefix exactness and singleton-deletion minimality for
+the selected residual scan.  `selectedPrefixBefore` fixes the strict prefix
+relation for the selected scan order.  The theorem package is scoped to the
+selected trace-only finite witness and does not claim global repair minimality.
+
+Lean proves:
+
+- `firstMissedSelectedBranch?_some_prefixHit`: if the selected scan returns a later code, every selected code before it is hit.
+- `traceOnly_firstResidual_prefixExact`: trace-only support returns the refined repair-frontier residual, hits every earlier selected code, and misses the returned residual.
+- `dropSelectedScanBranch`: selector-relative singleton branch deletion.
+- `traceOnly_dropCoarseTrace_not_restore_selectedTransversal`: deleting the earlier coarse trace branch does not restore trace-only selected transversality.
+- `traceOnly_dropRefinedTrace_not_restore_selectedTransversal`: deleting the earlier refined trace branch does not restore trace-only selected transversality.
+- `traceOnly_noEarlierDeletionRestoresSelectedTransversal`: no selected singleton deletion before the returned residual restores transversality.
+- `traceOnly_returnedDeletionRestoresSelectedTransversal`: deleting the returned refined repair-frontier residual restores trace-only selected transversality.
+- `selectedResidualPrefix_visibleContrast`: the selected prefix-minimal residual is invisible to the collapsed visible scan.
+- `selectedResidualScanPrefixMinimality_package`: the prefix-exactness, singleton-deletion minimality, and visible contrast package.
+
+This cycle remains selector-relative.  It does not assert a global canonical
+repair order, global minimal repair, runtime repair synthesis, source
+extraction completeness, ArchMap correctness, global sheaf completeness, or
+whole-codebase quality.  G2 四審判はいずれも `genius_eligibility: no` を返し、
+G3 は Lean proof と独立監査を通った。G4 は通常 SCORE として base 60 を
+confirm し、genius は通常 SCORE へ戻した。
+
+### Phase Boundary Status
+
+Cycle 74 後の total SCORE は 10090 であり、active threshold 10000 に到達した。
+portfolio constraint は満たしており、report は coherent な paper seed として読める。
+tracking Issue は open のまま、G6 phase-boundary judgment と phase summary へ進む。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 74 として、selected residual scan の prefix exactness と selector-relative singleton deletion minimality を追加します。`firstMissedSelectedBranch?` が返す residual を、単なる scan result ではなく、前方 selected branch が hit 済みで、前方 singleton deletion では trace-only selected transversality が復元せず、returned residual deletion では復元する protected diagnostic certificate として固定しました。

G4 SCORE は +120、total は 10090 / threshold 10000 です。tracking Issue は phase summary と人間判断のため閉じません。

## 証明した定理

- `selectedPrefixBefore`
- `firstMissedSelectedBranch?_some_prefixHit`
- `traceOnly_firstResidual_prefixExact`
- `dropSelectedScanBranch`
- `refinedRepairFrontier_ne_coarseTraceBranch`
- `refinedRepairFrontier_ne_refinedTraceBranch`
- `traceOnly_dropCoarseTrace_not_restore_selectedTransversal`
- `traceOnly_dropRefinedTrace_not_restore_selectedTransversal`
- `traceOnly_noEarlierDeletionRestoresSelectedTransversal`
- `traceOnly_returnedDeletionRestoresSelectedTransversal`
- `selectedResidualPrefix_visibleContrast`
- `selectedResidualScanPrefixMinimality_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-selected-residual-scan-prefix-minimality.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SelectedResidualScanPrefixMinimality.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SelectedResidualScanPrefixMinimality`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] private / local path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` for reported declarations: core finite witness declarations axiom-free; package/prefix declarations use standard `propext` only; no `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe`

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
  - tracking Issue のため `Refs #2348` とし、close しない。
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
