### PR TITLE
研究: 任意有限branch adequacy checkerを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -71,3 +71,4 @@ import Formal.AG.Research.QualitySurface.NaiveRefinementSupportCounterexample
 import Formal.AG.Research.QualitySurface.BranchTransversalScanKernel
 import Formal.AG.Research.QualitySurface.BranchReflectionAdequacyKernel
 import Formal.AG.Research.QualitySurface.SelectedResidualScanPrefixMinimality
+import Formal.AG.Research.QualitySurface.ArbitraryBranchFamilyAdequacy

--- a/Formal/AG/Research/QualitySurface/ArbitraryBranchFamilyAdequacy.lean
+++ b/Formal/AG/Research/QualitySurface/ArbitraryBranchFamilyAdequacy.lean
@@ -1,0 +1,555 @@
+import Formal.AG.Research.QualitySurface.BranchReflectionAdequacyKernel
+
+/-!
+Cycle 75 evidence for `G-aat-quality-surface-01`.
+
+This file lifts the selected residual scan and branch-reflection adequacy kernel
+to a finite branch-code checker.  The checker is deliberately relative to a
+supplied finite target order that exactly enumerates the target family and to a
+decidable coverage predicate.  It does not assert a canonical global branch
+order, runtime repair synthesis, source extraction completeness, ArchMap
+correctness, global sheaf completeness, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ArbitraryBranchFamilyAdequacy
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffRepairTransversalTheorem
+open RepairBasinExchangeObstruction
+open CurvatureBasisExchange
+open NaiveRefinementSupportCounterexample
+open BranchTransversalScanKernel
+open BranchReflectionAdequacyKernel
+
+/-! ## Finite target-order adequacy checker -/
+
+/--
+A supplied finite target order exactly enumerates a target branch family.
+The checker is complete only relative to this enumeration hypothesis.
+-/
+def TargetOrderEnumerates
+    {TargetCode : Type}
+    (targetFamily : ExchangeBranchFamily)
+    (targetOrder : List TargetCode)
+    (branchOf : TargetCode -> ExchangeBranchSupport) : Prop :=
+  (forall code, code ∈ targetOrder -> targetFamily (branchOf code)) /\
+    (forall branch,
+      targetFamily branch ->
+        exists code, code ∈ targetOrder /\ branchOf code = branch)
+
+/-- All listed target codes are covered by the supplied coverage predicate. -/
+def ListedTargetCodesCovered
+    {TargetCode : Type}
+    (covered : TargetCode -> Prop)
+    (targetOrder : List TargetCode) : Prop :=
+  forall code, code ∈ targetOrder -> covered code
+
+/--
+A target code is covered by a source branch when a source branch belongs to the
+source family and its hit witness can be lifted to the target branch.
+-/
+def CodeReflectionCovered
+    {TargetCode : Type}
+    (sourceFamily : ExchangeBranchFamily)
+    (sourceSupport targetSupport : HandoffRepairSupport)
+    (branchOf : TargetCode -> ExchangeBranchSupport)
+    (code : TargetCode) : Prop :=
+  exists sourceBranch,
+    sourceFamily sourceBranch /\
+      SupportLiftClosedForBranch
+        sourceBranch (branchOf code) sourceSupport targetSupport
+
+/-- Family-level reflection adequacy is the existing branch-reflection kernel. -/
+abbrev BranchFamilyReflectionAdequate
+    (sourceFamily targetFamily : ExchangeBranchFamily)
+    (sourceSupport targetSupport : HandoffRepairSupport) : Prop :=
+  BranchReflectionTransportAdequate
+    sourceFamily targetFamily sourceSupport targetSupport
+
+/-- First target code in the supplied order not covered by `covered`. -/
+def firstUncoveredTargetBranch?
+    {TargetCode : Type}
+    (covered : TargetCode -> Prop)
+    [DecidablePred covered] :
+    List TargetCode -> Option TargetCode
+  | [] => none
+  | code :: rest =>
+      if covered code then
+        firstUncoveredTargetBranch? covered rest
+      else
+        some code
+
+/-- A returned target code belongs to the supplied target order. -/
+theorem firstUncoveredTargetBranch?_some_mem
+    {TargetCode : Type}
+    (covered : TargetCode -> Prop)
+    [DecidablePred covered] :
+    forall {targetOrder : List TargetCode} {code : TargetCode},
+      firstUncoveredTargetBranch? covered targetOrder = some code ->
+        code ∈ targetOrder
+  | [], _code, hsome => by
+      cases hsome
+  | head :: rest, code, hsome => by
+      by_cases hhead : covered head
+      · have htail :
+            firstUncoveredTargetBranch? covered rest = some code := by
+          simpa [firstUncoveredTargetBranch?, hhead] using hsome
+        exact List.mem_cons_of_mem head
+          (firstUncoveredTargetBranch?_some_mem covered htail)
+      · have hcode : code = head := by
+          simpa [firstUncoveredTargetBranch?, hhead] using hsome.symm
+        subst hcode
+        simp
+
+/-- A returned target code is genuinely uncovered. -/
+theorem firstUncoveredTargetBranch?_some_uncovered
+    {TargetCode : Type}
+    (covered : TargetCode -> Prop)
+    [DecidablePred covered] :
+    forall {targetOrder : List TargetCode} {code : TargetCode},
+      firstUncoveredTargetBranch? covered targetOrder = some code ->
+        Not (covered code)
+  | [], _code, hsome => by
+      cases hsome
+  | head :: rest, code, hsome => by
+      by_cases hhead : covered head
+      · have htail :
+            firstUncoveredTargetBranch? covered rest = some code := by
+          simpa [firstUncoveredTargetBranch?, hhead] using hsome
+        exact firstUncoveredTargetBranch?_some_uncovered covered htail
+      · have hcode : code = head := by
+          simpa [firstUncoveredTargetBranch?, hhead] using hsome.symm
+        subst hcode
+        exact hhead
+
+/--
+A returned target code is listed, belongs to the target family under an exact
+target-order enumeration, and is genuinely uncovered.
+-/
+theorem firstUncoveredTargetBranch?_some_witness
+    {TargetCode : Type}
+    {targetFamily : ExchangeBranchFamily}
+    {targetOrder : List TargetCode}
+    {branchOf : TargetCode -> ExchangeBranchSupport}
+    {covered : TargetCode -> Prop}
+    [DecidablePred covered]
+    (henum : TargetOrderEnumerates targetFamily targetOrder branchOf)
+    {code : TargetCode}
+    (hsome :
+      firstUncoveredTargetBranch? covered targetOrder = some code) :
+    code ∈ targetOrder /\
+      targetFamily (branchOf code) /\
+        Not (covered code) := by
+  have hmem :
+      code ∈ targetOrder :=
+    firstUncoveredTargetBranch?_some_mem covered hsome
+  exact
+    ⟨hmem,
+      henum.1 code hmem,
+      firstUncoveredTargetBranch?_some_uncovered covered hsome⟩
+
+/-- The checker returns `none` exactly when every listed target code is covered. -/
+theorem firstUncoveredTargetBranch?_none_iff_listedAdequate
+    {TargetCode : Type}
+    (covered : TargetCode -> Prop)
+    [DecidablePred covered] :
+    forall targetOrder,
+      firstUncoveredTargetBranch? covered targetOrder = none <->
+        ListedTargetCodesCovered covered targetOrder
+  | [] => by
+      constructor
+      · intro _ code hmem
+        cases hmem
+      · intro _
+        rfl
+  | head :: rest => by
+      constructor
+      · intro hnone code hmem
+        by_cases hhead : covered head
+        · have htail :
+            firstUncoveredTargetBranch? covered rest = none := by
+            simpa [firstUncoveredTargetBranch?, hhead] using hnone
+          cases hmem with
+          | head =>
+              exact hhead
+          | tail _ hlisted =>
+              exact
+                ((firstUncoveredTargetBranch?_none_iff_listedAdequate
+                  covered rest).mp htail) code hlisted
+        · have hsome :
+              firstUncoveredTargetBranch? covered (head :: rest) =
+                some head := by
+            simp [firstUncoveredTargetBranch?, hhead]
+          rw [hsome] at hnone
+          cases hnone
+      · intro hall
+        have hhead : covered head := hall head (by simp)
+        have htail :
+            ListedTargetCodesCovered covered rest := by
+          intro code hmem
+          exact hall code (by simp [hmem])
+        have htailNone :
+            firstUncoveredTargetBranch? covered rest = none :=
+          (firstUncoveredTargetBranch?_none_iff_listedAdequate
+            covered rest).mpr htail
+        simp [firstUncoveredTargetBranch?, hhead, htailNone]
+
+/--
+Listed support-lift coverage plus target-order exactness gives full
+family-level branch-reflection adequacy.
+-/
+theorem listedCoverage_gives_branchFamilyAdequacy
+    {TargetCode : Type}
+    {targetFamily sourceFamily : ExchangeBranchFamily}
+    {targetOrder : List TargetCode}
+    {branchOf : TargetCode -> ExchangeBranchSupport}
+    {sourceSupport targetSupport : HandoffRepairSupport}
+    (henum : TargetOrderEnumerates targetFamily targetOrder branchOf)
+    (hlisted :
+      ListedTargetCodesCovered
+        (CodeReflectionCovered
+          sourceFamily sourceSupport targetSupport branchOf)
+        targetOrder) :
+    BranchFamilyReflectionAdequate
+      sourceFamily targetFamily sourceSupport targetSupport := by
+  intro targetBranch htarget
+  rcases henum.2 targetBranch htarget with ⟨code, hmem, hcode⟩
+  rcases hlisted code hmem with ⟨sourceBranch, hsource, hlift⟩
+  exact ⟨sourceBranch, hsource, by simpa [hcode] using hlift⟩
+
+/--
+With an exact target order, `none` is equivalent to full family-level adequacy.
+-/
+theorem firstUncoveredTargetBranch?_none_iff_adequate
+    {TargetCode : Type}
+    {targetFamily sourceFamily : ExchangeBranchFamily}
+    {targetOrder : List TargetCode}
+    {branchOf : TargetCode -> ExchangeBranchSupport}
+    {sourceSupport targetSupport : HandoffRepairSupport}
+    [DecidablePred
+      (CodeReflectionCovered
+        sourceFamily sourceSupport targetSupport branchOf)]
+    (henum : TargetOrderEnumerates targetFamily targetOrder branchOf) :
+    firstUncoveredTargetBranch?
+        (CodeReflectionCovered
+          sourceFamily sourceSupport targetSupport branchOf)
+        targetOrder = none <->
+      BranchFamilyReflectionAdequate
+        sourceFamily targetFamily sourceSupport targetSupport := by
+  constructor
+  · intro hnone
+    exact
+      listedCoverage_gives_branchFamilyAdequacy henum
+        ((firstUncoveredTargetBranch?_none_iff_listedAdequate
+          (CodeReflectionCovered
+            sourceFamily sourceSupport targetSupport branchOf)
+          targetOrder).mp hnone)
+  · intro hadequate
+    apply
+      (firstUncoveredTargetBranch?_none_iff_listedAdequate
+        (CodeReflectionCovered
+          sourceFamily sourceSupport targetSupport branchOf)
+        targetOrder).mpr
+    intro code hmem
+    exact
+      hadequate (branchOf code) (henum.1 code hmem)
+
+/-- Adequacy transports source branch-transversal clearance to the target. -/
+theorem branchFamilyAdequacy_transportsTransversal
+    {sourceFamily targetFamily : ExchangeBranchFamily}
+    {sourceSupport targetSupport : HandoffRepairSupport}
+    (hadequate :
+      BranchFamilyReflectionAdequate
+        sourceFamily targetFamily sourceSupport targetSupport)
+    (hsource :
+      ExchangeBranchRepairTransversal sourceFamily sourceSupport) :
+    ExchangeBranchRepairTransversal targetFamily targetSupport := by
+  exact branchReflectionKernel_pass_preservesTransversal hadequate hsource
+
+/-! ## Selected finite stress test -/
+
+/-- Trace-only support covers the selected trace branches but not repair-frontier. -/
+def selectedTraceOnlyCoveredByCollapsed :
+    SelectedScanBranch -> Prop
+  | SelectedScanBranch.coarseTrace => True
+  | SelectedScanBranch.refinedTrace => True
+  | SelectedScanBranch.refinedRepairFrontier => False
+
+instance selectedTraceOnlyCoveredByCollapsed_decidable
+    (code : SelectedScanBranch) :
+    Decidable (selectedTraceOnlyCoveredByCollapsed code) := by
+  cases code
+  · exact isTrue trivial
+  · exact isTrue trivial
+  · exact isFalse (by intro hfalse; exact hfalse)
+
+/-- Trace-only support covers the collapsed visible branch. -/
+def collapsedTraceOnlyCoveredByCollapsed :
+    CollapsedVisibleScanBranch -> Prop :=
+  fun _ => True
+
+instance collapsedTraceOnlyCoveredByCollapsed_decidable
+    (code : CollapsedVisibleScanBranch) :
+    Decidable (collapsedTraceOnlyCoveredByCollapsed code) := by
+  cases code
+  exact isTrue trivial
+
+/-- The selected scan order exactly enumerates the selected exchange family. -/
+theorem selectedTargetOrderEnumerates :
+    TargetOrderEnumerates
+      selectedBasisExchangeFamily selectedScanOrder
+      SelectedScanBranch.branch := by
+  constructor
+  · intro code _hmem
+    cases code
+    · exact Or.inl rfl
+    · exact Or.inr (Or.inl rfl)
+    · exact Or.inr (Or.inr rfl)
+  · intro branch hbranch
+    exact
+      (selectedScanBranchFamily_complete branch).mpr hbranch
+
+/-- The collapsed visible scan order exactly enumerates the collapsed family. -/
+theorem collapsedTargetOrderEnumerates :
+    TargetOrderEnumerates
+      collapsedVisibleExchangeFamily collapsedVisibleScanOrder
+      CollapsedVisibleScanBranch.branch := by
+  constructor
+  · intro code _hmem
+    cases code
+    rfl
+  · intro branch hbranch
+    subst branch
+    exact
+      ⟨CollapsedVisibleScanBranch.collapsed,
+        by simp [collapsedVisibleScanOrder],
+        rfl⟩
+
+/--
+For the selected finite witness, the decidable coverage predicate agrees with
+actual support-lift coverage from the collapsed visible source family.
+-/
+theorem selectedTraceOnlyCoveredByCollapsed_iff_reflection
+    (code : SelectedScanBranch) :
+    selectedTraceOnlyCoveredByCollapsed code <->
+      CodeReflectionCovered
+        collapsedVisibleExchangeFamily
+        traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched
+        SelectedScanBranch.branch code := by
+  cases code
+  · constructor
+    · intro _
+      exact
+        ⟨collapsedVisibleExchangeBranch, rfl,
+          by
+            intro _coarseComponent _hcoarseBranch _hcoarseSupport
+            exact
+              ⟨(ExchangeSide.coarse, BridgeComponent.trace),
+                ⟨rfl, rfl⟩,
+                rfl⟩⟩
+    · intro _
+      trivial
+  · constructor
+    · intro _
+      exact
+        ⟨collapsedVisibleExchangeBranch, rfl,
+          by
+            intro _coarseComponent _hcoarseBranch _hcoarseSupport
+            exact
+              ⟨(ExchangeSide.refined, BridgeComponent.trace),
+                ⟨rfl, rfl⟩,
+                rfl⟩⟩
+    · intro _
+      trivial
+  · constructor
+    · intro hfalse
+      cases hfalse
+    · intro hcovered
+      rcases hcovered with ⟨sourceBranch, hsource, hlift⟩
+      subst sourceBranch
+      rcases
+          hlift (ExchangeSide.coarse, BridgeComponent.trace)
+            (Or.inl rfl) rfl with
+        ⟨targetComponent, htargetBranch, htargetSupport⟩
+      exact
+        traceOnly_misses_refinedRepairFrontierExchangeBranch
+          targetComponent htargetBranch htargetSupport
+
+/-- The selected checker returns the refined repair-frontier residual. -/
+theorem selected_firstUncoveredTargetBranch :
+    firstUncoveredTargetBranch?
+        selectedTraceOnlyCoveredByCollapsed selectedScanOrder =
+      some SelectedScanBranch.refinedRepairFrontier := by
+  simp [firstUncoveredTargetBranch?, selectedScanOrder,
+    selectedTraceOnlyCoveredByCollapsed]
+
+/-- The collapsed checker has no residual for the same trace-only support. -/
+theorem collapsed_firstUncoveredTargetBranch_none :
+    firstUncoveredTargetBranch?
+        collapsedTraceOnlyCoveredByCollapsed collapsedVisibleScanOrder =
+      none := by
+  simp [firstUncoveredTargetBranch?, collapsedVisibleScanOrder,
+    collapsedTraceOnlyCoveredByCollapsed]
+
+/--
+The returned selected residual is listed, is a target branch, and is not
+covered by the reflected support-lift predicate.
+-/
+theorem selected_firstUncoveredTargetBranch_witness :
+    (SelectedScanBranch.refinedRepairFrontier ∈ selectedScanOrder) /\
+      selectedBasisExchangeFamily
+        (SelectedScanBranch.branch
+          SelectedScanBranch.refinedRepairFrontier) /\
+      Not
+        (selectedTraceOnlyCoveredByCollapsed
+          SelectedScanBranch.refinedRepairFrontier) /\
+      Not
+        (CodeReflectionCovered
+          collapsedVisibleExchangeFamily
+          traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched
+          SelectedScanBranch.branch
+          SelectedScanBranch.refinedRepairFrontier) := by
+  exact
+    ⟨by simp [selectedScanOrder],
+      Or.inr (Or.inr rfl),
+      by simp [selectedTraceOnlyCoveredByCollapsed],
+      by
+        intro hcovered
+        exact
+          (selectedTraceOnlyCoveredByCollapsed_iff_reflection
+            SelectedScanBranch.refinedRepairFrontier).mpr hcovered⟩
+
+/--
+Visible component-union projection is not faithful to the arbitrary finite
+adequacy checker: selected and collapsed readings have the same visible union,
+but the selected checker returns a protected residual while the collapsed one
+returns none.
+-/
+theorem visibleUnion_not_faithful_to_arbitraryAdequacyCheck :
+    (forall component,
+      ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+        ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+      firstUncoveredTargetBranch?
+          selectedTraceOnlyCoveredByCollapsed selectedScanOrder =
+        some SelectedScanBranch.refinedRepairFrontier /\
+      firstUncoveredTargetBranch?
+          collapsedTraceOnlyCoveredByCollapsed collapsedVisibleScanOrder =
+        none /\
+      Not
+        (BranchFamilyReflectionAdequate
+          collapsedVisibleExchangeFamily selectedBasisExchangeFamily
+          traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched) /\
+      BranchFamilyReflectionAdequate
+        collapsedVisibleExchangeFamily collapsedVisibleExchangeFamily
+        traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched := by
+  refine
+    ⟨selected_collapsed_same_visibleUnion,
+      selected_firstUncoveredTargetBranch,
+      collapsed_firstUncoveredTargetBranch_none,
+      ?_,
+      ?_⟩
+  · intro hadequate
+    exact
+      traceOnly_not_hits_selectedBasisExchange
+        (branchFamilyAdequacy_transportsTransversal
+          hadequate traceOnly_hits_collapsedVisibleExchange)
+  · intro targetBranch htarget
+    subst targetBranch
+    exact
+      ⟨collapsedVisibleExchangeBranch, rfl,
+        by
+          intro coarseComponent hcoarseBranch hcoarseSupport
+          exact
+            ⟨coarseComponent,
+              hcoarseBranch,
+              hcoarseSupport⟩⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-75 theorem package: finite target orders produce witness-complete
+adequacy checks, adequacy transports branch-transversal repair, and visible
+projection cannot recover the protected branch-family adequacy result.
+-/
+theorem arbitraryBranchFamilyAdequacyChecker_package :
+    (forall {TargetCode : Type}
+      {covered : TargetCode -> Prop}
+      [DecidablePred covered] (targetOrder : List TargetCode),
+        firstUncoveredTargetBranch? covered targetOrder = none <->
+          ListedTargetCodesCovered covered targetOrder) /\
+      (forall {TargetCode : Type}
+        {targetFamily : ExchangeBranchFamily}
+        {targetOrder : List TargetCode}
+        {branchOf : TargetCode -> ExchangeBranchSupport}
+        {covered : TargetCode -> Prop}
+        [DecidablePred covered] {code : TargetCode},
+          TargetOrderEnumerates targetFamily targetOrder branchOf ->
+          firstUncoveredTargetBranch? covered targetOrder = some code ->
+            code ∈ targetOrder /\
+              targetFamily (branchOf code) /\
+                Not (covered code)) /\
+      (forall {TargetCode : Type}
+        {targetFamily sourceFamily : ExchangeBranchFamily}
+        {targetOrder : List TargetCode}
+        {branchOf : TargetCode -> ExchangeBranchSupport}
+        {sourceSupport targetSupport : HandoffRepairSupport}
+        [DecidablePred
+          (CodeReflectionCovered
+            sourceFamily sourceSupport targetSupport branchOf)],
+          TargetOrderEnumerates targetFamily targetOrder branchOf ->
+            (firstUncoveredTargetBranch?
+                (CodeReflectionCovered
+                  sourceFamily sourceSupport targetSupport branchOf)
+                targetOrder = none <->
+              BranchFamilyReflectionAdequate
+                sourceFamily targetFamily sourceSupport targetSupport)) /\
+      (forall {sourceFamily targetFamily : ExchangeBranchFamily}
+        {sourceSupport targetSupport : HandoffRepairSupport},
+          BranchFamilyReflectionAdequate
+            sourceFamily targetFamily sourceSupport targetSupport ->
+          ExchangeBranchRepairTransversal sourceFamily sourceSupport ->
+          ExchangeBranchRepairTransversal targetFamily targetSupport) /\
+      firstUncoveredTargetBranch?
+          selectedTraceOnlyCoveredByCollapsed selectedScanOrder =
+        some SelectedScanBranch.refinedRepairFrontier /\
+      firstUncoveredTargetBranch?
+          collapsedTraceOnlyCoveredByCollapsed collapsedVisibleScanOrder =
+        none /\
+      ((forall component,
+        ExchangeVisibleUnion selectedBasisExchangeFamily component <->
+          ExchangeVisibleUnion collapsedVisibleExchangeFamily component) /\
+        Not
+          (BranchFamilyReflectionAdequate
+            collapsedVisibleExchangeFamily selectedBasisExchangeFamily
+            traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched) /\
+        BranchFamilyReflectionAdequate
+          collapsedVisibleExchangeFamily collapsedVisibleExchangeFamily
+          traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched) := by
+  refine
+    ⟨?_, ?_, ?_, ?_,
+      selected_firstUncoveredTargetBranch,
+      collapsed_firstUncoveredTargetBranch_none,
+      ?_⟩
+  · intro TargetCode covered _ targetOrder
+    exact firstUncoveredTargetBranch?_none_iff_listedAdequate
+      covered targetOrder
+  · intro TargetCode targetFamily targetOrder branchOf covered _ code
+      henum hsome
+    exact firstUncoveredTargetBranch?_some_witness henum hsome
+  · intro TargetCode targetFamily sourceFamily targetOrder branchOf
+      sourceSupport targetSupport _ henum
+    exact firstUncoveredTargetBranch?_none_iff_adequate henum
+  · intro sourceFamily targetFamily sourceSupport targetSupport
+      hadequate hsource
+    exact branchFamilyAdequacy_transportsTransversal hadequate hsource
+  · exact
+      ⟨visibleUnion_not_faithful_to_arbitraryAdequacyCheck.1,
+        visibleUnion_not_faithful_to_arbitraryAdequacyCheck.2.2.2.1,
+        visibleUnion_not_faithful_to_arbitraryAdequacyCheck.2.2.2.2⟩
+
+end ArbitraryBranchFamilyAdequacy
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-arbitrary-branch-family-adequacy-checker.md
+++ b/research/ideas/g-aat-quality-surface-01-arbitrary-branch-family-adequacy-checker.md
@@ -1,0 +1,166 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: closer / wildcard / unifier
+candidate_type: computability
+capability_category: computability / certificate-transport / repair-potential / obstruction / invariance / quality-surface
+expected_base_score: 84
+expected_evidence_multiplier: 2.0
+expected_final_score: 168
+evidence_stage: proved-in-research
+rival_advantage: ADL / dashboard / AI-review readings can show pass/fail rows or visible component unions, but they do not certify that a finite branch-family adequacy checker is sound, complete, and returns a protected missing reflected branch witness.
+origin: cycle-75
+tags: [quality-surface, finite-branch-family, adequacy-checker, residual-witness, genius-support]
+created: 2026-06-22
+cycle: 75
+lean: proved-in-research
+---
+
+# Arbitrary finite branch-family adequacy checker with witness-complete residuals
+
+## 主張
+
+任意の source branch family、target branch family、branch-reflection relation、declared repair support に対して、
+supplied finite target order が target family を exact に列挙するという仮定のもとで adequacy checker を定義する。
+checker が `none` を返すことは、その finite target order 上の全 branch が source family の branch と support-lift closure によって
+covered されることと同値である。加えて target-order completeness により、それは target family 全体の adequacy と同値になる。
+`some b` を返す場合は、`b` が target order に属し、target family の branch であり、source 側に reflected support-lift witness を持たない
+protected missing branch witness である。
+
+さらに adequacy が通るなら、source branch-transversal repair clearance は target branch-transversal clearance へ transport する。
+同じ visible component-union projection を持つ selected / collapsed readings でも、protected adequacy checker は異なる結果を返しうる。
+
+この主張は、exact target-order enumeration、decidable covered predicate、supplied branch-reflection relation、declared component repair support、
+selected finite Quality Surface witness に相対化する。
+global canonical refinement、runtime repair synthesis、source extraction completeness、ArchMap correctness、global sheaf completeness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`computability`
+
+## 依拠
+
+- Cycle 70: `CurvatureBasisExchange.lean` の path-indexed exchange branch family。
+- Cycle 72: `BranchTransversalScanKernel.lean` の selected residual scan。
+- Cycle 73: `BranchReflectionAdequacyKernel.lean` の branch-local support-lift adequacy。
+- Cycle 74: `SelectedResidualScanPrefixMinimality.lean` の prefix-exact residual diagnostics。
+- tracking Issue #2348 の genius target seed: semantic repair-gluing obstruction theorem。
+
+## 非自明性
+
+Cycle 72-74 は selected scan order と trace-only witness に依存していた。この候補は、target family を exact に列挙する
+任意の finite target order と branch-reflection relation を入力にした proof-producing checker へ一般化する。
+単なる list scan ではなく、checker の `none` / `some` を adequacy、missing branch witness、
+transversality transport に結びつける点が非自明である。
+
+## 数学的興味
+
+finite repair obstruction を、存在命題ではなく executable residual object として読む。`some b` は UI の first failing row ではなく、
+supplied target order に相対化された protected branch-reflection failure witness であり、`none` は repair-transversal transport の
+十分条件を証明する。この形は、将来の semantic repair-gluing obstruction theorem で必要になる finite adequacy witness engine になる。
+
+## GOAL への前進
+
+arbitrary finite branch family に対する executable adequacy checking を与え、Quality Surface の computability、
+certificate-transport、repair-potential、obstruction 軸を一段広げる。Cycle 73 の selected adequacy kernel を、次の
+component-level refinement support-lift theorem と semantic repair-gluing obstruction target の support node にする。
+
+## ライバルに対する有効性
+
+ADL / conformance dashboard は component set、view、first failing row、pass/fail summary を表示できる。
+しかしこの候補は、finite branch-family checker の soundness / completeness と、failure 時に返る protected missing reflected branch witness を
+theorem として固定する。strong rival の AI-review summary でも、branch-reflection relation と support-lift closure を持たなければ、
+visible component union から adequacy result を復元できない。
+
+## SCORE 見込み
+
+- `score_reason`: selected residual scan と branch-reflection adequacy を任意有限 branch family の sound / complete checker へ持ち上げる。G2 四審判後、A の厳格値に合わせて base 84 / final 168 見込みへ下げる。
+- `dullness_risk`: generic list search の再包装に落ちると低価値。branch reflection relation、support-lift closure、missing protected branch witness、transport theorem、visible projection contrast をすべて Lean statement に含める。
+- `proof_or_evidence_plan`: Research 側 Lean ファイルで finite target order、target-order exactness、decidable covered predicate、first uncovered branch checker、none iff listed adequacy、target-order completeness から full adequacy への変換、some witness membership/missingness、adequate transport theorem、selected/collapsed visible nonfaithfulness package を証明する。
+
+## CS / SWE への帰結
+
+refinement / viewer / diagnostic surface が first failure を表示するとき、その failure が protected branch-reflection transport のどの missing witness かを返せる。
+逆に `none` の場合は、source repair clearance を target repair clearance へ運べる条件を持つため、可視 pass/fail を repair-transversal semantics へ接続できる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/ArbitraryBranchFamilyAdequacy.lean` に固定した。
+
+- `TargetOrderEnumerates`
+- `ListedTargetCodesCovered`
+- `CodeReflectionCovered`
+- `BranchFamilyReflectionAdequate`
+- `firstUncoveredTargetBranch?`
+- `firstUncoveredTargetBranch?_some_mem`
+- `firstUncoveredTargetBranch?_some_uncovered`
+- `firstUncoveredTargetBranch?_some_witness`
+- `firstUncoveredTargetBranch?_none_iff_listedAdequate`
+- `listedCoverage_gives_branchFamilyAdequacy`
+- `firstUncoveredTargetBranch?_none_iff_adequate`
+- `branchFamilyAdequacy_transportsTransversal`
+- `selectedTargetOrderEnumerates`
+- `collapsedTargetOrderEnumerates`
+- `selectedTraceOnlyCoveredByCollapsed_iff_reflection`
+- `selected_firstUncoveredTargetBranch`
+- `collapsed_firstUncoveredTargetBranch_none`
+- `selected_firstUncoveredTargetBranch_witness`
+- `visibleUnion_not_faithful_to_arbitraryAdequacyCheck`
+- `arbitraryBranchFamilyAdequacyChecker_package`
+
+G3 実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/ArbitraryBranchFamilyAdequacy.lean`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: definitions、`listedCoverage_gives_branchFamilyAdequacy`、`branchFamilyAdequacy_transportsTransversal`、`selectedTraceOnlyCoveredByCollapsed_iff_reflection` は axiom-free。`firstUncoveredTargetBranch?_some_*`、list / iff / selected-collapsed witness / package 系 theorem は標準 `propext` のみ。`sorryAx`、custom axiom、`Classical.choice`、`Quot.sound`、`unsafe` は出ていない。
+- `rg -n "\\b(axiom|admit|sorry|unsafe)\\b"` on changed files: no matches。
+
+## 審判メモ
+
+- 厳密性: revise 後 accept。base 84。target-order exactness、decidable coverage、`none iff listed adequacy` と full adequacy 変換を分けたことで、order omission の穴は閉じた。残るリスクは adequacy 定義の tautology 化と visible contrast の再掲化。
+- 研究価値: accept。base 90。Cycle 72-74 の scan / adequacy / prefix residual / visible nonfaithfulness を arbitrary finite checker contract に圧縮し、semantic repair-gluing target の support node を作る。
+- repo 全体価値: accept。base 86。Lean / paper / future tooling 価値があり、AAT の computability、certificate-transport、repair-potential、projection nonfaithfulness に整合する。
+- ライバル比較: accept。base 90。ADL / dashboard / AI-review に対し、pass/fail row ではなく protected missing reflected branch witness と transport theorem を返す点が差分。
+- genius: 四審判とも `genius_eligibility: no`。通常 SCORE の genius-support-normal として扱う。
+
+## G4 SCORE 監査結果
+
+- score_verdict: confirm。
+- base_score: 84。
+- evidence_multiplier: 2.0。
+- penalty: 0。
+- final_score: 168。
+- category: computability / certificate-transport / repair-potential / obstruction / invariance / quality-surface。
+- genius_verdict: downgrade-to-normal。四審判すべて `genius_eligibility: no` であり、これは target unlock ではなく support node である。
+- total_delta: 10090 -> 10258。active threshold 12000 までは残り 1742。
+- research_kiri_contribution: positive support-cycle contribution。phase boundary ではない。
+
+## 追加 required fields
+
+- `mathematical_interest`: finite branch obstruction を executable residual object として正規化し、transport adequacy と結びつける点。
+- `goal_advancement`: arbitrary finite branch-family adequacy checking を確立し、semantic repair-gluing obstruction target の support node を作る。
+- `planned_theorem_names`: `BranchFamilyReflectionAdequate`, `firstUncoveredTargetBranch?_none_iff_adequate`, `branchFamilyAdequacy_transportsTransversal`, `visibleUnion_not_faithful_to_arbitraryAdequacyCheck`, `arbitraryBranchFamilyAdequacyChecker_package`
+- `visible_projection`: collapsed visible component-union / UI-level pass-fail reading。これは protected branch adequacy checker に faithful ではない。
+- `protected_structure`: target branch incidence, source-to-target reflection coverage, branch-local support-lift closure, missing reflected branch witness。
+- `exactness_or_minimality_claim`: target family を exact に列挙する supplied finite order に相対化した sound / complete adequacy decision。global canonical minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: visible union が同じでも checker result と missing protected branch が異なる。
+- `previous_cycle_delta`: Cycle 72 selected scan、Cycle 73 adequacy kernel、Cycle 74 prefix residual theorem を arbitrary finite family へ広げる。
+- `rival_stress_test`: 同じ visible union を持つ selected/reflected branch families を入力し、一方は checker pass、他方は missing repair-frontier branch を返す finite case を置く。
+- `genius_potential`: no
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: finite adequacy witness engine。semantic repair-gluing theorem の support map の第一ノード。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-branch-transversal-scan-kernel.md`
+- `research/ideas/g-aat-quality-surface-01-branch-reflection-adequacy-kernel.md`
+- `research/ideas/g-aat-quality-surface-01-selected-residual-scan-prefix-minimality.md`
+
+## 進捗ログ
+
+- 2026-06-22: G1 四ロールの候補 pool から Cycle 75 通常候補として作成。genius target seed への support role を明記した。
+- 2026-06-22: G2 A の revise により、`arbitrary finite branch family` を exact target-order enumeration と decidable coverage に相対化し、checker の `none iff adequacy` が target order omission で破綻しないよう主張を修正した。
+- 2026-06-22: G2 四審判が accept。base は A=84, B=90, C=86, D=90。strict base 84 / expected final 168 として picked に更新。
+- 2026-06-22: G3 Lean 証拠を `ArbitraryBranchFamilyAdequacy.lean` に固定し、`FormalAGResearch` が通った。
+- 2026-06-22: G3 形式化品質監査の minor caveat を受け、generic `some -> listed ∧ targetFamily ∧ uncovered` を `firstUncoveredTargetBranch?_some_witness` として追加し、package theorem に含めて再ビルドした。
+- 2026-06-22: G4 SCORE 監査が confirm。base 84、multiplier 2.0、final +168。genius は通常 SCORE へ downgrade。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 10090
+- total SCORE: 10258
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -79,8 +79,9 @@
   - computability / repair-potential / certificate-transport / obstruction / quality-surface: 160
   - computability / certificate-transport / invariance / repair-potential / obstruction / quality-surface: 176
   - computability / minimality / obstruction / repair-potential / certificate-transport / quality-surface: 120
+  - computability / certificate-transport / repair-potential / obstruction / invariance / quality-surface: 168
 - evidence portfolio:
-  - proved-in-research: 74
+  - proved-in-research: 75
 
 ## Phase synthesis
 
@@ -96,7 +97,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-74 件の Lean-proved research artifacts は、次の paper seed を形成している。
+75 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -110,6 +111,7 @@ certificate の基本単位は
 - Cech overlap support は exact component basis だけでなく branch incidence を持ち、同じ visible component union でも branch-transversal class が分離しうる。
 - branch-reflection transport は、visible union preservation ではなく branch-local support-lift closure と missing reflected branch witness で判定される。
 - selected residual scan の returned branch は selector-relative prefix exactness と singleton-deletion restoration semantics を持つ。
+- finite target order に相対化した branch-family adequacy checker は、`none` を support-lift adequacy と、`some` を protected missing branch witness として返し、visible projection では復元できない adequacy result を固定する。
 
 ### Related-work separation
 
@@ -148,8 +150,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
 その後、tracking Issue の active threshold は 10000 に更新され、Cycle 74 後の total SCORE は 10090 である。
-現在の 10000 threshold には到達した。tracking Issue は phase summary と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 74 件持ち、
+現在の active threshold は tracking Issue 上で 12000 に更新され、Cycle 75 後の total SCORE は 10258 である。
+tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 75 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -158,7 +161,8 @@ finite overlap obstruction basis / repair-transversal duality theorem、
 repair/transport Cech commutator curvature theorem、repair-basin exchange obstruction theorem、
 antichain Cech overlap branch-transversal theorem、curvature basis exchange theorem、
 selected branch-reflection failure theorem、selector-relative branch-transversal scan kernel、
-branch-reflection adequacy kernel、selected residual scan prefix-minimality theorem を含む。
+branch-reflection adequacy kernel、selected residual scan prefix-minimality theorem、
+arbitrary finite branch-family adequacy checker theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -3522,3 +3526,65 @@ confirm し、genius は通常 SCORE へ戻した。
 Cycle 74 後の total SCORE は 10090 であり、active threshold 10000 に到達した。
 portfolio constraint は満たしており、report は coherent な paper seed として読める。
 tracking Issue は open のまま、G6 phase-boundary judgment と phase summary へ進む。
+
+## Cycle 75: Arbitrary finite branch-family adequacy checker with witness-complete residuals
+
+```text
+candidate: Arbitrary finite branch-family adequacy checker with witness-complete residuals
+candidate_type: computability
+evidence_stage: proved-in-research
+base_score: 84
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 168
+category: computability / certificate-transport / repair-potential / obstruction / invariance / quality-surface
+goal_delta: finite target-order branch adequacy now has a witness-complete executable checker: `none` is equivalent to support-lift adequacy under exact target-order enumeration, and `some` returns a listed target branch that is genuinely uncovered.
+project_value_delta: Turns Cycle 72-74 selected residual and adequacy kernels into a reusable finite adequacy witness engine, and supplies the first support node for the semantic repair-gluing obstruction genius target.
+rival_delta: ADL / conformance / dashboard / AI-review readings can show visible pass-fail rows or component unions, but they do not recover the protected branch-reflection coverage, support-lift closure, missing reflected branch witness, or repair-transversal transport theorem fixed here.
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/ArbitraryBranchFamilyAdequacy.lean` and `lake build FormalAGResearch` passed. Definitions and core transport theorems are axiom-free; list / iff / selected-collapsed witness / package theorems use only standard `propext`. No `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe` was reported. G3 formalization audit passed.
+open_questions: component-level refinement support-lift theorem; projection-kernel rule for loss-aware Quality Surface drill-down; finite semantic repair cocycle witness for the open genius target; order-invariance / confluence conditions for residual scans.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ArbitraryBranchFamilyAdequacy.lean`
+adds a finite target-order adequacy checker for branch-reflection transport.
+The checker is explicitly relative to a supplied target order that exactly
+enumerates the target branch family, a decidable coverage predicate, a supplied
+branch-reflection relation, and declared repair support.
+
+Lean proves:
+
+- `TargetOrderEnumerates`: exact enumeration of a target family by a finite target order.
+- `ListedTargetCodesCovered`: all target codes in the supplied order are covered.
+- `CodeReflectionCovered`: a target code is covered by a source branch and support-lift closure.
+- `firstUncoveredTargetBranch?`: the finite checker returning the first uncovered target code.
+- `firstUncoveredTargetBranch?_some_mem`: returned target codes belong to the supplied order.
+- `firstUncoveredTargetBranch?_some_uncovered`: returned target codes are genuinely uncovered.
+- `firstUncoveredTargetBranch?_some_witness`: returned codes are listed target-family members and uncovered under exact enumeration.
+- `firstUncoveredTargetBranch?_none_iff_listedAdequate`: `none` iff every listed code is covered.
+- `listedCoverage_gives_branchFamilyAdequacy`: listed coverage plus exact enumeration gives family-level adequacy.
+- `firstUncoveredTargetBranch?_none_iff_adequate`: `none` iff branch-family reflection adequacy under exact target-order enumeration.
+- `branchFamilyAdequacy_transportsTransversal`: adequate branch-reflection transport sends source transversality to target transversality.
+- `selectedTraceOnlyCoveredByCollapsed_iff_reflection`: the selected finite coverage predicate agrees with reflected support-lift coverage from the collapsed visible source family.
+- `selected_firstUncoveredTargetBranch`: the selected checker returns the refined repair-frontier residual.
+- `collapsed_firstUncoveredTargetBranch_none`: the collapsed visible checker returns no residual.
+- `selected_firstUncoveredTargetBranch_witness`: the selected residual is listed, targeted, and uncovered.
+- `visibleUnion_not_faithful_to_arbitraryAdequacyCheck`: visible component-union projection does not determine the finite adequacy checker result.
+- `arbitraryBranchFamilyAdequacyChecker_package`: the generic checker, transport theorem, and selected/collapsed nonfaithfulness package.
+
+This cycle does not claim a canonical global branch order, global atlas
+refinement, runtime repair synthesis, source extraction completeness, ArchMap
+correctness, global sheaf completeness, or whole-codebase quality. G2 四審判は
+いずれも `genius_eligibility: no` を返し、G3 は Lean proof と独立監査を通った。
+G4 は通常 SCORE として base 84 を confirm し、genius は通常 SCORE へ戻した。
+The open genius target remains `Semantic repair-gluing obstruction theorem for
+finite atom-supported quality atlases`; this cycle is a normal SCORE support
+node, not a genius unlock.
+
+### Next Frontier
+
+Cycle 75 後の total SCORE は 10258 であり、active threshold 12000 までは残り 1742 SCORE である。
+次 cycle では、component-level refinement support-lift theorem、projection kernel rule for loss-aware Quality Surface drill-down、
+または finite semantic repair cocycle witness を狙う。genius unlock はまだ成立しておらず、semantic repair-gluing obstruction theorem の
+support map を積む段階にある。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 75 として、任意有限 target order に相対化した branch-family adequacy checker を追加しました。`none` が branch-reflection adequacy と同値になる条件、`some` が protected missing branch witness になる条件、adequacy から branch-transversal transport へ進む theorem package を `Formal/AG/Research` 側に閉じて証明しています。

tracking Issue #2348 は research runtime state の正本なので、この PR では閉じません。Cycle 75 SCORE は #2348 に `+168` として記録済みです。

## 証明した定理

- `TargetOrderEnumerates`
- `ListedTargetCodesCovered`
- `CodeReflectionCovered`
- `firstUncoveredTargetBranch?`
- `firstUncoveredTargetBranch?_some_mem`
- `firstUncoveredTargetBranch?_some_uncovered`
- `firstUncoveredTargetBranch?_some_witness`
- `firstUncoveredTargetBranch?_none_iff_listedAdequate`
- `listedCoverage_gives_branchFamilyAdequacy`
- `firstUncoveredTargetBranch?_none_iff_adequate`
- `branchFamilyAdequacy_transportsTransversal`
- `selectedTraceOnlyCoveredByCollapsed_iff_reflection`
- `selected_firstUncoveredTargetBranch`
- `collapsed_firstUncoveredTargetBranch_none`
- `selected_firstUncoveredTargetBranch_witness`
- `visibleUnion_not_faithful_to_arbitraryAdequacyCheck`
- `arbitraryBranchFamilyAdequacyChecker_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-arbitrary-branch-family-adequacy-checker.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/ArbitraryBranchFamilyAdequacy.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local/private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan on Lean changes
- [x] `#print axioms` for reported declarations

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
  - research tracking Issue を閉じない規律のため `Refs #2348` としています。
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
  - Cycle 75 evidence は `proved-in-research` です。
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
