### PR TITLE
研究ループ Cycle 90 の transition cut scanner を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -86,3 +86,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualFiniteScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualIndexedTransport
 import Formal.AG.Research.QualitySurface.SemanticResidualEdgeTransitionObstruction
 import Formal.AG.Research.QualitySurface.SemanticResidualTransitionCut
+import Formal.AG.Research.QualitySurface.SemanticResidualTransitionCutScanner

--- a/Formal/AG/Research/QualitySurface/SemanticResidualTransitionCutScanner.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualTransitionCutScanner.lean
@@ -1,0 +1,527 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualTransitionCut
+
+/-!
+Cycle 90 evidence for `G-aat-quality-surface-01`.
+
+This file turns the Cycle 89 residual transition cut certificate into a finite
+scanner exactness theorem.  A supplied finite edge order can return the first
+residual-present to residual-free active edge, and `none` is exact for absence
+of such cut witnesses when the edge order covers the active edge family.
+
+The result is edge-order-relative and cut-relative.  It does not assert that
+absence of residual transition cuts implies residual transition closure, does
+not assert a canonical global edge order, does not assert arbitrary sheaf
+gluing or a Cech cohomology class, and does not assert source extraction
+completeness, ArchMap correctness, runtime repair synthesis, UI correctness,
+or whole-codebase quality.
+-/
+
+universe u w
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualTransitionCutScanner
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+
+/-! ## Finite cut scanner -/
+
+/-- A pair of indices is a residual transition cut pair for the atlas. -/
+def IsResidualTransitionCutPair
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    (pair : Index × Index) : Prop :=
+  atlas.edge pair.1 pair.2 /\
+    IndexedResidualPresentAt atlas.projection atlas.cover pair.1 /\
+      IndexedResidualFreeAt atlas.projection atlas.cover pair.2
+
+/-- The supplied edge order contains every active atlas edge. -/
+def ListedAtlasEdgesComplete
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    (edgeOrder : List (Index × Index)) : Prop :=
+  forall source target,
+    atlas.edge source target ->
+      (source, target) ∈ edgeOrder
+
+/-- No listed edge pair is a residual transition cut. -/
+def ListedResidualTransitionCutsClear
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    (edgeOrder : List (Index × Index)) : Prop :=
+  forall pair,
+    pair ∈ edgeOrder ->
+      Not (IsResidualTransitionCutPair atlas pair)
+
+/-- A cut pair gives the structured residual transition cut certificate. -/
+def residualTransitionCut_of_pair
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {pair : Index × Index}
+    (hpair : IsResidualTransitionCutPair atlas pair) :
+    ResidualTransitionCut atlas where
+  sourceIndex := pair.1
+  targetIndex := pair.2
+  edge_active := hpair.1
+  source_residual_present := hpair.2.1
+  target_residual_free := hpair.2.2
+
+/-- A structured residual transition cut determines its listed pair predicate. -/
+theorem residualTransitionCut_pair_isCut
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (cut : ResidualTransitionCut atlas) :
+    IsResidualTransitionCutPair atlas
+      (cut.sourceIndex, cut.targetIndex) := by
+  exact
+    ⟨cut.edge_active,
+      cut.source_residual_present,
+      cut.target_residual_free⟩
+
+/-- The first residual transition cut in a supplied finite edge order. -/
+def firstResidualTransitionCut?
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    [DecidablePred (IsResidualTransitionCutPair atlas)] :
+    List (Index × Index) -> Option (Index × Index)
+  | [] => none
+  | pair :: rest =>
+      if IsResidualTransitionCutPair atlas pair then
+        some pair
+      else
+        firstResidualTransitionCut? atlas rest
+
+/-- A returned pair is in the supplied edge order. -/
+theorem firstResidualTransitionCut?_some_mem
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    [DecidablePred (IsResidualTransitionCutPair atlas)] :
+    forall {edgeOrder : List (Index × Index)} {pair : Index × Index},
+      firstResidualTransitionCut? atlas edgeOrder = some pair ->
+        pair ∈ edgeOrder
+  | [], _pair, hsome => by
+      cases hsome
+  | head :: rest, pair, hsome => by
+      by_cases hcut : IsResidualTransitionCutPair atlas head
+      · have hpair : pair = head := by
+          simpa [firstResidualTransitionCut?, hcut] using hsome.symm
+        subst pair
+        simp
+      · have htail :
+          firstResidualTransitionCut? atlas rest = some pair := by
+          simpa [firstResidualTransitionCut?, hcut] using hsome
+        exact List.mem_cons_of_mem head
+          (firstResidualTransitionCut?_some_mem atlas htail)
+
+/-- A returned pair is an actual residual transition cut pair. -/
+theorem firstResidualTransitionCut?_some_pairCut
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    [DecidablePred (IsResidualTransitionCutPair atlas)] :
+    forall {edgeOrder : List (Index × Index)} {pair : Index × Index},
+      firstResidualTransitionCut? atlas edgeOrder = some pair ->
+        IsResidualTransitionCutPair atlas pair
+  | [], _pair, hsome => by
+      cases hsome
+  | head :: rest, pair, hsome => by
+      by_cases hcut : IsResidualTransitionCutPair atlas head
+      · have hpair : pair = head := by
+          simpa [firstResidualTransitionCut?, hcut] using hsome.symm
+        subst pair
+        exact hcut
+      · have htail :
+          firstResidualTransitionCut? atlas rest = some pair := by
+          simpa [firstResidualTransitionCut?, hcut] using hsome
+        exact firstResidualTransitionCut?_some_pairCut atlas htail
+
+/-- A returned pair gives the structured residual transition cut certificate. -/
+def firstResidualTransitionCut?_some_cut
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    [DecidablePred (IsResidualTransitionCutPair atlas)]
+    {edgeOrder : List (Index × Index)}
+    {pair : Index × Index}
+    (hscan :
+      firstResidualTransitionCut? atlas edgeOrder = some pair) :
+    ResidualTransitionCut atlas :=
+  residualTransitionCut_of_pair
+    (firstResidualTransitionCut?_some_pairCut atlas hscan)
+
+/-- A returned scanner cut obstructs atlas-wide residual transition closure. -/
+theorem firstResidualTransitionCut?_some_obstructs_atlasTransitionClosure
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    [DecidablePred (IsResidualTransitionCutPair atlas)]
+    {edgeOrder : List (Index × Index)}
+    {pair : Index × Index}
+    (hscan :
+      firstResidualTransitionCut? atlas edgeOrder = some pair)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (AtlasResidualTransitionClosed atlas transition) := by
+  exact
+    residualTransitionCut_obstructs_atlasTransitionClosure
+      (firstResidualTransitionCut?_some_cut hscan)
+      transition
+
+/-- A returned scanner cut obstructs transition-coherent atlas data. -/
+theorem firstResidualTransitionCut?_some_obstructs_transitionCoherentData
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    [DecidablePred (IsResidualTransitionCutPair atlas)]
+    {edgeOrder : List (Index × Index)}
+    {pair : Index × Index}
+    (hscan :
+      firstResidualTransitionCut? atlas edgeOrder = some pair)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (Nonempty (TransitionCoherentAtlasData atlas transition)) := by
+  exact
+    residualTransitionCut_obstructs_transitionCoherentData
+      (firstResidualTransitionCut?_some_cut hscan)
+      transition
+
+/--
+The returned pair is preceded only by listed non-cuts in the supplied order.
+This is order-relative minimality, not an absolute minimal cut claim.
+-/
+def PrefixBeforeFirstCut
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    (pair : Index × Index)
+    (edgeOrder : List (Index × Index)) : Prop :=
+  exists front back,
+    edgeOrder = front ++ (pair :: back) /\
+      ListedResidualTransitionCutsClear atlas front
+
+/-- A returned scanner pair is order-minimal relative to the supplied list. -/
+theorem firstResidualTransitionCut?_some_prefixClear
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    [DecidablePred (IsResidualTransitionCutPair atlas)] :
+    forall {edgeOrder : List (Index × Index)} {pair : Index × Index},
+      firstResidualTransitionCut? atlas edgeOrder = some pair ->
+        PrefixBeforeFirstCut atlas pair edgeOrder
+  | [], _pair, hsome => by
+      cases hsome
+  | head :: rest, pair, hsome => by
+      by_cases hcut : IsResidualTransitionCutPair atlas head
+      · have hpair : pair = head := by
+          simpa [firstResidualTransitionCut?, hcut] using hsome.symm
+        subst pair
+        refine ⟨[], rest, by simp, ?_⟩
+        intro candidate hmem _hcandidate
+        cases hmem
+      · have htail :
+          firstResidualTransitionCut? atlas rest = some pair := by
+          simpa [firstResidualTransitionCut?, hcut] using hsome
+        rcases firstResidualTransitionCut?_some_prefixClear atlas htail with
+          ⟨front, back, hrest, hfrontClear⟩
+        refine ⟨head :: front, back, ?_, ?_⟩
+        · simp [hrest]
+        · intro candidate hmem hcandidate
+          cases hmem with
+          | head =>
+              exact hcut hcandidate
+          | tail _ hfront =>
+              exact hfrontClear candidate hfront hcandidate
+
+/--
+The scanner returns `none` exactly when the supplied edge order is clear of
+residual transition cut pairs.
+-/
+theorem firstResidualTransitionCut?_none_iff_listedCutsClear
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    [DecidablePred (IsResidualTransitionCutPair atlas)] :
+    forall edgeOrder,
+      firstResidualTransitionCut? atlas edgeOrder = none <->
+        ListedResidualTransitionCutsClear atlas edgeOrder
+  | [] => by
+      constructor
+      · intro _ pair hmem _hpair
+        cases hmem
+      · intro _
+        rfl
+  | head :: rest => by
+      constructor
+      · intro hnone pair hmem hpair
+        by_cases hcut : IsResidualTransitionCutPair atlas head
+        · have hsome :
+            firstResidualTransitionCut? atlas (head :: rest) =
+              some head := by
+            simp [firstResidualTransitionCut?, hcut]
+          rw [hsome] at hnone
+          cases hnone
+        · have htail :
+            firstResidualTransitionCut? atlas rest = none := by
+            simpa [firstResidualTransitionCut?, hcut] using hnone
+          cases hmem with
+          | head =>
+              exact hcut hpair
+          | tail _ hlisted =>
+              exact
+                ((firstResidualTransitionCut?_none_iff_listedCutsClear
+                  atlas rest).mp htail) pair hlisted hpair
+      · intro hclear
+        by_cases hcut : IsResidualTransitionCutPair atlas head
+        · have hnot :
+            Not (IsResidualTransitionCutPair atlas head) :=
+            hclear head (by simp)
+          exact False.elim (hnot hcut)
+        · have hrestClear :
+            ListedResidualTransitionCutsClear atlas rest := by
+            intro pair hmem hpair
+            exact hclear pair (by simp [hmem]) hpair
+          have htailNone :
+            firstResidualTransitionCut? atlas rest = none :=
+            (firstResidualTransitionCut?_none_iff_listedCutsClear
+              atlas rest).mpr hrestClear
+          simp [firstResidualTransitionCut?, hcut, htailNone]
+
+/--
+For a complete supplied edge order, `none` is exact for absence of residual
+transition cut certificates.
+-/
+theorem firstResidualTransitionCut?_none_iff_noResidualTransitionCut
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    [DecidablePred (IsResidualTransitionCutPair atlas)]
+    {edgeOrder : List (Index × Index)}
+    (hcomplete : ListedAtlasEdgesComplete atlas edgeOrder) :
+    firstResidualTransitionCut? atlas edgeOrder = none <->
+      Not (Nonempty (ResidualTransitionCut atlas)) := by
+  constructor
+  · intro hnone hcut
+    rcases hcut with ⟨cut⟩
+    have hclear :
+        ListedResidualTransitionCutsClear atlas edgeOrder :=
+      (firstResidualTransitionCut?_none_iff_listedCutsClear
+        atlas edgeOrder).mp hnone
+    exact
+      hclear
+        (cut.sourceIndex, cut.targetIndex)
+        (hcomplete cut.sourceIndex cut.targetIndex cut.edge_active)
+        (residualTransitionCut_pair_isCut cut)
+  · intro hnocut
+    apply
+      (firstResidualTransitionCut?_none_iff_listedCutsClear
+        atlas edgeOrder).mpr
+    intro pair _hmem hpair
+    exact hnocut ⟨residualTransitionCut_of_pair hpair⟩
+
+/-! ## Selected frontier-to-flat scanner witness -/
+
+/-- A selected edge order whose second edge is the frontier-to-flat cut. -/
+def selectedFrontierFlatScanOrder :
+    List
+      (SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex) :=
+  [(SelectedSemanticOverlapIndex.flat,
+      SelectedSemanticOverlapIndex.repairFrontier),
+    (SelectedSemanticOverlapIndex.repairFrontier,
+      SelectedSemanticOverlapIndex.flat)]
+
+/-- The selected scanner predicate is decidable without classical choice. -/
+instance selectedFrontierFlatCutPairDecidable :
+    DecidablePred
+      (IsResidualTransitionCutPair selectedFrontierFlatAtlasSkeleton) := by
+  intro pair
+  cases pair with
+  | mk source target =>
+      cases source <;> cases target
+      · apply isFalse
+        intro hcut
+        exact
+          (by
+            simpa [IsResidualTransitionCutPair,
+              selectedFrontierFlatAtlasSkeleton,
+              selectedFrontierToFlatEdge] using hcut.1)
+      · apply isFalse
+        intro hcut
+        exact
+          (by
+            simpa [IsResidualTransitionCutPair,
+              selectedFrontierFlatAtlasSkeleton,
+              selectedFrontierToFlatEdge] using hcut.1)
+      · apply isTrue
+        exact
+          residualTransitionCut_pair_isCut
+            selectedFrontierFlatResidualTransitionCut
+      · apply isFalse
+        intro hcut
+        exact
+          (by
+            simpa [IsResidualTransitionCutPair,
+              selectedFrontierFlatAtlasSkeleton,
+              selectedFrontierToFlatEdge] using hcut.1)
+
+/-- The selected finite scanner returns the frontier-to-flat cut. -/
+theorem selected_firstResidualTransitionCut :
+    firstResidualTransitionCut?
+        selectedFrontierFlatAtlasSkeleton
+        selectedFrontierFlatScanOrder =
+      some
+        (SelectedSemanticOverlapIndex.repairFrontier,
+          SelectedSemanticOverlapIndex.flat) := by
+  have hfirst :
+      Not
+        (IsResidualTransitionCutPair
+          selectedFrontierFlatAtlasSkeleton
+          (SelectedSemanticOverlapIndex.flat,
+            SelectedSemanticOverlapIndex.repairFrontier)) := by
+    intro hcut
+    exact
+      (by
+        simpa [IsResidualTransitionCutPair,
+          selectedFrontierFlatAtlasSkeleton,
+          selectedFrontierToFlatEdge] using hcut.1)
+  have hsecond :
+      IsResidualTransitionCutPair
+        selectedFrontierFlatAtlasSkeleton
+        (SelectedSemanticOverlapIndex.repairFrontier,
+          SelectedSemanticOverlapIndex.flat) :=
+    residualTransitionCut_pair_isCut
+      selectedFrontierFlatResidualTransitionCut
+  simp [selectedFrontierFlatScanOrder, firstResidualTransitionCut?,
+    hfirst, hsecond]
+
+/-- The selected scanner result is order-minimal relative to the supplied list. -/
+theorem selected_firstResidualTransitionCut_prefixClear :
+    PrefixBeforeFirstCut
+      selectedFrontierFlatAtlasSkeleton
+      (SelectedSemanticOverlapIndex.repairFrontier,
+        SelectedSemanticOverlapIndex.flat)
+      selectedFrontierFlatScanOrder := by
+  exact
+    firstResidualTransitionCut?_some_prefixClear
+      selectedFrontierFlatAtlasSkeleton
+      selected_firstResidualTransitionCut
+
+/-- The selected scanner result obstructs frontier-to-flat transition closure. -/
+theorem selected_firstResidualTransitionCut_obstructs_transitionClosure
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    firstResidualTransitionCut?_some_obstructs_atlasTransitionClosure
+      selected_firstResidualTransitionCut
+      transition
+
+/-- The selected scanner result obstructs transition-coherent atlas data. -/
+theorem selected_firstResidualTransitionCut_obstructs_transitionCoherentData
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    firstResidualTransitionCut?_some_obstructs_transitionCoherentData
+      selected_firstResidualTransitionCut
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-90 theorem package: a finite edge-order scanner returns proof-carrying
+residual transition cut certificates, `none` is exact for absence of such cuts
+under edge-order completeness, and the selected frontier-to-flat atlas realizes
+the order-minimal scanner witness.
+-/
+theorem semanticResidualTransitionCutScanner_package :
+    (forall {Index : Type w}
+      {Atom : Type u}
+      {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+      [DecidablePred (IsResidualTransitionCutPair atlas)]
+      {edgeOrder : List (Index × Index)}
+      {pair : Index × Index},
+      firstResidualTransitionCut? atlas edgeOrder = some pair ->
+        Nonempty (ResidualTransitionCut atlas)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        [DecidablePred (IsResidualTransitionCutPair atlas)]
+        {edgeOrder : List (Index × Index)}
+        {pair : Index × Index},
+        firstResidualTransitionCut? atlas edgeOrder = some pair ->
+          PrefixBeforeFirstCut atlas pair edgeOrder) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        [DecidablePred (IsResidualTransitionCutPair atlas)]
+        {edgeOrder : List (Index × Index)},
+        ListedAtlasEdgesComplete atlas edgeOrder ->
+          (firstResidualTransitionCut? atlas edgeOrder = none <->
+            Not (Nonempty (ResidualTransitionCut atlas)))) /\
+      firstResidualTransitionCut?
+          selectedFrontierFlatAtlasSkeleton
+          selectedFrontierFlatScanOrder =
+        some
+          (SelectedSemanticOverlapIndex.repairFrontier,
+            SelectedSemanticOverlapIndex.flat) /\
+      PrefixBeforeFirstCut
+        selectedFrontierFlatAtlasSkeleton
+        (SelectedSemanticOverlapIndex.repairFrontier,
+          SelectedSemanticOverlapIndex.flat)
+        selectedFrontierFlatScanOrder /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_Index} {_Atom} {_atlas} {_inst} {_edgeOrder} {_pair} hscan =>
+        ⟨firstResidualTransitionCut?_some_cut hscan⟩,
+      fun {_Index} {_Atom} {_atlas} {_inst} {_edgeOrder} {_pair} hscan =>
+        firstResidualTransitionCut?_some_prefixClear _ hscan,
+      fun {_Index} {_Atom} {_atlas} {_inst} {_edgeOrder} hcomplete =>
+        firstResidualTransitionCut?_none_iff_noResidualTransitionCut
+          hcomplete,
+      selected_firstResidualTransitionCut,
+      selected_firstResidualTransitionCut_prefixClear,
+      selected_firstResidualTransitionCut_obstructs_transitionClosure,
+      selected_firstResidualTransitionCut_obstructs_transitionCoherentData⟩
+
+end SemanticResidualTransitionCutScanner
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-residual-transition-cut-scanner.md
+++ b/research/ideas/g-aat-quality-surface-01-residual-transition-cut-scanner.md
@@ -1,0 +1,152 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: closer / computability / minimality / obstruction-class support convergence
+candidate_type: computability / exactness / genius-support
+capability_category: semantic-obstruction / finite-atlas-transition / computability / genius-support
+expected_base_score: 72
+expected_evidence_multiplier: 2.0
+expected_final_score: 144
+evidence_stage: proved-in-research
+rival_advantage: ADL, static analyzers, dashboards, and AI summaries can report edges or suspected violations, but they do not return a Lean proof-carrying residual transition cut certificate with scanner exactness over a supplied finite atlas edge order.
+origin: cycle-90
+tags: [quality-surface, semantic-repair, indexed-transport, residual-cut, scanner, genius-support]
+created: 2026-06-23
+cycle: 90
+lean: proved-in-research
+planned_report_section: "Cycle 90: Supplied-order residual transition cut scanner exactness"
+---
+
+# Supplied-order Residual Transition Cut Scanner Exactness
+
+## 主張
+
+Cycle 89 の finite atlas `ResidualTransitionCut` を、supplied finite edge order 上の scanner exactness へ上げる。
+scanner が `some pair` を返すなら、その pair は `ResidualTransitionCut` を復元し、任意の `AtlasResidualTransitionClosed` と `TransitionCoherentAtlasData` を阻む。
+scanner が `none` を返すことは listed edge order 上の residual cut 不在と同値であり、edge order が active edge family を cover する場合に限って atlas 上の `ResidualTransitionCut` 不在と同値になる。
+
+この主張は、`none -> transition closure`、canonical/global minimal cut、order-independent minimality、obstruction class、arbitrary sheaf gluing、runtime repair synthesis、source extraction completeness、ArchMap correctness、whole-codebase quality を含まない。
+
+## 候補種別
+
+`computability` / `exactness` / `genius-support`
+
+## 依拠
+
+- Cycle 86: semantic residual finite scanner。
+- Cycle 88: residual-present / residual-free edge obstruction。
+- Cycle 89: finite semantic atlas residual transition cut certificate。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+単に Cycle 89 の cut witness を list recursion で包むだけでは弱い。
+この候補では、cut pair predicate、finite edge-order scanner、`some -> cut certificate`、`some -> obstruction`、`none <-> listed cut-free`、complete edge-order 下の `none <-> no ResidualTransitionCut`、および supplied order に相対化した prefix-clear witness を一つの theorem package にする。
+
+## 数学的興味
+
+finite atom-supported atlas の semantic residual obstruction を、存在証明だけでなく diagnostic selector として扱えるようにする。
+これは H^1 obstruction class そのものではないが、edge-local obstruction を proof-carrying finite detector に変換する support node であり、次の obstruction-class formulation の入力になる。
+
+## GOAL への前進
+
+`finite transition scanner exactness` frontier を閉じ、open genius target の certificate-selector layer を追加する。
+Cycle 89 の cut certificate を、finite diagnostic regime が返せる obstruction certificate に変える。
+
+## ライバルに対する有効性
+
+ADL や architecture conformance checker は edge row、violation、constraint failure を示せる。
+static analyzer や dashboard は検出結果や severity を返せる。
+AI review summary は疑わしい edge を説明できる。
+この候補の差分は、選ばれた semantic atom vocabulary と finite atlas skeleton に相対化して、scanner の返り値が Lean の `ResidualTransitionCut` certificate を復元し、その certificate が closure/data を阻む theorem まで持つ点にある。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 86 scanner pattern と Cycle 89 cut certificate を接続し、supplied finite edge order に対する exact proof-carrying diagnostic にする。新しい obstruction 原理ではないため genius unlock ではなく support cycle とする。
+- `dullness_risk`: `some -> cut` だけなら Cycle 89 の thin wrapper になる。`none` exactness、edge-order completeness、prefix-clear witness、selected concrete scanner witness を揃えることで研究 delta を確保する。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualTransitionCutScanner.lean` で scanner predicate、finite scanner、some/none exactness、prefix-clear witness、selected frontier-flat scanner theorem、package theorem を証明する。
+
+## CS / SWE への帰結
+
+finite atlas diagnostic で edge row を見せるだけでは不十分である。
+診断 surface は、返した edge pair が semantic residual cut certificate を復元し、その certificate が transition closure を阻むことまで保持して初めて、AAT 側の quality geometry に載る。
+
+## 証明・根拠の見込み
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualTransitionCutScanner.lean` に固定した。
+
+- `IsResidualTransitionCutPair`
+- `ListedAtlasEdgesComplete`
+- `ListedResidualTransitionCutsClear`
+- `residualTransitionCut_of_pair`
+- `residualTransitionCut_pair_isCut`
+- `firstResidualTransitionCut?`
+- `firstResidualTransitionCut?_some_mem`
+- `firstResidualTransitionCut?_some_pairCut`
+- `firstResidualTransitionCut?_some_cut`
+- `firstResidualTransitionCut?_some_obstructs_atlasTransitionClosure`
+- `firstResidualTransitionCut?_some_obstructs_transitionCoherentData`
+- `PrefixBeforeFirstCut`
+- `firstResidualTransitionCut?_some_prefixClear`
+- `firstResidualTransitionCut?_none_iff_listedCutsClear`
+- `firstResidualTransitionCut?_none_iff_noResidualTransitionCut`
+- `selectedFrontierFlatScanOrder`
+- `selectedFrontierFlatCutPairDecidable`
+- `selected_firstResidualTransitionCut`
+- `selected_firstResidualTransitionCut_prefixClear`
+- `selected_firstResidualTransitionCut_obstructs_transitionClosure`
+- `selected_firstResidualTransitionCut_obstructs_transitionCoherentData`
+- `semanticResidualTransitionCutScanner_package`
+
+G3 初期実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualTransitionCutScanner.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualTransitionCutScanner`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: `firstResidualTransitionCut?_some_pairCut`、`firstResidualTransitionCut?_some_obstructs_atlasTransitionClosure`、`firstResidualTransitionCut?_none_iff_noResidualTransitionCut` は標準 `propext` のみ。selected scanner witness と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+- G3 形式化品質監査: pass。`none` は listed cut-free / complete edge-order no-cut に限定され、`none -> transition closure`、absolute minimality、H^1 class、global gluing claim は主張していない。
+- G3.5 同期監査の revise に従い、`selectedFrontierFlatScanOrder`、`selectedFrontierFlatCutPairDecidable`、axiom audit、G2 revise 解決、genius support role 同期を追記した。
+
+claim boundary は、finite supplied edge order、decidable cut predicate regime、selected semantic atom vocabulary、finite atlas skeleton、edge-family residual transition closure に留める。
+`none` は residual transition cut absence の exactness であり、transition closure の十分条件ではない。
+
+## 審判メモ
+
+- G2 A: accept / base 70 / genius no。`supplied-order first residual transition cut scanner exactness` に寄せる条件つき。
+- G2 B: accept / base 72 / genius no。新しい obstruction 原理ではないが finite transition scanner exactness frontier を閉じる。
+- G2 C: revise / base 78 after narrowing / genius no。proof-carrying AAT obstruction certificate という rival 差分に限定する。
+- G2 D: revise / base 72 / genius no。absolute minimality を避け、prefix no-cut exactness と complete edge-order no-cut theorem に限定する。
+- G2 revise 解決: 候補名・本文・Lean theorem は `supplied finite edge order` 相対に限定し、`minimality` は `PrefixBeforeFirstCut` / `prefixClear` のみとした。`none -> transition closure`、global minimal cut、obstruction class、H^1、global gluing、ArchMap correctness、runtime repair synthesis は claim から外した。
+- unchecked: 実コード全体の品質、source extraction completeness、canonical semantic ontology、tooling runtime extraction、UI / dashboard correctness、general obstruction class theorem。
+
+## 追加 required fields
+
+- `mathematical_interest`: residual transition cut を finite edge-order diagnostic selector として読む。
+- `goal_advancement`: Cycle 89 cut certificate を scanner exactness layer へ上げ、open genius target の detector/certificate support node を作る。
+- `planned_theorem_names`: `firstResidualTransitionCut?_some_cut`, `firstResidualTransitionCut?_none_iff_noResidualTransitionCut`, `semanticResidualTransitionCutScanner_package`
+- `visible_projection`: listed atlas edge row / dashboard-like edge diagnostic / component-level edge surface。
+- `protected_structure`: semantic residual-present source、residual-free target、active edge family、finite edge-order completeness、proof-carrying cut certificate。
+- `exactness_or_minimality_claim`: supplied finite edge order に相対した first cut / prefix-clear exactness。complete edge order の下で `none` は `ResidualTransitionCut` 不在と同値。
+- `nonfaithfulness_or_failure_mode`: visible edge row や scalar diagnostic は、returned edge が semantic residual cut certificate を持つことを自動では保持しない。
+- `previous_cycle_delta`: Cycle 89 の finite atlas cut witness を supplied-order scanner exactness theorem に変換する。
+- `rival_stress_test`: rival は edge/violation/witness を示せても、chosen semantic atom vocabulary 上の `some -> ResidualTransitionCut -> closure obstruction` と `none -> no cut` を Lean theorem として保持しない。
+- `genius_potential`: support-cycle。1000 点 unlock ではなく、future obstruction-class theorem の input node。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: finite atlas obstruction を proof-carrying diagnostic selector へ変換する certificate-selector layer。
+- `genius_support_map_sync`: tracking Issue #2348 の open genius target は `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。今回の result は unlock condition ではなく、target theorem に必要な finite detector / certificate-selector node として同期する。
+- `genius_unlock_condition_remaining`: finite obstruction class、coboundary-like equivalence、vanishing/nonvanishing criterion、または local-pass/global-fail classification が未到達。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-residual-transition-cut-theorem.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-edge-transition-obstruction.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-indexed-transport.md`
+- planned report section: `Cycle 90: Supplied-order residual transition cut scanner exactness`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 90 G1 で scanner exactness / order-relative prefix-clear 候補を採択。obstruction 1-preclass は次候補として温存。
+- 2026-06-23: G2 審判に従い、canonical/global minimality、`none -> closure`、H^1 obstruction class claim を外し、supplied finite edge order 相対の scanner exactness に限定した。
+- 2026-06-23: Lean 証拠を `SemanticResidualTransitionCutScanner.lean` に固定し、単体 `lake env lean` が通った。
+- 2026-06-23: module build、FormalAGResearch、G3 公理監査、G3 形式化品質監査が pass。
+- 2026-06-23: G3.5 revise に従い、カードに helper declaration、axiom audit、G2 revise 解決、genius support map 同期を追記。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 12182
+- total SCORE: 12326
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -94,8 +94,9 @@
   - semantic-obstruction / indexed-transport / repair-coherence / certificate-transport / quality-surface: 168
   - semantic-obstruction / indexed-transport / edge-obstruction / repair-coherence / certificate-transport / quality-surface: 60
   - semantic-obstruction / finite-atlas-transition / repair-coherence / genius-support: 130
+  - semantic-obstruction / finite-atlas-transition / computability / genius-support: 144
 - evidence portfolio:
-  - proved-in-research: 89
+  - proved-in-research: 90
 
 ## Phase synthesis
 
@@ -111,7 +112,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-89 件の Lean-proved research artifacts は、次の paper seed を形成している。
+90 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -138,6 +139,7 @@ certificate の基本単位は
 - semantic residual indexed transport は、indexed finite overlap family 上の residual support transport と selected frontier-to-flat residual transition no-go を示す。
 - semantic residual edge transition obstruction は、residual-present source から residual-free target への edge が transition closure を阻む一般 criterion を示す。
 - semantic residual transition cut は、complete finite index / atom lists を持つ atlas skeleton 上で、single-edge residual cut witness が atlas-wide residual transition closure を阻むことを示す。
+- semantic residual transition cut scanner は、supplied finite edge order 上で first residual cut を検出し、`some` を proof-carrying cut certificate と obstruction へ、`none` を complete edge-order 下の no-cut exactness へ接続する。
 
 ### Related-work separation
 
@@ -178,8 +180,9 @@ Cycle 55 後に total SCORE 7090 で当時の tracking Issue active threshold 70
 その後、tracking Issue の active threshold は 10000 に更新され、Cycle 74 後の total SCORE は 10090 である。
 tracking Issue の active threshold は 12000 に更新され、Cycle 88 後の total SCORE は 12052 で 12000 phase boundary に到達した。
 その後、tracking Issue の active threshold は 15000 に更新され、Cycle 89 後の total SCORE は 12182 である。
+Cycle 90 後の total SCORE は 12326 であり、tracking Issue active threshold 15000 までは残り 2674 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 89 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 90 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -200,7 +203,9 @@ semantic-fiber-aware viewer criterion theorem、
 semantic residual component faithfulness theorem、
 semantic residual alias classification theorem、
 semantic residual indexed transport theorem、
-semantic residual edge transition obstruction theorem を含む。
+semantic residual edge transition obstruction theorem、
+semantic residual transition cut theorem、
+semantic residual transition cut scanner exactness theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -4554,4 +4559,68 @@ to a Cycle 88 lift, and confirmed base 65 / multiplier 2.0 / final +130.
 
 Cycle 89 後の total SCORE は 12182 であり、tracking Issue active threshold 15000 までは残り 2818 SCORE である。
 次 cycle では、minimal residual cut theorem、finite transition scanner exactness、または obstruction-class formulation を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 90: Supplied-order residual transition cut scanner exactness
+
+```text
+candidate: Supplied-order residual transition cut scanner exactness
+candidate_type: computability / exactness / genius-support
+evidence_stage: proved-in-research
+base_score: 72
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 144
+category: semantic-obstruction / finite-atlas-transition / computability / genius-support
+goal_delta: Cycle 89 の finite atlas cut certificate を、supplied finite edge order 上の proof-carrying diagnostic selector として固定した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、`some -> ResidualTransitionCut -> closure/data obstruction` と `none -> no cut` exactness を接続する finite transition scanner theorem を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は edge row や疑わしい violation を返せるが、返った edge pair から Lean の residual transition cut certificate を復元し、その certificate が transition closure/data を阻むことまでは theorem artifact として保持しない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualTransitionCutScanner.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualTransitionCutScanner`, and `lake build FormalAGResearch` passed. Axiom probe reported standard `propext` for generic scanner theorems and standard `propext` / `Quot.sound` for the selected witness/package only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: finite residual obstruction 1-preclass; obstruction-class formulation; local-pass/global-fail taxonomy; finite H^1-style vanishing/nonvanishing criterion for the open genius target.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualTransitionCutScanner.lean`
+turns the Cycle 89 cut certificate into a finite scanner exactness theorem.
+The scanner is relative to a supplied finite edge order and a decidable cut
+predicate.  It does not construct a canonical global edge order and does not
+claim that absence of residual cuts implies residual transition closure.
+
+Lean proves:
+
+- `IsResidualTransitionCutPair`: active source/target pair whose source has a semantic residual and whose target is residual-free.
+- `ListedAtlasEdgesComplete`: supplied finite edge order covers the active edge family.
+- `ListedResidualTransitionCutsClear`: listed edge order has no residual transition cut pair.
+- `residualTransitionCut_of_pair`: cut pair predicate gives a structured `ResidualTransitionCut`.
+- `residualTransitionCut_pair_isCut`: structured cut determines its pair predicate.
+- `firstResidualTransitionCut?`: first residual transition cut scanner over a supplied edge order.
+- `firstResidualTransitionCut?_some_mem`: returned pair is listed.
+- `firstResidualTransitionCut?_some_pairCut`: returned pair satisfies the cut predicate.
+- `firstResidualTransitionCut?_some_cut`: returned pair recovers a `ResidualTransitionCut`.
+- `firstResidualTransitionCut?_some_obstructs_atlasTransitionClosure`: returned scanner cut obstructs atlas residual transition closure.
+- `firstResidualTransitionCut?_some_obstructs_transitionCoherentData`: returned scanner cut obstructs transition-coherent atlas data.
+- `PrefixBeforeFirstCut`: supplied-order prefix-clear witness for the returned pair.
+- `firstResidualTransitionCut?_some_prefixClear`: scanner result is first relative to the supplied order.
+- `firstResidualTransitionCut?_none_iff_listedCutsClear`: `none` is exact for listed cut-freeness.
+- `firstResidualTransitionCut?_none_iff_noResidualTransitionCut`: under edge-order completeness, `none` is exact for absence of `ResidualTransitionCut`.
+- `selectedFrontierFlatScanOrder`: selected order with a non-cut edge followed by the frontier-to-flat cut.
+- `selectedFrontierFlatCutPairDecidable`: concrete selected decidability instance without `Classical.choice`.
+- `selected_firstResidualTransitionCut`: selected scanner returns `(repairFrontier, flat)`.
+- `selected_firstResidualTransitionCut_prefixClear`: selected scanner result is supplied-order prefix-clear.
+- `selected_firstResidualTransitionCut_obstructs_transitionClosure`: selected scanner result obstructs transition closure.
+- `selected_firstResidualTransitionCut_obstructs_transitionCoherentData`: selected scanner result obstructs transition-coherent atlas data.
+- `semanticResidualTransitionCutScanner_package`: theorem package.
+
+This cycle is a support node, not a `genius unlock`.  G2 accepted the narrowed
+claim with base scores 70 / 72 / 78 / 72 and `genius_eligibility: no`
+throughout.  G4 confirmed base 72 / multiplier 2.0 / penalty 0 / final +144.
+The G4 text contained an arithmetic slip on remaining SCORE; the correct
+update is total 12182 -> 12326, leaving 2674 SCORE to the active threshold
+15000.
+
+### Next Frontier
+
+Cycle 90 後の total SCORE は 12326 であり、tracking Issue active threshold 15000 までは残り 2674 SCORE である。
+次 cycle では、finite residual obstruction 1-preclass、obstruction-class formulation、または local-pass/global-fail taxonomy を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 90 として、Cycle 89 の finite atlas residual transition cut certificate を supplied finite edge order 上の scanner exactness theorem へ上げました。tracking Issue #2348 は active threshold 15000 まで継続するため、この PR では close しません。

## 証明した定理

- `IsResidualTransitionCutPair`
- `ListedAtlasEdgesComplete`
- `ListedResidualTransitionCutsClear`
- `residualTransitionCut_of_pair`
- `residualTransitionCut_pair_isCut`
- `firstResidualTransitionCut?`
- `firstResidualTransitionCut?_some_mem`
- `firstResidualTransitionCut?_some_pairCut`
- `firstResidualTransitionCut?_some_cut`
- `firstResidualTransitionCut?_some_obstructs_atlasTransitionClosure`
- `firstResidualTransitionCut?_some_obstructs_transitionCoherentData`
- `PrefixBeforeFirstCut`
- `firstResidualTransitionCut?_some_prefixClear`
- `firstResidualTransitionCut?_none_iff_listedCutsClear`
- `firstResidualTransitionCut?_none_iff_noResidualTransitionCut`
- `selected_firstResidualTransitionCut`
- `selected_firstResidualTransitionCut_prefixClear`
- `selected_firstResidualTransitionCut_obstructs_transitionClosure`
- `selected_firstResidualTransitionCut_obstructs_transitionCoherentData`
- `semanticResidualTransitionCutScanner_package`

Lean status: proved-in-research。`none` は supplied/listed residual cut absence と、complete edge order 下の `ResidualTransitionCut` absence までに限定し、`none -> transition closure`、canonical/global minimality、H1 obstruction class、global gluing は主張していません。

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-residual-transition-cut-scanner.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualTransitionCutScanner.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualTransitionCutScanner`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] local/private path scan
- [x] `#print axioms` audit（generic scanner theorem は標準 `propext`、selected witness/package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

注: tracking Issue #2348 は research-loop 継続用の親 Issue なので、この PR では `Closes #2348` を使っていません。
