### PR TITLE
研究: component refinement support liftを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -72,3 +72,4 @@ import Formal.AG.Research.QualitySurface.BranchTransversalScanKernel
 import Formal.AG.Research.QualitySurface.BranchReflectionAdequacyKernel
 import Formal.AG.Research.QualitySurface.SelectedResidualScanPrefixMinimality
 import Formal.AG.Research.QualitySurface.ArbitraryBranchFamilyAdequacy
+import Formal.AG.Research.QualitySurface.ComponentRefinementSupportLift

--- a/Formal/AG/Research/QualitySurface/ComponentRefinementSupportLift.lean
+++ b/Formal/AG/Research/QualitySurface/ComponentRefinementSupportLift.lean
@@ -1,0 +1,422 @@
+import Formal.AG.Research.QualitySurface.ArbitraryBranchFamilyAdequacy
+
+/-!
+Cycle 76 evidence for `G-aat-quality-surface-01`.
+
+This file turns component-level refinement lifts into branch-family adequacy
+certificates for the finite checker from Cycle 75.  The lift is explicit and
+code-indexed: every target branch code carries a component transport and a
+support-transport proof.  The result closes the selected residual only after
+the declared repair support is expanded from trace-only to trace plus
+repair-frontier.
+
+The construction remains relative to finite target orders, selected exchange
+branch families, explicit component lifts, and declared support predicates.  It
+does not assert global atlas refinement, canonical source extraction, ArchMap
+correctness, runtime repair synthesis, global sheaf completeness, or
+whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ComponentRefinementSupportLift
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffRepairTransversalTheorem
+open RepairBasinExchangeObstruction
+open AntichainOverlapBasisTransversal
+open CurvatureBasisExchange
+open NaiveRefinementSupportCounterexample
+open BranchTransversalScanKernel
+open BranchReflectionAdequacyKernel
+open ArbitraryBranchFamilyAdequacy
+
+/-! ## Component lifts as adequacy certificates -/
+
+/-- A component lift sends every source branch component into the target branch. -/
+def BranchComponentLiftClosed
+    (componentLift : ExchangeComponent -> ExchangeComponent)
+    (sourceBranch targetBranch : ExchangeBranchSupport) : Prop :=
+  forall component,
+    sourceBranch component ->
+      targetBranch (componentLift component)
+
+/-- A component lift sends touched source support into touched target support. -/
+def ComponentSupportLiftClosed
+    (componentLift : ExchangeComponent -> ExchangeComponent)
+    (sourceSupport targetSupport : HandoffRepairSupport) : Prop :=
+  forall component,
+    sourceSupport component.2 ->
+      targetSupport (componentLift component).2
+
+/- A branch-component lift plus support lift is exactly the witness shape
+needed by the branch-reflection adequacy kernel. -/
+theorem branchComponentLiftClosed_gives_supportLiftClosedForBranch
+    {componentLift : ExchangeComponent -> ExchangeComponent}
+    {sourceBranch targetBranch : ExchangeBranchSupport}
+    {sourceSupport targetSupport : HandoffRepairSupport}
+    (hbranch :
+      BranchComponentLiftClosed componentLift sourceBranch targetBranch)
+    (hsupport :
+      ComponentSupportLiftClosed componentLift sourceSupport targetSupport) :
+    SupportLiftClosedForBranch
+      sourceBranch targetBranch sourceSupport targetSupport := by
+  intro component hsourceBranch hsourceSupport
+  exact
+    ⟨componentLift component,
+      hbranch component hsourceBranch,
+      hsupport component hsourceSupport⟩
+
+/--
+A target code is covered by an explicit component-level refinement lift from a
+source branch and source support to the coded target branch.
+-/
+def CodeComponentLiftCovered
+    {TargetCode : Type}
+    (componentLift : TargetCode -> ExchangeComponent -> ExchangeComponent)
+    (sourceFamily : ExchangeBranchFamily)
+    (sourceSupport targetSupport : HandoffRepairSupport)
+    (branchOf : TargetCode -> ExchangeBranchSupport)
+    (code : TargetCode) : Prop :=
+  exists sourceBranch,
+    sourceFamily sourceBranch /\
+      BranchComponentLiftClosed
+        (componentLift code) sourceBranch (branchOf code) /\
+      ComponentSupportLiftClosed
+        (componentLift code) sourceSupport targetSupport
+
+/-- Component-lift coverage refines to the support-lift coverage predicate. -/
+theorem codeComponentLiftCovered_gives_codeReflectionCovered
+    {TargetCode : Type}
+    {componentLift : TargetCode -> ExchangeComponent -> ExchangeComponent}
+    {sourceFamily : ExchangeBranchFamily}
+    {sourceSupport targetSupport : HandoffRepairSupport}
+    {branchOf : TargetCode -> ExchangeBranchSupport}
+    {code : TargetCode}
+    (hcovered :
+      CodeComponentLiftCovered
+        componentLift sourceFamily sourceSupport targetSupport branchOf
+        code) :
+    CodeReflectionCovered
+      sourceFamily sourceSupport targetSupport branchOf code := by
+  rcases hcovered with
+    ⟨sourceBranch, hsource, hbranch, hsupport⟩
+  exact
+    ⟨sourceBranch, hsource,
+      branchComponentLiftClosed_gives_supportLiftClosedForBranch
+        hbranch hsupport⟩
+
+/--
+Listed component-lift coverage plus target-order exactness gives full
+branch-family adequacy for the underlying support-lift kernel.
+-/
+theorem listedComponentLiftCoverage_gives_branchFamilyAdequacy
+    {TargetCode : Type}
+    {targetFamily sourceFamily : ExchangeBranchFamily}
+    {targetOrder : List TargetCode}
+    {branchOf : TargetCode -> ExchangeBranchSupport}
+    {componentLift : TargetCode -> ExchangeComponent -> ExchangeComponent}
+    {sourceSupport targetSupport : HandoffRepairSupport}
+    (henum : TargetOrderEnumerates targetFamily targetOrder branchOf)
+    (hlisted :
+      ListedTargetCodesCovered
+        (CodeComponentLiftCovered
+          componentLift sourceFamily sourceSupport targetSupport branchOf)
+        targetOrder) :
+    BranchFamilyReflectionAdequate
+      sourceFamily targetFamily sourceSupport targetSupport := by
+  apply listedCoverage_gives_branchFamilyAdequacy henum
+  intro code hmem
+  exact codeComponentLiftCovered_gives_codeReflectionCovered
+    (hlisted code hmem)
+
+/--
+If the finite component-lift checker returns no residual, the target branch
+family is adequate for support-lift transport.
+-/
+theorem firstUncoveredComponentLift?_none_gives_branchFamilyAdequacy
+    {TargetCode : Type}
+    {targetFamily sourceFamily : ExchangeBranchFamily}
+    {targetOrder : List TargetCode}
+    {branchOf : TargetCode -> ExchangeBranchSupport}
+    {componentLift : TargetCode -> ExchangeComponent -> ExchangeComponent}
+    {sourceSupport targetSupport : HandoffRepairSupport}
+    [DecidablePred
+      (CodeComponentLiftCovered
+        componentLift sourceFamily sourceSupport targetSupport branchOf)]
+    (henum : TargetOrderEnumerates targetFamily targetOrder branchOf)
+    (hnone :
+      firstUncoveredTargetBranch?
+          (CodeComponentLiftCovered
+            componentLift sourceFamily sourceSupport targetSupport branchOf)
+          targetOrder = none) :
+    BranchFamilyReflectionAdequate
+      sourceFamily targetFamily sourceSupport targetSupport := by
+  exact
+    listedComponentLiftCoverage_gives_branchFamilyAdequacy henum
+      ((firstUncoveredTargetBranch?_none_iff_listedAdequate
+        (CodeComponentLiftCovered
+          componentLift sourceFamily sourceSupport targetSupport branchOf)
+        targetOrder).mp hnone)
+
+/-! ## Selected refinement-support lift -/
+
+/--
+The selected component lift sends the collapsed visible source branch into the
+target branch named by each selected code.
+-/
+def selectedCollapsedComponentLift :
+    SelectedScanBranch -> ExchangeComponent -> ExchangeComponent
+  | SelectedScanBranch.coarseTrace, _ =>
+      (ExchangeSide.coarse, BridgeComponent.trace)
+  | SelectedScanBranch.refinedTrace, _ =>
+      (ExchangeSide.refined, BridgeComponent.trace)
+  | SelectedScanBranch.refinedRepairFrontier, _ =>
+      (ExchangeSide.refined, BridgeComponent.repairFrontier)
+
+/-- The selected component lift covers every selected branch code. -/
+theorem selectedCollapsedComponentLift_covers_code
+    (code : SelectedScanBranch) :
+    CodeComponentLiftCovered
+      selectedCollapsedComponentLift collapsedVisibleExchangeFamily
+      traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport
+      SelectedScanBranch.branch code := by
+  refine
+    ⟨collapsedVisibleExchangeBranch, rfl, ?_, ?_⟩
+  · intro component _hsource
+    cases code <;>
+      simp [selectedCollapsedComponentLift, SelectedScanBranch.branch,
+        coarseTraceExchangeBranch, refinedTraceExchangeBranch,
+        refinedRepairFrontierExchangeBranch, liftBranchToExchangeSide,
+        traceBranch, repairFrontierBranch, singletonRepairSupport]
+  · intro component _hsupport
+    cases code <;>
+      simp [selectedCollapsedComponentLift,
+        traceRepairFrontierRepairSupport]
+
+instance selectedCollapsedComponentLift_covers_code_decidable
+    (code : SelectedScanBranch) :
+    Decidable
+      (CodeComponentLiftCovered
+        selectedCollapsedComponentLift collapsedVisibleExchangeFamily
+        traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport
+        SelectedScanBranch.branch code) :=
+  isTrue (selectedCollapsedComponentLift_covers_code code)
+
+/--
+Trace-only support admits no component-lift coverage for the selected refined
+repair-frontier target branch.  Any branch-component lift into that target
+forces the lifted touched component to be a repair-frontier component, which
+trace-only support does not touch.
+-/
+theorem traceOnly_componentLift_not_covers_refinedRepairFrontier
+    (componentLift : SelectedScanBranch -> ExchangeComponent -> ExchangeComponent) :
+    Not
+      (CodeComponentLiftCovered
+        componentLift collapsedVisibleExchangeFamily
+        traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched
+        SelectedScanBranch.branch
+        SelectedScanBranch.refinedRepairFrontier) := by
+  intro hcovered
+  rcases hcovered with ⟨sourceBranch, hsource, hbranch, hsupport⟩
+  subst sourceBranch
+  have htarget :
+      SelectedScanBranch.branch SelectedScanBranch.refinedRepairFrontier
+        (componentLift
+          SelectedScanBranch.refinedRepairFrontier
+          (ExchangeSide.coarse, BridgeComponent.trace)) :=
+    hbranch (ExchangeSide.coarse, BridgeComponent.trace) (Or.inl rfl)
+  have hliftSupport :
+      traceOnlyRepairPlan.touched
+        (componentLift
+          SelectedScanBranch.refinedRepairFrontier
+          (ExchangeSide.coarse, BridgeComponent.trace)).2 :=
+    hsupport (ExchangeSide.coarse, BridgeComponent.trace) rfl
+  have hcomponent :
+      (componentLift
+        SelectedScanBranch.refinedRepairFrontier
+        (ExchangeSide.coarse, BridgeComponent.trace)).2 =
+        BridgeComponent.repairFrontier := by
+    rcases htarget with ⟨_hside, htargetComponent⟩
+    simpa [repairFrontierBranch, singletonRepairSupport] using htargetComponent
+  exact traceOnlyRepairPlan_misses_repairFrontier
+    (by simpa [hcomponent] using hliftSupport)
+
+/--
+The selected component-lift checker has no residual once the declared repair
+support touches both trace and repair-frontier.
+-/
+theorem selectedComponentLift_firstUncovered_none :
+    firstUncoveredTargetBranch?
+        (CodeComponentLiftCovered
+          selectedCollapsedComponentLift collapsedVisibleExchangeFamily
+          traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport
+          SelectedScanBranch.branch)
+        selectedScanOrder = none := by
+  have hcoarse :
+      CodeComponentLiftCovered
+        selectedCollapsedComponentLift collapsedVisibleExchangeFamily
+        traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport
+        SelectedScanBranch.branch SelectedScanBranch.coarseTrace :=
+    selectedCollapsedComponentLift_covers_code SelectedScanBranch.coarseTrace
+  have hrefinedTrace :
+      CodeComponentLiftCovered
+        selectedCollapsedComponentLift collapsedVisibleExchangeFamily
+        traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport
+        SelectedScanBranch.branch SelectedScanBranch.refinedTrace :=
+    selectedCollapsedComponentLift_covers_code SelectedScanBranch.refinedTrace
+  have hrefinedRepair :
+      CodeComponentLiftCovered
+        selectedCollapsedComponentLift collapsedVisibleExchangeFamily
+        traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport
+        SelectedScanBranch.branch
+        SelectedScanBranch.refinedRepairFrontier :=
+    selectedCollapsedComponentLift_covers_code
+      SelectedScanBranch.refinedRepairFrontier
+  simp [firstUncoveredTargetBranch?, selectedScanOrder,
+    hcoarse, hrefinedTrace, hrefinedRepair]
+
+/--
+The selected component-lift certificate gives branch-family adequacy from the
+collapsed visible branch family to the selected branch family.
+-/
+theorem selectedComponentLift_gives_branchFamilyAdequacy :
+    BranchFamilyReflectionAdequate
+      collapsedVisibleExchangeFamily selectedBasisExchangeFamily
+      traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport := by
+  exact
+    firstUncoveredComponentLift?_none_gives_branchFamilyAdequacy
+      selectedTargetOrderEnumerates
+      selectedComponentLift_firstUncovered_none
+
+/--
+Component-level refinement support lifts transport collapsed visible
+transversality to the selected branch-reflection family.
+-/
+theorem componentLift_transports_selectedReflection :
+    ExchangeBranchRepairTransversal
+      selectedBasisExchangeFamily traceRepairFrontierRepairSupport := by
+  exact
+    branchFamilyAdequacy_transportsTransversal
+      selectedComponentLift_gives_branchFamilyAdequacy
+      traceRepairFrontierSupport_hits_collapsedVisible
+
+/--
+The component-lift pass exactly contrasts with the trace-only residual: the
+same target order reports the protected repair-frontier residual under
+trace-only support and no residual under the trace plus repair-frontier lift.
+-/
+theorem componentLift_closes_selected_residual :
+    firstUncoveredTargetBranch?
+        selectedTraceOnlyCoveredByCollapsed selectedScanOrder =
+      some SelectedScanBranch.refinedRepairFrontier /\
+      firstUncoveredTargetBranch?
+          (CodeComponentLiftCovered
+            selectedCollapsedComponentLift collapsedVisibleExchangeFamily
+            traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport
+            SelectedScanBranch.branch)
+          selectedScanOrder = none /\
+      BranchFamilyReflectionAdequate
+        collapsedVisibleExchangeFamily selectedBasisExchangeFamily
+        traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport /\
+      ExchangeBranchRepairTransversal
+        selectedBasisExchangeFamily traceRepairFrontierRepairSupport /\
+      (forall componentLift,
+        Not
+          (CodeComponentLiftCovered
+            componentLift collapsedVisibleExchangeFamily
+            traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched
+            SelectedScanBranch.branch
+            SelectedScanBranch.refinedRepairFrontier)) := by
+  exact
+    ⟨selected_firstUncoveredTargetBranch,
+      selectedComponentLift_firstUncovered_none,
+      selectedComponentLift_gives_branchFamilyAdequacy,
+      componentLift_transports_selectedReflection,
+      traceOnly_componentLift_not_covers_refinedRepairFrontier⟩
+
+/-! ## Theorem package -/
+
+/--
+Cycle-76 theorem package: component-level refinement lifts are sufficient
+evidence for the finite adequacy checker, and the selected lift closes exactly
+the trace-only protected residual by expanding declared support to
+trace plus repair-frontier.
+-/
+theorem componentRefinementSupportLift_package :
+    (forall {componentLift : ExchangeComponent -> ExchangeComponent}
+      {sourceBranch targetBranch : ExchangeBranchSupport}
+      {sourceSupport targetSupport : HandoffRepairSupport},
+        BranchComponentLiftClosed
+          componentLift sourceBranch targetBranch ->
+        ComponentSupportLiftClosed
+          componentLift sourceSupport targetSupport ->
+        SupportLiftClosedForBranch
+          sourceBranch targetBranch sourceSupport targetSupport) /\
+      (forall {TargetCode : Type}
+        {componentLift :
+          TargetCode -> ExchangeComponent -> ExchangeComponent}
+        {sourceFamily : ExchangeBranchFamily}
+        {sourceSupport targetSupport : HandoffRepairSupport}
+        {branchOf : TargetCode -> ExchangeBranchSupport}
+        {code : TargetCode},
+          CodeComponentLiftCovered
+            componentLift sourceFamily sourceSupport targetSupport
+            branchOf code ->
+          CodeReflectionCovered
+            sourceFamily sourceSupport targetSupport branchOf code) /\
+      (forall {TargetCode : Type}
+        {targetFamily sourceFamily : ExchangeBranchFamily}
+        {targetOrder : List TargetCode}
+        {branchOf : TargetCode -> ExchangeBranchSupport}
+        {componentLift :
+          TargetCode -> ExchangeComponent -> ExchangeComponent}
+        {sourceSupport targetSupport : HandoffRepairSupport},
+          TargetOrderEnumerates targetFamily targetOrder branchOf ->
+          ListedTargetCodesCovered
+            (CodeComponentLiftCovered
+              componentLift sourceFamily sourceSupport targetSupport
+              branchOf)
+            targetOrder ->
+          BranchFamilyReflectionAdequate
+            sourceFamily targetFamily sourceSupport targetSupport) /\
+      firstUncoveredTargetBranch?
+          (CodeComponentLiftCovered
+            selectedCollapsedComponentLift collapsedVisibleExchangeFamily
+            traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport
+            SelectedScanBranch.branch)
+          selectedScanOrder = none /\
+      BranchFamilyReflectionAdequate
+        collapsedVisibleExchangeFamily selectedBasisExchangeFamily
+        traceRepairFrontierRepairSupport traceRepairFrontierRepairSupport /\
+      ExchangeBranchRepairTransversal
+        selectedBasisExchangeFamily traceRepairFrontierRepairSupport /\
+      firstUncoveredTargetBranch?
+          selectedTraceOnlyCoveredByCollapsed selectedScanOrder =
+        some SelectedScanBranch.refinedRepairFrontier /\
+      (forall componentLift,
+        Not
+          (CodeComponentLiftCovered
+            componentLift collapsedVisibleExchangeFamily
+            traceOnlyRepairPlan.touched traceOnlyRepairPlan.touched
+            SelectedScanBranch.branch
+            SelectedScanBranch.refinedRepairFrontier)) := by
+  exact
+    ⟨fun hbranch hsupport =>
+        branchComponentLiftClosed_gives_supportLiftClosedForBranch
+          hbranch hsupport,
+      fun hcovered =>
+        codeComponentLiftCovered_gives_codeReflectionCovered hcovered,
+      fun henum hlisted =>
+        listedComponentLiftCoverage_gives_branchFamilyAdequacy
+          henum hlisted,
+      selectedComponentLift_firstUncovered_none,
+      selectedComponentLift_gives_branchFamilyAdequacy,
+      componentLift_transports_selectedReflection,
+      selected_firstUncoveredTargetBranch,
+      traceOnly_componentLift_not_covers_refinedRepairFrontier⟩
+
+end ComponentRefinementSupportLift
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-component-refinement-support-lift.md
+++ b/research/ideas/g-aat-quality-surface-01-component-refinement-support-lift.md
@@ -1,0 +1,163 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: closer / obstruction / unifier / wildcard
+candidate_type: closure / unification / genius-support
+capability_category: certificate-transport / repair-potential / invariance / computability / obstruction / quality-surface
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: ADL / conformance / dashboard readings may preserve component refinements or visible component unions, but they do not certify the component-level support-lift condition that transports branch-family repair adequacy.
+origin: cycle-76
+tags: [quality-surface, component-refinement, support-lift, branch-family, adequacy, genius-support]
+created: 2026-06-22
+cycle: 76
+lean: proved-in-research
+---
+
+# Component-level refinement support-lift theorem
+
+## 主張
+
+finite branch-family adequacy checker の coverage predicate を、明示的な component-level refinement lift から生成する。
+各 target branch code に対して、source branch component を target branch component へ送る `componentLift` と、
+source support を target support へ送る support-closure law が与えられるなら、その code は
+`CodeReflectionCovered` である。したがって exact target-order enumeration 上で全 code が component-lift covered なら、
+source family から target family への `BranchFamilyReflectionAdequate` が従い、source branch-transversal repair clearance は
+target branch-transversal clearance へ transport される。
+
+selected witness では、collapsed visible branch family から selected branch family への component lift を構成し、
+declared repair support を trace-only から trace plus repair-frontier に拡張すると adequacy checker が `none` を返すことを証明する。
+一方、trace-only support では任意の component lift が refined repair-frontier target branch を cover できないことも証明する。
+
+この主張は finite target order、selected exchange branch family、明示的 component lift、declared support predicate に相対化する。
+global atlas refinement、canonical source extraction、ArchMap correctness、runtime repair synthesis、global sheaf completeness、
+whole-codebase quality は主張しない。
+
+## 候補種別
+
+`closure` / `unification` / `genius-support`
+
+## 依拠
+
+- Cycle 70: `CurvatureBasisExchange.lean` の path-indexed exchange branch family。
+- Cycle 73: `BranchReflectionAdequacyKernel.lean` の branch-local `SupportLiftClosedForBranch`。
+- Cycle 75: `ArbitraryBranchFamilyAdequacy.lean` の finite target-order adequacy checker。
+- tracking Issue #2348 の genius target seed: semantic repair-gluing obstruction theorem。
+
+## 非自明性
+
+Cycle 75 の checker は `CodeReflectionCovered` を supplied predicate として受け取っていた。この候補は、その coverage を
+component-level refinement lift と support-closure law から導出する。単なる `SupportLiftClosedForBranch` の言い換えにせず、
+component lift が branch membership と support membership の二つを同時に運ぶことを theorem 化し、trace-only では
+refined repair-frontier lift が不可能である no-go witness も固定する。
+
+## 数学的興味
+
+repair/refinement の local adequacy を、component 対応の存在だけではなく、branch incidence と repair support の両方を保存する
+transport certificate として読む。これにより、finite checker の `none` は「component refinement がある」ではなく、
+「repair support を保つ branch-level lift がある」という強い証明条件になる。
+
+## GOAL への前進
+
+Quality Surface の certificate-transport / repair-potential / computability 軸を進める。特に open genius target theorem の
+semantic repair-gluing obstruction に必要な support node として、局所 chart adequacy を gluing 側へ運ぶための component-level
+support-lift 仮定を Lean-proved artifact にする。
+
+## ライバルに対する有効性
+
+ADL や conformance checker は component refinement、component graph preservation、visible branch union preservation を扱える。
+この候補は、それらが repair adequacy transport には不足することを、refined repair-frontier lift の trace-only no-go として固定する。
+strong rival の AI-review summary でも、component lift と support-closure law を持たなければ branch-family adequacy transport は証明できない。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 75 checker の supplied coverage predicate を component-level refinement support lift から生成し、trace-only failure と trace-plus-repair-frontier pass を同じ finite selected witness に載せる。G2 A の strict review に合わせ、既存 adequacy machinery への adapter 性を織り込んで expected base を 70 に下げる。
+- `dullness_risk`: `SupportLiftClosedForBranch` の名前替えに落ちると低価値。component lift、support closure、finite checker connection、selected pass、trace-only no-go の全てを evidence に含める。
+- `proof_or_evidence_plan`: Research 側 Lean ファイルで `BranchComponentLiftClosed`、`ComponentSupportLiftClosed`、`CodeComponentLiftCovered`、listed coverage から branch-family adequacy、selected component lift pass、trace-only no-go witness、theorem package を証明する。
+
+## CS / SWE への帰結
+
+refinement-aware diagnostic surface が「component refinement は保たれている」と表示するだけでは repair adequacy は足りない。
+repair support が refined branch obligation へ lift されるかを certificate として持つ必要がある。この theorem により、future tooling / viewer が
+component refinement と repair-support adequacy を分けて表示する数学的根拠が得られる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/ComponentRefinementSupportLift.lean` に固定した。
+
+- `BranchComponentLiftClosed`
+- `ComponentSupportLiftClosed`
+- `branchComponentLiftClosed_gives_supportLiftClosedForBranch`
+- `CodeComponentLiftCovered`
+- `codeComponentLiftCovered_gives_codeReflectionCovered`
+- `listedComponentLiftCoverage_gives_branchFamilyAdequacy`
+- `firstUncoveredComponentLift?_none_gives_branchFamilyAdequacy`
+- `selectedCollapsedComponentLift`
+- `selectedCollapsedComponentLift_covers_code`
+- `traceOnly_componentLift_not_covers_refinedRepairFrontier`
+- `selectedComponentLift_firstUncovered_none`
+- `selectedComponentLift_gives_branchFamilyAdequacy`
+- `componentLift_transports_selectedReflection`
+- `componentLift_closes_selected_residual`
+- `componentRefinementSupportLift_package`
+
+G3 実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/ComponentRefinementSupportLift.lean`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: `BranchComponentLiftClosed`、`ComponentSupportLiftClosed`、`branchComponentLiftClosed_gives_supportLiftClosedForBranch`、`CodeComponentLiftCovered`、`codeComponentLiftCovered_gives_codeReflectionCovered`、`listedComponentLiftCoverage_gives_branchFamilyAdequacy`、`traceOnly_componentLift_not_covers_refinedRepairFrontier` は axiom-free。`firstUncoveredComponentLift?_none_gives_branchFamilyAdequacy`、selected pass / package theorem は標準 `propext` のみ。`sorryAx`、custom axiom、`Classical.choice`、`Quot.sound`、`unsafe` は出ていない。
+
+## 審判メモ
+
+- 厳密性: revise 後 accept。base 70。claim boundary は強いが、generic bridge は既存 `SupportLiftClosedForBranch` と Cycle 75 coverage machinery への adapter 性があるため、expected base を 84 から 70 に下げた。core declarations は axiom-free、selected / package theorem は標準 `propext` のみ。
+- 研究価値: accept。base 84。component refinement、support closure、finite adequacy checking、selected pass、trace-only failure を一つの theorem package に圧縮し、semantic repair-gluing target の support node を作る。
+- repo 全体価値: accept。base 84。Lean / future tooling / report surface に、component refinement と repair-support-preserving adequacy の区別を与える。
+- ライバル比較: accept。base 84。ADL / static analyzer / conformance checker / dashboard / AI-review に対し、support-preserving branch-family transport と refined repair-frontier no-go を Lean-fixed evidence として与える。
+- genius: open target の support cycle。target unlock ではなく通常 SCORE の予定。
+- G3 公理検査: pass。15 declaration は axiom-free または標準 `propext` のみ。`sorryAx`、custom axiom、`Classical.choice`、`Quot.sound`、`unsafe` はない。
+- G3 形式化品質: pass。`ComponentSupportLiftClosed` は branch-restricted ではなく source support 全体に対する保存 law なので必要最小よりやや強いが、候補カードの support-closure law と一致し、vacuous ではない。
+- G4 SCORE 監査: confirm。base 70、evidence multiplier 2.0、penalty 0、final +140。genius unlock ではなく open target の support cycle。
+
+## G4 SCORE 監査結果
+
+- score_verdict: confirm。
+- base_score: 70。
+- evidence_multiplier: 2.0。
+- penalty: 0。
+- final_score: 140。
+- category: genius-support / certificate-transport / repair-potential / computability。
+- genius_verdict: not-applicable。これは target unlock ではなく、semantic repair-gluing obstruction theorem の component-level support-lift node を進める通常 SCORE support cycle である。
+- total_delta: 10258 -> 10398。active threshold 12000 までは残り 1602。
+- research_kiri_contribution: positive support-cycle contribution。phase boundary ではない。
+
+## 追加 required fields
+
+- `mathematical_interest`: component-level refinement を branch incidence と repair support の二重 transport certificate として読む点。
+- `goal_advancement`: local adequacy checker を semantic repair-gluing target へ運ぶための support-lift node を確立する。
+- `planned_theorem_names`: `branchComponentLiftClosed_gives_supportLiftClosedForBranch`, `listedComponentLiftCoverage_gives_branchFamilyAdequacy`, `selectedComponentLift_gives_branchFamilyAdequacy`, `traceOnly_componentLift_not_covers_refinedRepairFrontier`, `componentRefinementSupportLift_package`
+- `visible_projection`: component refinement / visible component union。これだけでは branch-family repair adequacy transport に faithful ではない。
+- `protected_structure`: branch component lift, support-closure law, target branch incidence, refined repair-frontier no-go witness。
+- `exactness_or_minimality_claim`: exact target-order enumeration と component-lift coverage に相対化した adequacy transport。global canonical minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: trace-only support cannot cover the refined repair-frontier target branch by any component lift.
+- `previous_cycle_delta`: Cycle 75 の arbitrary checker に component-level coverage generator を与える。
+- `rival_stress_test`: component graph / visible union preservation だけでは trace-only failure を検出できず、support-preserving branch lift が必要である。
+- `genius_potential`: no immediate unlock
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: local adequacy pass を semantic repair-gluing theorem の support map へ運ぶための component-level support-lift node。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-branch-reflection-adequacy-kernel.md`
+- `research/ideas/g-aat-quality-surface-01-arbitrary-branch-family-adequacy-checker.md`
+- `research/ideas/g-aat-quality-surface-01-naive-refinement-support-counterexample.md`
+
+## 進捗ログ
+
+- 2026-06-22: G1 四ロール候補 pool で component-level refinement support-lift が closer / obstruction / unifier / wildcard の全てに現れた。semantic repair cocycle witness は次の高期待 genius-support 候補として残し、Cycle 76 ではその局所 adequacy transport に必要な support-lift node を picked とした。
+- 2026-06-22: Lean 証拠を `ComponentRefinementSupportLift.lean` に固定し、単体 `lake env lean` が通った。
+- 2026-06-22: G2 A の revise を受け、expected base を 70、expected final を 140 に下げた。既存 machinery への adapter 性を認めたうえで、component lift generator、trace-plus-repair-frontier pass、trace-only no-go を主価値として残す。
+- 2026-06-22: G2 A が revise 後 accept。G2 四審判は A=70, B=84, C=84, D=84。strict base 70、expected final 140 として G3 へ進む。
+- 2026-06-22: G3 公理検査と形式化品質監査が pass。core bridge / no-go は axiom-free、selected checker / package layer は標準 `propext` のみ。
+- 2026-06-22: G4 SCORE 監査が confirm。base 70、multiplier 2.0、final +140。total は 10398 / threshold 12000、残り 1602。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 10258
+- total SCORE: 10398
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -80,8 +80,9 @@
   - computability / certificate-transport / invariance / repair-potential / obstruction / quality-surface: 176
   - computability / minimality / obstruction / repair-potential / certificate-transport / quality-surface: 120
   - computability / certificate-transport / repair-potential / obstruction / invariance / quality-surface: 168
+  - genius-support / certificate-transport / repair-potential / computability: 140
 - evidence portfolio:
-  - proved-in-research: 75
+  - proved-in-research: 76
 
 ## Phase synthesis
 
@@ -97,7 +98,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-75 件の Lean-proved research artifacts は、次の paper seed を形成している。
+76 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -112,6 +113,7 @@ certificate の基本単位は
 - branch-reflection transport は、visible union preservation ではなく branch-local support-lift closure と missing reflected branch witness で判定される。
 - selected residual scan の returned branch は selector-relative prefix exactness と singleton-deletion restoration semantics を持つ。
 - finite target order に相対化した branch-family adequacy checker は、`none` を support-lift adequacy と、`some` を protected missing branch witness として返し、visible projection では復元できない adequacy result を固定する。
+- component-level refinement support lift は、explicit component lift と support-closure law から finite branch-family adequacy coverage を生成し、trace-only support では refined repair-frontier branch を cover できない no-go witness を持つ。
 
 ### Related-work separation
 
@@ -150,9 +152,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
 その後、tracking Issue の active threshold は 10000 に更新され、Cycle 74 後の total SCORE は 10090 である。
-現在の active threshold は tracking Issue 上で 12000 に更新され、Cycle 75 後の total SCORE は 10258 である。
+現在の active threshold は tracking Issue 上で 12000 に更新され、Cycle 76 後の total SCORE は 10398 である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 75 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 76 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -162,7 +164,8 @@ repair/transport Cech commutator curvature theorem、repair-basin exchange obstr
 antichain Cech overlap branch-transversal theorem、curvature basis exchange theorem、
 selected branch-reflection failure theorem、selector-relative branch-transversal scan kernel、
 branch-reflection adequacy kernel、selected residual scan prefix-minimality theorem、
-arbitrary finite branch-family adequacy checker theorem を含む。
+arbitrary finite branch-family adequacy checker theorem、
+component-level refinement support-lift theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -3588,3 +3591,65 @@ Cycle 75 後の total SCORE は 10258 であり、active threshold 12000 まで�
 次 cycle では、component-level refinement support-lift theorem、projection kernel rule for loss-aware Quality Surface drill-down、
 または finite semantic repair cocycle witness を狙う。genius unlock はまだ成立しておらず、semantic repair-gluing obstruction theorem の
 support map を積む段階にある。
+
+## Cycle 76: Component-level refinement support-lift theorem
+
+```text
+candidate: Component-level refinement support-lift theorem
+candidate_type: closure / unification / genius-support
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: genius-support / certificate-transport / repair-potential / computability
+goal_delta: Cycle 75 の supplied coverage predicate を explicit component lift と support-closure law から生成し、local branch-family adequacy checker を semantic repair-gluing target へ運ぶための support-lift node を固定した。
+project_value_delta: Research Lean layer に、component refinement と repair-support-preserving branch-family transport を分ける theorem package を追加し、future semantic cocycle / projection-kernel work の前提を作った。
+rival_delta: ADL / static analysis / conformance / dashboard / AI-review は visible component preservation や refinement row を扱えるが、support-preserving branch lift、target repair-frontier coverage、branch-family adequacy transport を theorem-level evidence として固定しない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/ComponentRefinementSupportLift.lean` and `lake build FormalAGResearch` passed. Core bridge / no-go declarations are axiom-free; selected checker / package declarations use only standard `propext`. No `sorryAx`, custom axiom, `Classical.choice`, `Quot.sound`, or `unsafe` was reported. G3 formalization audit passed. G4 confirmed base 70, multiplier 2.0, penalty 0, final +140.
+open_questions: finite semantic repair cocycle witness for the open genius target; projection-kernel rule for loss-aware Quality Surface drill-down; support-lift cocycle exactness criterion; semantic support nonfaithfulness over component-preserving refinement.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ComponentRefinementSupportLift.lean`
+adds a component-level coverage generator for the finite branch-family adequacy
+checker.  A code-indexed `componentLift` sends source exchange components into
+target branch components, and `ComponentSupportLiftClosed` sends touched source
+support into touched target support.  Together they produce the existing
+`SupportLiftClosedForBranch` witness needed by branch-reflection adequacy.
+
+Lean proves:
+
+- `BranchComponentLiftClosed`: a component lift sends source branch components into the target branch.
+- `ComponentSupportLiftClosed`: a component lift sends source support into target support.
+- `branchComponentLiftClosed_gives_supportLiftClosedForBranch`: branch membership lift plus support lift gives the branch-local support-lift kernel.
+- `CodeComponentLiftCovered`: a target code is covered by an explicit component lift from a source branch.
+- `codeComponentLiftCovered_gives_codeReflectionCovered`: component-lift coverage refines to the Cycle 75 reflection coverage predicate.
+- `listedComponentLiftCoverage_gives_branchFamilyAdequacy`: listed component-lift coverage plus exact target-order enumeration gives branch-family adequacy.
+- `firstUncoveredComponentLift?_none_gives_branchFamilyAdequacy`: no component-lift residual implies branch-family adequacy.
+- `selectedCollapsedComponentLift`: selected lift from the collapsed visible source branch to each selected target branch.
+- `selectedCollapsedComponentLift_covers_code`: trace plus repair-frontier support covers every selected code under the selected lift.
+- `traceOnly_componentLift_not_covers_refinedRepairFrontier`: trace-only support cannot cover the refined repair-frontier target branch by any component lift.
+- `selectedComponentLift_firstUncovered_none`: the selected component-lift checker returns no residual under trace plus repair-frontier support.
+- `selectedComponentLift_gives_branchFamilyAdequacy`: the selected component lift gives adequacy from the collapsed visible family to the selected family.
+- `componentLift_transports_selectedReflection`: component-level lift evidence transports collapsed visible transversality to selected branch-reflection transversality.
+- `componentLift_closes_selected_residual`: the selected trace-only residual is closed exactly by the component lift with trace plus repair-frontier support, while trace-only remains impossible.
+- `componentRefinementSupportLift_package`: the generic component-lift bridge, selected pass, selected transversal transport, and trace-only no-go package.
+
+This cycle is explicitly finite and support-relative. It does not claim global
+atlas refinement, canonical source extraction, ArchMap correctness, runtime
+repair synthesis, global sheaf completeness, or whole-codebase quality.  G2
+strict review lowered the base score to 70 because part of the generic bridge
+is an adapter into prior support-lift adequacy machinery; G4 confirmed the
+normal SCORE.  The open genius target remains `Semantic repair-gluing
+obstruction theorem for finite atom-supported quality atlases`; this cycle is
+a support node, not a genius unlock.
+
+### Next Frontier
+
+Cycle 76 後の total SCORE は 10398 であり、active threshold 12000 までは残り 1602 SCORE である。
+次 cycle では、finite semantic repair cocycle witness を第一候補として狙う。これは open genius target の中核 support node であり、
+local adequacy pass と global semantic repair-gluing failure の分離を Lean finite witness として固定する可能性がある。
+代替として、projection-kernel rule for loss-aware Quality Surface drill-down、support-lift cocycle exactness criterion、
+semantic support nonfaithfulness over component-preserving refinement を検討する。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 76 として、component-level refinement support-lift theorem を追加しました。
Cycle 75 の finite branch-family adequacy checker で supplied predicate だった coverage を、explicit component lift と support-closure law から生成します。
これは open genius target `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases` の support node であり、target unlock ではありません。

SCORE は G4 監査で +140 として confirm 済みです。

## 証明した定理

- `BranchComponentLiftClosed`
- `ComponentSupportLiftClosed`
- `branchComponentLiftClosed_gives_supportLiftClosedForBranch`
- `CodeComponentLiftCovered`
- `codeComponentLiftCovered_gives_codeReflectionCovered`
- `listedComponentLiftCoverage_gives_branchFamilyAdequacy`
- `firstUncoveredComponentLift?_none_gives_branchFamilyAdequacy`
- `selectedCollapsedComponentLift`
- `selectedCollapsedComponentLift_covers_code`
- `traceOnly_componentLift_not_covers_refinedRepairFrontier`
- `selectedComponentLift_firstUncovered_none`
- `selectedComponentLift_gives_branchFamilyAdequacy`
- `componentLift_transports_selectedReflection`
- `componentLift_closes_selected_residual`
- `componentRefinementSupportLift_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-component-refinement-support-lift.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/ComponentRefinementSupportLift.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` audit for reported declarations

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

`Closes #2348` は付けていません。#2348 は research-loop の runtime tracking Issue であり、active threshold 12000 まで open のまま継続します。
