### PR TITLE
研究ループ Cycle 89 の residual transition cut を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -85,3 +85,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualTransportNaturality
 import Formal.AG.Research.QualitySurface.SemanticResidualFiniteScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualIndexedTransport
 import Formal.AG.Research.QualitySurface.SemanticResidualEdgeTransitionObstruction
+import Formal.AG.Research.QualitySurface.SemanticResidualTransitionCut

--- a/Formal/AG/Research/QualitySurface/SemanticResidualTransitionCut.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualTransitionCut.lean
@@ -1,0 +1,269 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualEdgeTransitionObstruction
+import Formal.AG.Research.QualitySurface.VisibleLocalSemanticGluingObstruction
+
+/-!
+Cycle 89 evidence for `G-aat-quality-surface-01`.
+
+This file packages the Cycle 88 residual-present / residual-free edge
+obstruction as a finite atlas cut certificate.  A finite semantic repair atlas
+skeleton has an edge family, a residual projection, and an overlap cover at
+each index.  A residual transition cut is an active edge whose source index
+has a semantic residual while whose target index is residual-free.  Such a cut
+obstructs residual transition closure over the atlas edge family.
+
+The result is deliberately transition-closure-relative.  It does not assert
+arbitrary sheaf gluing, a Cech obstruction class, source extraction
+completeness, ArchMap correctness, runtime repair synthesis, canonical global
+semantic ontology, UI correctness, or whole-codebase quality.
+-/
+
+universe u w
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualTransitionCut
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+
+/-! ## Finite atlas transition cut certificate -/
+
+/--
+A finite semantic repair atlas skeleton for transition-closure questions.
+It records only the edge family and the residual reading at each index.
+-/
+structure FiniteSemanticRepairAtlasSkeleton
+    (Index : Type w)
+    (Atom : Type u) where
+  indexOrder : List Index
+  index_complete : forall index, index ∈ indexOrder
+  atomOrder : List Atom
+  atom_complete : forall atom, atom ∈ atomOrder
+  edge : Index -> Index -> Prop
+  projection : Index -> Atom -> BridgeComponent
+  cover : Index -> HandoffCechCover
+
+/-- Residual transition closure over every active edge of the atlas skeleton. -/
+def AtlasResidualTransitionClosed
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    (transition : Index -> Index -> Atom -> Atom) : Prop :=
+  IndexedResidualTransitionClosed
+    atlas.edge atlas.projection atlas.cover transition
+
+/--
+Transition-coherent atlas data includes residual transition closure over the
+active edge family.  This is an explicit boundary object, not an arbitrary
+global gluing claim.
+-/
+structure TransitionCoherentAtlasData
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    (transition : Index -> Index -> Atom -> Atom) where
+  edge_transitions :
+    AtlasResidualTransitionClosed atlas transition
+
+/-- Transition-coherent atlas data supplies the active edge obligations. -/
+theorem transitionCoherentAtlasData_implies_edgeTransitions
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {transition : Index -> Index -> Atom -> Atom}
+    (data : TransitionCoherentAtlasData atlas transition) :
+    AtlasResidualTransitionClosed atlas transition :=
+  data.edge_transitions
+
+/--
+A residual transition cut is an active atlas edge from a residual-present
+source index to a residual-free target index.
+-/
+structure ResidualTransitionCut
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom) where
+  sourceIndex : Index
+  targetIndex : Index
+  edge_active : atlas.edge sourceIndex targetIndex
+  source_residual_present :
+    IndexedResidualPresentAt atlas.projection atlas.cover sourceIndex
+  target_residual_free :
+    IndexedResidualFreeAt atlas.projection atlas.cover targetIndex
+
+/--
+Any residual transition cut obstructs atlas-wide residual transition closure.
+-/
+theorem residualTransitionCut_obstructs_atlasTransitionClosure
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (cut : ResidualTransitionCut atlas)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not
+      (AtlasResidualTransitionClosed atlas transition) := by
+  exact
+    residualTransitionClosed_obstructed_of_edge_residualFree
+      (edge := atlas.edge)
+      (projection := atlas.projection)
+      (cover := atlas.cover)
+      (transition := transition)
+      (sourceIndex := cut.sourceIndex)
+      (targetIndex := cut.targetIndex)
+      cut.edge_active
+      cut.source_residual_present
+      cut.target_residual_free
+
+/--
+A residual transition cut also rules out any transition-coherent atlas data
+for the same transition.
+-/
+theorem residualTransitionCut_obstructs_transitionCoherentData
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (cut : ResidualTransitionCut atlas)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData atlas transition)) := by
+  intro hdata
+  rcases hdata with ⟨data⟩
+  exact
+    residualTransitionCut_obstructs_atlasTransitionClosure
+      cut transition
+      (transitionCoherentAtlasData_implies_edgeTransitions data)
+
+/-! ## Selected frontier-to-flat finite atlas cut -/
+
+/-- The selected frontier-to-flat edge family as a finite atlas skeleton. -/
+def selectedFrontierFlatAtlasSkeleton :
+    FiniteSemanticRepairAtlasSkeleton
+      SelectedSemanticOverlapIndex
+      RefinedSemanticRepairAtom where
+  indexOrder :=
+    [SelectedSemanticOverlapIndex.flat,
+      SelectedSemanticOverlapIndex.repairFrontier]
+  index_complete := by
+    intro index
+    cases index <;> simp
+  atomOrder :=
+    [RefinedSemanticRepairAtom.traceContract,
+      RefinedSemanticRepairAtom.repairFrontierSurface,
+      RefinedSemanticRepairAtom.repairFrontierObligation]
+  atom_complete := by
+    intro atom
+    cases atom <;> simp
+  edge := selectedFrontierToFlatEdge
+  projection := selectedIndexedProjection
+  cover := selectedIndexedCover
+
+/-- The selected frontier-to-flat edge is a residual transition cut. -/
+def selectedFrontierFlatResidualTransitionCut :
+    ResidualTransitionCut selectedFrontierFlatAtlasSkeleton where
+  sourceIndex := SelectedSemanticOverlapIndex.repairFrontier
+  targetIndex := SelectedSemanticOverlapIndex.flat
+  edge_active := selected_frontierToFlatEdge
+  source_residual_present := selected_repairFrontierResidualPresent
+  target_residual_free := selected_flatIndexedResidualFree
+
+/-- The selected cut obstructs every frontier-to-flat residual transition closure. -/
+theorem selected_frontierFlatCut_obstructs_transitionClosure
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    residualTransitionCut_obstructs_atlasTransitionClosure
+      selectedFrontierFlatResidualTransitionCut
+      transition
+
+/--
+The selected cut rules out transition-coherent atlas data on the
+frontier-to-flat skeleton.
+-/
+theorem selected_frontierFlatCut_obstructs_transitionCoherentData
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    residualTransitionCut_obstructs_transitionCoherentData
+      selectedFrontierFlatResidualTransitionCut
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-89 theorem package: a residual transition cut is a finite atlas
+certificate obstructing residual transition closure, and the selected
+frontier-to-flat atlas realizes such a cut while still carrying the earlier
+visible/local declared-clearance profile.
+-/
+theorem semanticResidualTransitionCut_package :
+    (forall {Index : Type w}
+      {Atom : Type u}
+      {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+      ResidualTransitionCut atlas ->
+        forall transition : Index -> Index -> Atom -> Atom,
+          Not
+            (AtlasResidualTransitionClosed atlas transition)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        ResidualTransitionCut atlas ->
+          forall transition : Index -> Index -> Atom -> Atom,
+            Not
+              (Nonempty
+                (TransitionCoherentAtlasData atlas transition))) /\
+      Nonempty
+        (ResidualTransitionCut selectedFrontierFlatAtlasSkeleton) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedFrontierFlatAtlasSkeleton
+              transition))) /\
+      VisibleLocalDeclaredClearanceProfile
+        RepairTransportCechCommutatorCurvature.selectedRepairTransportCechCommutatorCell
+        ComponentClearanceSemanticObstruction.traceRepairFrontierDeclaredPlan := by
+  exact
+    ⟨fun {_Index} {_Atom} {_atlas} cut transition =>
+        residualTransitionCut_obstructs_atlasTransitionClosure
+          cut transition,
+      fun {_Index} {_Atom} {_atlas} cut transition =>
+        residualTransitionCut_obstructs_transitionCoherentData
+          cut transition,
+      ⟨selectedFrontierFlatResidualTransitionCut⟩,
+      selected_frontierFlatCut_obstructs_transitionClosure,
+      selected_frontierFlatCut_obstructs_transitionCoherentData,
+      selected_visibleLocalDeclaredClearanceProfile⟩
+
+end SemanticResidualTransitionCut
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-residual-transition-cut-theorem.md
+++ b/research/ideas/g-aat-quality-surface-01-residual-transition-cut-theorem.md
@@ -1,0 +1,141 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: closer / obstruction / unifier / wildcard convergence
+candidate_type: unification / genius-support
+capability_category: semantic-obstruction / finite-atlas-transition / repair-coherence / genius-support
+expected_base_score: 65
+expected_evidence_multiplier: 2.0
+expected_final_score: 130
+evidence_stage: proved-in-research
+rival_advantage: ADL, conformance dashboards, metric dashboards, static analyzers, and AI review summaries can expose edge or component rows, but they do not give a proof-carrying residual transition cut certificate over the finite atom-supported atlas.
+origin: cycle-89
+tags: [quality-surface, semantic-repair, indexed-transport, residual-cut, genius-support]
+created: 2026-06-23
+cycle: 89
+lean: proved-in-research
+planned_report_section: "Cycle 89: Residual transition cut theorem for finite semantic quality atlases"
+---
+
+# Residual Transition Cut Theorem for Finite Semantic Quality Atlases
+
+## 主張
+
+有限 atom-supported quality atlas の edge family 上で、source index に semantic residual が存在し、target index が residual-free である edge cut があるなら、その atlas はその edge family に沿う residual transition closure を満たせない。
+Cycle 88 の residual-present / residual-free edge obstruction を、single edge の no-go から finite atlas skeleton 上の cut certificate へ持ち上げる。
+ここでは arbitrary sheaf gluing、obstruction class、cohomology class、実コード全体の品質、source extraction completeness は主張しない。
+
+## 候補種別
+
+`unification` / `genius-support`
+
+## 依拠
+
+- Cycle 87: indexed residual support transport と selected frontier-to-flat transition no-go。
+- Cycle 88: `IndexedResidualPresentAt`、`IndexedResidualFreeAt`、`residualTransitionClosed_obstructed_of_edge_residualFree`。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+単一 edge の矛盾を繰り返すだけでは弱い。
+この候補では、finite complete index list / atom list を持つ atlas skeleton、transition closure、single-edge residual transition cut witness を明示的な certificate object として分ける。
+ただし G2 revise に従い、任意の大域貼り合わせ主張は使わない。
+成果は、transition-coherent finite atlas の edge obligation を single-edge residual cut witness が阻む、という reusable support node に限定する。
+
+## 数学的興味
+
+semantic residual の obstruction locus を、点wise failure ではなく finite atlas edge family 上の cut witness として読む。
+これは将来の obstruction-class frontier へ進む前段であり、residual support transport、edge closure、atlas-wide residual transition closure の境界を一つの有限対象に圧縮する。
+
+## GOAL への前進
+
+`broader atlas-edge obstruction theorem` frontier を進め、open genius target の support map に、edge-local obstruction から finite-atlas transition obstruction へ上げる bridge node を追加する。
+
+## ライバルに対する有効性
+
+ADL は component / connector / view / constraint を保持できるが、semantic residual identity と residual-free target condition の cut が atlas-wide residual transition closure を阻むことを theorem-level certificate として固定しない。
+静的解析器や conformance checker は failed edge や rule violation を返せるが、finite atom-supported residual cut の exact obstruction object は返さない。
+metric dashboard は scalar/row projection へ潰し、AI review summary は説明を生成できても、chosen atom vocabulary 上の proof-carrying residual cut certificate を残さない。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 87/88 の selected no-go と generic edge criterion を finite atlas skeleton 上の residual cut witness へ統合する。genius unlock ではなく support cycle として通常 SCORE に載せる。G4 SCORE 監査は Cycle 88 の直接 lift に近い点を反映し、base 65 / final 130 へ reduce した。
+- `dullness_risk`: cut certificate が単に Cycle 88 theorem の引数を包んだだけなら低価値になる。atlas skeleton、transition obligation、cut certificate、selected finite atlas instance、rival separation を揃え、次の scanner / minimal cut / obstruction-class frontier への bridge として読める必要がある。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualTransitionCut.lean` で finite atlas skeleton、atlas-wide residual transition closure、residual transition cut certificate、cut obstruction theorem、selected frontier-to-flat cut instance、package theorem を証明する。
+
+## CS / SWE への帰結
+
+finite atlas diagnostic では、edge row が component-compatible に見えても、source 側の semantic residual と target 側の residual-free reading が cut を形成すれば semantic repair transition closure は certify できない。
+dashboard や AI summary が edge を見せるだけでは足りず、residual cut certificate を quality surface の protected structure として保持する必要がある。
+
+## 証明・根拠の見込み
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualTransitionCut.lean` に固定した。
+
+- `FiniteSemanticRepairAtlasSkeleton`
+- `AtlasResidualTransitionClosed`
+- `TransitionCoherentAtlasData`
+- `ResidualTransitionCut`
+- `transitionCoherentAtlasData_implies_edgeTransitions`
+- `residualTransitionCut_obstructs_atlasTransitionClosure`
+- `residualTransitionCut_obstructs_transitionCoherentData`
+- `selectedFrontierFlatResidualTransitionCut`
+- `selected_frontierFlatCut_obstructs_transitionClosure`
+- `selected_frontierFlatCut_obstructs_transitionCoherentData`
+- `semanticResidualTransitionCut_package`
+
+G3 初期実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualTransitionCut.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualEdgeTransitionObstruction`: pass。
+- dependency build は既存 QualitySurface module 群を含めて pass。
+- G3 形式化品質監査の revise に従い、`FiniteSemanticRepairAtlasSkeleton` に complete finite `indexOrder` / `atomOrder` witnesses を追加した。selected instance は flat / repair-frontier index と three refined semantic atoms を明示的に列挙する。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualTransitionCut`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: `transitionCoherentAtlasData_implies_edgeTransitions`、`residualTransitionCut_obstructs_atlasTransitionClosure`、`residualTransitionCut_obstructs_transitionCoherentData` は axiom-free。selected frontier-flat closure / data obstruction と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+- G3 公理監査: pass。core cut theorem は axiom-free、selected finite witness/package の標準公理依存は既存 selected Prop / quotient witness 由来として許容。
+- G3 Lean 形式化品質監査: pass。finite skeleton の complete lists と single-edge cut witness が候補カードと一致し、minimality、scanner exactness、obstruction class は今回の主張外として分離済み。
+- G3.5 同期監査: synced。`Formal/AG/Research.lean` aggregate import と planned report section も同期済み。
+- G4 SCORE 監査: reduce / base 65 / multiplier 2.0 / penalty 0 / final +130。open genius target の support node だが unlock ではない。
+
+claim boundary は、有限 index family、選ばれた semantic atom vocabulary、cover-relative residual predicate、selected transition closure 上に留める。
+source extraction completeness、ArchMap correctness、runtime repair synthesis、canonical semantic ontology、UI correctness、whole-codebase quality は主張しない。
+
+## 審判メモ
+
+- 厳密性: G2 A は final accept / base 72 / genius no。Cycle 88 の lift なので一部 immediate corollary だが、finite atlas skeleton と cut certificate を明示する support theorem として採択。
+- 研究価値: G2 B は final accept / base 78 / genius no。target support として価値はあるが、90 点級ではないと判定。
+- repo 全体価値: G2 C は accept / base 84。AAT / Research / 将来 tooling surface に有効だが、arbitrary sheaf gluing や whole-codebase quality は不可。
+- ライバル比較: G2 D は accept / base 82。proof-carrying residual cut certificate は rival 差分になるが、実装が edge closure の別名だけなら弱い。
+
+## 追加 required fields
+
+- `mathematical_interest`: residual support transport failure を finite atlas cut certificate として読む。
+- `goal_advancement`: Cycle 88 edge obstruction を open genius target の finite atlas support node へ持ち上げる。
+- `planned_theorem_names`: `residualTransitionCut_obstructs_atlasTransitionClosure`, `selected_frontierFlatCut_obstructs_transitionClosure`, `semanticResidualTransitionCut_package`
+- `visible_projection`: component-preserving atlas edge / declared local clearance surface / scalar verdict。
+- `protected_structure`: complete finite index/atom lists、semantic residual atoms、residual-present source、residual-free target、edge transition closure。
+- `exactness_or_minimality_claim`: single-edge cut witness があれば atlas transition closure は不可能。minimality、scanner exactness、obstruction class は今回の主張に含めず、次 frontier に残す。
+- `nonfaithfulness_or_failure_mode`: visible/component projection は edge family を見せても residual cut obstruction を失いうる。
+- `previous_cycle_delta`: Cycle 88 の single-edge obstruction を finite atlas skeleton と atlas-wide residual transition obstruction に接続する。
+- `rival_stress_test`: ADL / static analysis / conformance / dashboard / AI review の各 rival は edge/status/summary を扱えるが、semantic residual cut の proof-carrying obstruction certificate を保持しない。
+- `genius_potential`: support-cycle。1000 点 unlock は狙わず、target theorem への bridge として通常 SCORE で審判する。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: edge-local obstruction から finite-atlas obstruction class へ上げる cut certificate node。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-edge-transition-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-indexed-transport.md`
+- planned report section: `Cycle 89: Residual transition cut theorem for finite semantic quality atlases`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 89 G1 候補 pool から picked candidate として作成。
+- 2026-06-23: G2 A/B の revise に従い、任意の大域貼り合わせ / obstruction class / cohomology class 方向を外し、transition-coherent finite atlas cut certificate へ主張を下げた。
+- 2026-06-23: G2 final は A base 72、B base 78、C base 84、D base 82、全員 accept、genius eligibility は no。G4 前入力として base 72 / final 144 に更新。
+- 2026-06-23: Lean 証拠を `SemanticResidualTransitionCut.lean` に固定し、単体 `lake env lean` が通った。
+- 2026-06-23: G3 形式化品質監査の revise を受け、finite skeleton に complete finite lists を追加し、カードの claim を single-edge cut witness として同期した。
+- 2026-06-23: module build、FormalAGResearch、G3 公理監査、G3 形式化品質監査が pass。
+- 2026-06-23: G3.5 revise に従い `Formal/AG/Research.lean` の aggregate import と planned report section を同期。
+- 2026-06-23: G4 SCORE 監査で base 65 / final +130 に reduce。total SCORE 12052 -> 12182、active threshold 15000 まで残り 2818。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 12052
+- total SCORE: 12182
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -93,8 +93,9 @@
   - semantic-obstruction / projection-nonfaithfulness / repair-coherence / certificate-transport / quality-surface: 130
   - semantic-obstruction / indexed-transport / repair-coherence / certificate-transport / quality-surface: 168
   - semantic-obstruction / indexed-transport / edge-obstruction / repair-coherence / certificate-transport / quality-surface: 60
+  - semantic-obstruction / finite-atlas-transition / repair-coherence / genius-support: 130
 - evidence portfolio:
-  - proved-in-research: 88
+  - proved-in-research: 89
 
 ## Phase synthesis
 
@@ -110,7 +111,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-88 件の Lean-proved research artifacts は、次の paper seed を形成している。
+89 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -136,6 +137,7 @@ certificate の基本単位は
 - semantic residual alias classification は、same component projection と explicit missed residual witness の下で residual alias gap と missed residual normal form が一致することを示す。
 - semantic residual indexed transport は、indexed finite overlap family 上の residual support transport と selected frontier-to-flat residual transition no-go を示す。
 - semantic residual edge transition obstruction は、residual-present source から residual-free target への edge が transition closure を阻む一般 criterion を示す。
+- semantic residual transition cut は、complete finite index / atom lists を持つ atlas skeleton 上で、single-edge residual cut witness が atlas-wide residual transition closure を阻むことを示す。
 
 ### Related-work separation
 
@@ -174,9 +176,10 @@ support family、trace exactness、route-internal defect excursion、repair nece
 
 Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 7000 に到達した。
 その後、tracking Issue の active threshold は 10000 に更新され、Cycle 74 後の total SCORE は 10090 である。
-現在の active threshold は tracking Issue 上で 12000 に更新され、Cycle 88 後の total SCORE は 12052 である。
+tracking Issue の active threshold は 12000 に更新され、Cycle 88 後の total SCORE は 12052 で 12000 phase boundary に到達した。
+その後、tracking Issue の active threshold は 15000 に更新され、Cycle 89 後の total SCORE は 12182 である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 88 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 89 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -4495,3 +4498,60 @@ threshold 12000.
 Cycle 88 後の total SCORE は 12052 であり、tracking Issue active threshold 12000 を超えた。
 portfolio constraint は既に満たされており、この phase は G6 phase boundary 判定に進める。
 genius unlock は成立していないが、open target `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases` に対する support node は増えた。
+
+## Cycle 89: Residual transition cut theorem for finite semantic quality atlases
+
+```text
+candidate: Residual Transition Cut Theorem for Finite Semantic Quality Atlases
+candidate_type: unification / genius-support
+evidence_stage: proved-in-research
+base_score: 65
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 130
+category: semantic-obstruction / finite-atlas-transition / repair-coherence / genius-support
+goal_delta: Cycle 88 の edge-local residual-present / residual-free obstruction を、complete finite index / atom lists を持つ atlas skeleton 上の single-edge residual transition cut witness として固定した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、future scanner / minimal cut / obstruction-class frontier へ再利用できる finite-atlas transition cut support node を追加した。
+rival_delta: ADL / static analysis / conformance checker / metric dashboard / AI review summary は edge/status/summary を出せるが、semantic residual-present source と residual-free target の cut witness を theorem artifact として保持しない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualTransitionCut.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualTransitionCut`, and `lake build FormalAGResearch` passed. Axiom probe reported `transitionCoherentAtlasData_implies_edgeTransitions`, `residualTransitionCut_obstructs_atlasTransitionClosure`, and `residualTransitionCut_obstructs_transitionCoherentData` axiom-free; selected frontier-flat closure/data obstruction and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: minimal residual cut theorem; finite transition scanner exactness; obstruction-class formulation for the open genius target.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualTransitionCut.lean`
+packages the Cycle 88 edge-local obstruction as a finite atlas transition cut
+certificate.  `FiniteSemanticRepairAtlasSkeleton` now carries complete finite
+`indexOrder` and `atomOrder` witnesses, together with the edge family,
+residual projection, and cover at each index.  `ResidualTransitionCut` is a
+single active edge whose source index has a semantic residual and whose target
+index is residual-free.
+
+Lean proves:
+
+- `FiniteSemanticRepairAtlasSkeleton`: finite atlas skeleton with complete index and atom lists.
+- `AtlasResidualTransitionClosed`: residual transition closure over every active atlas edge.
+- `TransitionCoherentAtlasData`: explicit transition-coherent data boundary for this cycle.
+- `transitionCoherentAtlasData_implies_edgeTransitions`: transition-coherent data supplies atlas residual transition closure.
+- `ResidualTransitionCut`: active residual-present / residual-free edge witness.
+- `residualTransitionCut_obstructs_atlasTransitionClosure`: any residual transition cut obstructs atlas-wide residual transition closure.
+- `residualTransitionCut_obstructs_transitionCoherentData`: the cut rules out transition-coherent atlas data for the same transition.
+- `selectedFrontierFlatAtlasSkeleton`: selected two-index frontier-to-flat skeleton.
+- `selectedFrontierFlatResidualTransitionCut`: selected frontier-to-flat cut witness.
+- `selected_frontierFlatCut_obstructs_transitionClosure`: selected cut obstructs every frontier-to-flat residual transition closure.
+- `selected_frontierFlatCut_obstructs_transitionCoherentData`: selected cut rules out transition-coherent atlas data.
+- `semanticResidualTransitionCut_package`: theorem package.
+
+This cycle is a support node, not a `genius unlock`.  It does not claim
+minimality, scanner exactness, obstruction class, arbitrary sheaf gluing,
+source extraction completeness, ArchMap correctness, runtime repair synthesis,
+UI correctness, or whole-codebase quality.  G2 accepted the revised candidate
+with base scores 72 / 78 / 84 / 82 and `genius_eligibility: no` throughout.
+G4 reduced the proposed base to 65 because the central theorem is still close
+to a Cycle 88 lift, and confirmed base 65 / multiplier 2.0 / final +130.
+
+### Next Frontier
+
+Cycle 89 後の total SCORE は 12182 であり、tracking Issue active threshold 15000 までは残り 2818 SCORE である。
+次 cycle では、minimal residual cut theorem、finite transition scanner exactness、または obstruction-class formulation を狙う。
+genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

G-aat-quality-surface-01 の research-loop Cycle 89 として、Cycle 88 の residual-present / residual-free edge obstruction を、complete finite index / atom lists を持つ finite atlas skeleton 上の single-edge residual transition cut witness へ持ち上げました。

Refs #2348

## 証明した定理

- `transitionCoherentAtlasData_implies_edgeTransitions`
- `residualTransitionCut_obstructs_atlasTransitionClosure`
- `residualTransitionCut_obstructs_transitionCoherentData`
- `selected_frontierFlatCut_obstructs_transitionClosure`
- `selected_frontierFlatCut_obstructs_transitionCoherentData`
- `semanticResidualTransitionCut_package`

Lean status: `proved-in-research`。core cut theorem は axiom-free、selected/package は標準 `propext` / `Quot.sound` のみです。

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-residual-transition-cut-theorem.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualTransitionCut.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualTransitionCut`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue #2348 は閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
