### PR TITLE
G-aat-quality-surface-01 Cycle 88 edge transition obstruction

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -84,3 +84,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualAliasClassification
 import Formal.AG.Research.QualitySurface.SemanticResidualTransportNaturality
 import Formal.AG.Research.QualitySurface.SemanticResidualFiniteScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualIndexedTransport
+import Formal.AG.Research.QualitySurface.SemanticResidualEdgeTransitionObstruction

--- a/Formal/AG/Research/QualitySurface/SemanticResidualEdgeTransitionObstruction.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualEdgeTransitionObstruction.lean
@@ -1,0 +1,192 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualIndexedTransport
+
+/-!
+Cycle 88 evidence for `G-aat-quality-surface-01`.
+
+This file extracts the small cross-index obstruction criterion used by the
+Cycle 87 selected atlas witness.  If a selected atlas edge starts at an index
+with a semantic residual and ends at a residual-free index, then no residual
+transition can be closed along that edge.
+
+The result remains edge-relative and finite.  It does not assert arbitrary
+atlas gluing, source extraction completeness, ArchMap correctness, runtime
+repair synthesis, canonical global semantic ontology, UI correctness, or
+whole-codebase quality.
+-/
+
+universe u w
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualEdgeTransitionObstruction
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open RefinedSemanticRepairAtom
+
+/-! ## Edge residual-free obstruction criterion -/
+
+/-- A selected overlap index has no semantic projected residuals. -/
+def IndexedResidualFreeAt
+    {Index : Type w}
+    {Atom : Type u}
+    (projection : Index -> Atom -> BridgeComponent)
+    (cover : Index -> HandoffCechCover)
+    (index : Index) : Prop :=
+  forall residual,
+    Not
+      (SemanticProjectedResidual
+        (projection index) (cover index) residual)
+
+/-- A selected overlap index has at least one semantic projected residual. -/
+def IndexedResidualPresentAt
+    {Index : Type w}
+    {Atom : Type u}
+    (projection : Index -> Atom -> BridgeComponent)
+    (cover : Index -> HandoffCechCover)
+    (index : Index) : Prop :=
+  exists residual,
+    SemanticProjectedResidual
+      (projection index) (cover index) residual
+
+/--
+If an atlas edge starts at an index with a residual and ends at a residual-free
+index, then no residual transition closure can exist along that edge.
+-/
+theorem residualTransitionClosed_obstructed_of_edge_residualFree
+    {Index : Type w}
+    {Atom : Type u}
+    {edge : Index -> Index -> Prop}
+    {projection : Index -> Atom -> BridgeComponent}
+    {cover : Index -> HandoffCechCover}
+    {transition : Index -> Index -> Atom -> Atom}
+    {sourceIndex targetIndex : Index}
+    (hedge : edge sourceIndex targetIndex)
+    (hsource :
+      IndexedResidualPresentAt projection cover sourceIndex)
+    (htargetFree :
+      IndexedResidualFreeAt projection cover targetIndex) :
+    Not
+      (IndexedResidualTransitionClosed
+        edge projection cover transition) := by
+  intro hclosed
+  rcases hsource with ⟨residual, hresidual⟩
+  exact
+    htargetFree
+      (transition sourceIndex targetIndex residual)
+      (hclosed hedge residual hresidual)
+
+/-! ## Selected repair-frontier to flat edge -/
+
+/-- The selected repair-frontier index has the obligation residual. -/
+theorem selected_repairFrontierResidualPresent :
+    IndexedResidualPresentAt
+      selectedIndexedProjection
+      selectedIndexedCover
+      SelectedSemanticOverlapIndex.repairFrontier := by
+  refine ⟨repairFrontierObligation, ?_⟩
+  simpa [selectedIndexedProjection, selectedIndexedCover,
+    SemanticProjectedResidual, refinedSemanticComponent]
+    using
+      ((repairFrontierOverlapBasis).1
+        BridgeComponent.repairFrontier rfl)
+
+/-- The selected flat index has no refined semantic residual. -/
+theorem selected_flatIndexedResidualFree :
+    IndexedResidualFreeAt
+      selectedIndexedProjection
+      selectedIndexedCover
+      SelectedSemanticOverlapIndex.flat := by
+  intro residual hresidual
+  exact
+    selected_flat_no_refinedResidual residual
+      (by
+        simpa [selectedIndexedProjection, selectedIndexedCover]
+          using hresidual)
+
+/--
+The Cycle 87 selected frontier-to-flat no-go follows from the generic
+residual-present to residual-free edge obstruction criterion.
+-/
+theorem selected_no_frontierToFlatResidualTransition_by_freeTarget
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (IndexedResidualTransitionClosed
+        selectedFrontierToFlatEdge
+        selectedIndexedProjection
+        selectedIndexedCover
+        transition) := by
+  exact
+    residualTransitionClosed_obstructed_of_edge_residualFree
+      (edge := selectedFrontierToFlatEdge)
+      (projection := selectedIndexedProjection)
+      (cover := selectedIndexedCover)
+      (transition := transition)
+      (sourceIndex := SelectedSemanticOverlapIndex.repairFrontier)
+      (targetIndex := SelectedSemanticOverlapIndex.flat)
+      selected_frontierToFlatEdge
+      selected_repairFrontierResidualPresent
+      selected_flatIndexedResidualFree
+
+/-! ## Theorem package -/
+
+/--
+Cycle-88 theorem package: a residual-present to residual-free atlas edge
+obstructs residual transition closure, and the selected repair-frontier to flat
+edge is an instance.
+-/
+theorem semanticResidualEdgeTransitionObstruction_package :
+    (forall {Index : Type w}
+      {Atom : Type u}
+      {edge : Index -> Index -> Prop}
+      {projection : Index -> Atom -> BridgeComponent}
+      {cover : Index -> HandoffCechCover}
+      {transition : Index -> Index -> Atom -> Atom}
+      {sourceIndex targetIndex : Index},
+      edge sourceIndex targetIndex ->
+        IndexedResidualPresentAt projection cover sourceIndex ->
+          IndexedResidualFreeAt projection cover targetIndex ->
+            Not
+              (IndexedResidualTransitionClosed
+                edge projection cover transition)) /\
+      IndexedResidualPresentAt
+        selectedIndexedProjection
+        selectedIndexedCover
+        SelectedSemanticOverlapIndex.repairFrontier /\
+      IndexedResidualFreeAt
+        selectedIndexedProjection
+        selectedIndexedCover
+        SelectedSemanticOverlapIndex.flat /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (IndexedResidualTransitionClosed
+            selectedFrontierToFlatEdge
+            selectedIndexedProjection
+            selectedIndexedCover
+            transition)) := by
+  exact
+    ⟨fun {Index} {Atom} {edge} {projection} {cover} {transition}
+        {sourceIndex} {targetIndex} =>
+        residualTransitionClosed_obstructed_of_edge_residualFree
+          (edge := edge)
+          (projection := projection)
+          (cover := cover)
+          (transition := transition)
+          (sourceIndex := sourceIndex)
+          (targetIndex := targetIndex),
+      selected_repairFrontierResidualPresent,
+      selected_flatIndexedResidualFree,
+      selected_no_frontierToFlatResidualTransition_by_freeTarget⟩
+
+end SemanticResidualEdgeTransitionObstruction
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-edge-transition-obstruction.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-edge-transition-obstruction.md
@@ -1,0 +1,118 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: closer / edge-obstruction
+candidate_type: closure / edge-obstruction / genius-support
+capability_category: semantic-obstruction / indexed-transport / repair-coherence / certificate-transport / quality-surface
+expected_base_score: 30
+expected_evidence_multiplier: 2.0
+expected_final_score: 60
+evidence_stage: proved-in-research
+rival_advantage: Per-overlap component views do not expose the residual-present to residual-free edge obstruction that blocks residual transition closure.
+origin: cycle-88
+tags: [quality-surface, semantic-repair, indexed-transport, edge-obstruction, residual-free, genius-support]
+created: 2026-06-22
+cycle: 88
+lean: proved-in-research
+---
+
+# Semantic residual edge transition obstruction
+
+## 主張
+
+indexed finite overlap family の edge が、semantic residual を持つ source index から residual-free な target index へ向かうなら、どんな residual transition closure も存在しない。
+Cycle 87 の selected repair-frontier-to-flat no-go は、この一般 criterion の instance である。
+
+## 候補種別
+
+`closure` / `edge-obstruction` / `genius-support`
+
+## 依拠
+
+- Cycle 87: indexed residual support transport and selected frontier-to-flat transition no-go。
+- `SemanticProjectedResidual` / `IndexedResidualTransitionClosed`。
+
+## 非自明性
+
+Cycle 87 では selected witness を直接証明した。
+Cycle 88 はその理由を、edge source に residual が存在し target が residual-free であるという小さな一般 obstruction criterion に抽出する。
+大定理ではないが、frontier-to-flat no-go の原因を theorem として分離し、次の broader atlas-edge family theorem の再利用単位にする。
+
+## 数学的興味
+
+residual transition closure は、edge に沿って source residual を target residual へ送ることを要求する。
+target index が residual-free なら、source residual の存在だけで closure は不可能になる。
+これは indexed atlas obstruction の最小局所形であり、selected repair-frontier-to-flat edge の失敗を説明する。
+
+## GOAL への前進
+
+Cycle 87 の no-go witness を一般 edge obstruction criterion に圧縮し、finite semantic repair-gluing obstruction theorem へ向かう小さな support node を追加する。
+threshold 到達用の小 cycle だが、単なる ledger 調整ではなく Lean-proved reusable criterion である。
+
+## ライバルに対する有効性
+
+ADL / dashboard / AI review summary は component view や per-overlap status を提示できるが、edge source の residual presence と target residual-free condition の組み合わせが transition closure を不可能にすることを certificate として分離しにくい。
+AAT は residual identity と cover-relative residual absence を同じ finite criterion に入れられる。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 87 selected no-go の原因を general edge criterion として抽出し、残り threshold を越える小さな closure nodeにする。
+- `dullness_risk`: theorem は短く、Cycle 87 の immediate abstraction に近い。価値は selected no-go の原因を reusable obstruction criterion として固定する点に限定される。
+- `proof_or_evidence_plan`: `SemanticResidualEdgeTransitionObstruction.lean` で residual-present/residual-free definitions、generic no-transition theorem、selected instance、package を証明する。
+
+## CS / SWE への帰結
+
+finite overlap family の diagnostic では、edge source に未解消 residual obligation があり、target view が residual-free と読まれている場合、その edge は semantic residual transition closure を certify できない。
+component row の pass/fail だけでなく、residual presence / absence の edge-level mismatch を certificate として見る必要がある。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualEdgeTransitionObstruction.lean` に固定した。
+
+- `IndexedResidualFreeAt`
+- `IndexedResidualPresentAt`
+- `residualTransitionClosed_obstructed_of_edge_residualFree`
+- `selected_repairFrontierResidualPresent`
+- `selected_flatIndexedResidualFree`
+- `selected_no_frontierToFlatResidualTransition_by_freeTarget`
+- `semanticResidualEdgeTransitionObstruction_package`
+
+G3 初期実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualEdgeTransitionObstruction.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualEdgeTransitionObstruction`: pass。
+- `lake build Formal.AG.Research`: pass。
+- axiom probe: generic edge criterion は axiom-free。selected residual-present / residual-free / no-go / package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はない。
+
+## 審判メモ
+
+- G2 rigor: accept / base 18 / genius no。定義からの短い矛盾に近いため小補題評価。
+- G2 research value: accept / base 20 / genius no。Cycle 87 no-go の原因を reusable criterion として分離する support lemma。
+- G2 repo integration: accept / base 30 / genius no。Research layer として自然だが小さな support node。
+- G2 rival comparison: accept / base 38 / genius no。per-overlap status ではなく edge-level transition obstruction を certificate 化する差分あり。
+- G4 SCORE 監査: confirm / base 30 / multiplier 2.0 / penalty 0 / final +60。total 11992 -> 12052。genius は support node であり unlock ではない。
+
+## 追加 required fields
+
+- `mathematical_interest`: residual-present to residual-free edge が transition closure を阻む最小 obstruction criterion。
+- `goal_advancement`: Cycle 87 selected no-go を再利用可能な edge obstruction theorem に圧縮する。
+- `planned_theorem_names`: `residualTransitionClosed_obstructed_of_edge_residualFree`, `selected_no_frontierToFlatResidualTransition_by_freeTarget`, `semanticResidualEdgeTransitionObstruction_package`
+- `visible_projection`: selected frontier-to-flat atlas edge。
+- `protected_structure`: source residual presence, target residual-free cover, residual transition closure。
+- `exactness_or_minimality_claim`: target residual-free condition に相対化した no-transition criterion。global atlas minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: source residual cannot be transported into a residual-free target index。
+- `previous_cycle_delta`: Cycle 87 の selected transition no-go を general edge criterion として抽出する。
+- `rival_stress_test`: per-overlap component pass/fail cannot replace edge-level residual presence / absence obstruction。
+- `genius_potential`: support node
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: edge-local obstruction kernel for indexed residual transition failure.
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-indexed-transport.md`
+
+## 進捗ログ
+
+- 2026-06-22: Cycle 88 edge obstruction closer として picked。
+- 2026-06-22: Lean 証拠を `SemanticResidualEdgeTransitionObstruction.lean` に固定し、単体 `lake env lean`、module build、`Formal.AG.Research` build が通った。
+- 2026-06-22: G4 SCORE 監査で base 30 / final +60 に確定し、total SCORE 12052 で active threshold 12000 を超えた。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 11992
+- total SCORE: 12052
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -92,8 +92,9 @@
   - semantic-obstruction / computability / transport-naturality / repair-coherence / quality-surface: 156
   - semantic-obstruction / projection-nonfaithfulness / repair-coherence / certificate-transport / quality-surface: 130
   - semantic-obstruction / indexed-transport / repair-coherence / certificate-transport / quality-surface: 168
+  - semantic-obstruction / indexed-transport / edge-obstruction / repair-coherence / certificate-transport / quality-surface: 60
 - evidence portfolio:
-  - proved-in-research: 87
+  - proved-in-research: 88
 
 ## Phase synthesis
 
@@ -109,7 +110,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-87 件の Lean-proved research artifacts は、次の paper seed を形成している。
+88 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -134,6 +135,7 @@ certificate の基本単位は
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
 - semantic residual alias classification は、same component projection と explicit missed residual witness の下で residual alias gap と missed residual normal form が一致することを示す。
 - semantic residual indexed transport は、indexed finite overlap family 上の residual support transport と selected frontier-to-flat residual transition no-go を示す。
+- semantic residual edge transition obstruction は、residual-present source から residual-free target への edge が transition closure を阻む一般 criterion を示す。
 
 ### Related-work separation
 
@@ -172,9 +174,9 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
 その後、tracking Issue の active threshold は 10000 に更新され、Cycle 74 後の total SCORE は 10090 である。
-現在の active threshold は tracking Issue 上で 12000 に更新され、Cycle 87 後の total SCORE は 11992 である。
+現在の active threshold は tracking Issue 上で 12000 に更新され、Cycle 88 後の total SCORE は 12052 である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 87 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 88 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -194,7 +196,8 @@ semantic residual alias nonfaithfulness theorem、
 semantic-fiber-aware viewer criterion theorem、
 semantic residual component faithfulness theorem、
 semantic residual alias classification theorem、
-semantic residual indexed transport theorem を含む。
+semantic residual indexed transport theorem、
+semantic residual edge transition obstruction theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -4443,3 +4446,52 @@ base 82、repo 統合と rival 比較は base 84 と判定した。G4 は expect
 Cycle 87 後の total SCORE は 11992 であり、active threshold 12000 までは残り 8 SCORE である。
 次 cycle では、transition scanner、edge-order minimality、または finite atlas semantic repair-gluing obstruction one-way theorem の小さな support node を狙う。
 genius unlock はまだ成立していない。
+
+## Cycle 88: Semantic residual edge transition obstruction
+
+```text
+candidate: Semantic residual edge transition obstruction
+candidate_type: closure / edge-obstruction / genius-support
+evidence_stage: proved-in-research
+base_score: 30
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 60
+category: semantic-obstruction / indexed-transport / edge-obstruction / repair-coherence / certificate-transport / quality-surface
+goal_delta: Cycle 87 の selected frontier-to-flat no-go の原因を、source residual present / target residual-free の再利用可能な edge-local obstruction criterion として抽出した。
+project_value_delta: Research Lean layer に、broader atlas-edge family theorem / finite semantic repair-gluing obstruction theorem へ使える小さな edge obstruction kernel と selected instance を追加した。
+rival_delta: ADL / dashboard / AI review summary が per-overlap view を出せても、source residual presence と target residual-free condition の組み合わせが transition closure を不可能にすることを certificate として分離する。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualEdgeTransitionObstruction.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualEdgeTransitionObstruction`, `lake build Formal.AG.Research`, and `lake build` passed. The full build only replayed pre-existing `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warnings. Axiom probe reported the generic edge criterion axiom-free; selected residual-present / residual-free / no-go / package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: broader atlas-edge obstruction theorem; residual-present / residual-free mismatch minimality or finite-family characterization; transition scanner.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualEdgeTransitionObstruction.lean`
+extracts the edge-local obstruction criterion behind Cycle 87.  If an atlas
+edge starts at an index with a semantic residual and ends at an index with no
+semantic residuals, then any transition closure along that edge is impossible.
+
+Lean proves:
+
+- `IndexedResidualFreeAt`: a selected overlap index has no semantic projected residuals.
+- `IndexedResidualPresentAt`: a selected overlap index has at least one semantic projected residual.
+- `residualTransitionClosed_obstructed_of_edge_residualFree`: residual-present source plus residual-free target obstructs residual transition closure.
+- `selected_repairFrontierResidualPresent`: the selected repair-frontier index has the obligation residual.
+- `selected_flatIndexedResidualFree`: the selected flat index has no refined semantic residual.
+- `selected_no_frontierToFlatResidualTransition_by_freeTarget`: the Cycle 87 selected frontier-to-flat no-go follows from the generic criterion.
+- `semanticResidualEdgeTransitionObstruction_package`: theorem package.
+
+This cycle is intentionally small.  It is not a `genius unlock`, not a new
+global gluing theorem, and not a claim about arbitrary atlas minimality,
+source extraction completeness, ArchMap correctness, runtime repair synthesis,
+UI correctness, or whole-codebase quality.  G2 accepted the candidate with
+base scores 18 / 20 / 30 / 38; G4 confirmed base 30 / multiplier 2.0 /
+final +60.  Cycle 88 raises total SCORE from 11992 to 12052, passing the active
+threshold 12000.
+
+### Phase Boundary Candidate
+
+Cycle 88 後の total SCORE は 12052 であり、tracking Issue active threshold 12000 を超えた。
+portfolio constraint は既に満たされており、この phase は G6 phase boundary 判定に進める。
+genius unlock は成立していないが、open target `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases` に対する support node は増えた。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 88 として、Cycle 87 の selected frontier-to-flat residual transition no-go を、source residual present / target residual-free edge の一般 obstruction criterion に切り出しました。小さな support node ですが、G4 SCORE 監査で base 30 / multiplier 2.0 / final +60 が確定し、total SCORE は 11992 -> 12052 で active threshold 12000 を超えます。

tracking Issue は閉じません。PR merge 後に G6 phase boundary 判定へ進めます。

## 証明した定理

- `IndexedResidualFreeAt`
- `IndexedResidualPresentAt`
- `residualTransitionClosed_obstructed_of_edge_residualFree`
- `selected_repairFrontierResidualPresent`
- `selected_flatIndexedResidualFree`
- `selected_no_frontierToFlatResidualTransition_by_freeTarget`
- `semanticResidualEdgeTransitionObstruction_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-edge-transition-obstruction.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualEdgeTransitionObstruction.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualEdgeTransitionObstruction`
- [x] `lake build Formal.AG.Research`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] local path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` audit: generic edge criterion は axiom-free。selected residual-present / residual-free / no-go / package は標準 `propext` / `Quot.sound` のみ。

## チェックリスト

- [x] tracking Issue を `Refs #2348` 形式で本文に記載した（research-loop の正本なので close しない）
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
