### PR TITLE
研究ループ Cycle 92 の cut-noise obstruction class を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -88,3 +88,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualEdgeTransitionObstructi
 import Formal.AG.Research.QualitySurface.SemanticResidualTransitionCut
 import Formal.AG.Research.QualitySurface.SemanticResidualTransitionCutScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualObstructionPreclass
+import Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass

--- a/Formal/AG/Research/QualitySurface/SemanticResidualObstructionClass.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualObstructionClass.lean
@@ -1,0 +1,556 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualObstructionPreclass
+
+/-!
+Cycle 92 evidence for `G-aat-quality-surface-01`.
+
+This file turns the Cycle 91 residual obstruction preclass into a finite
+cut-locus obstruction class reading.  A raw cochain may carry support away
+from residual transition cuts; the class equivalence ignores that off-cut
+noise and compares representatives only on the residual cut locus.
+
+The result is a cut-locus quotient-style criterion, not a Cech `H^1` class.
+It does not construct a coboundary quotient, does not assert arbitrary sheaf
+gluing, does not assert that class vanishing implies residual transition
+closure, and does not assert source extraction completeness, ArchMap
+correctness, runtime repair synthesis, UI correctness, or whole-codebase
+quality.
+-/
+
+universe u w
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualObstructionClass
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionPreclass
+
+/-! ## Cut-locus residual obstruction cochains -/
+
+/--
+A raw residual cut cochain over a finite semantic repair atlas.
+The support may contain off-cut diagnostic noise; class predicates below
+restrict it to the residual transition cut locus.
+-/
+structure ResidualCutCochain
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom) where
+  support : Index × Index -> Prop
+
+/-- The canonical raw cochain supported exactly on residual transition cuts. -/
+def canonicalResidualCutCochain
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom) :
+    ResidualCutCochain atlas where
+  support := IsResidualTransitionCutPair atlas
+
+/--
+Cut-noise equivalence compares raw cochain representatives only on the
+residual transition cut locus.
+-/
+def CutNoiseEquivalent
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (left right : ResidualCutCochain atlas) : Prop :=
+  forall pair,
+    IsResidualTransitionCutPair atlas pair ->
+      (left.support pair <-> right.support pair)
+
+namespace ResidualCutCochain
+
+/-- A cochain class vanishes when it has no support on residual cut pairs. -/
+def CutVanishes
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (cochain : ResidualCutCochain atlas) : Prop :=
+  forall pair,
+    IsResidualTransitionCutPair atlas pair ->
+      Not (cochain.support pair)
+
+/-- A cochain class is nonzero when it has support on some residual cut pair. -/
+def CutNonzero
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (cochain : ResidualCutCochain atlas) : Prop :=
+  exists pair,
+    IsResidualTransitionCutPair atlas pair /\ cochain.support pair
+
+end ResidualCutCochain
+
+/-! ## Equivalence laws and class predicates -/
+
+/-- Cut-noise equivalence is reflexive. -/
+theorem cutNoiseEquivalent_refl
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (cochain : ResidualCutCochain atlas) :
+    CutNoiseEquivalent cochain cochain := by
+  intro pair _hcut
+  rfl
+
+/-- Cut-noise equivalence is symmetric. -/
+theorem cutNoiseEquivalent_symm
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {left right : ResidualCutCochain atlas}
+    (hequiv : CutNoiseEquivalent left right) :
+    CutNoiseEquivalent right left := by
+  intro pair hcut
+  exact (hequiv pair hcut).symm
+
+/-- Cut-noise equivalence is transitive. -/
+theorem cutNoiseEquivalent_trans
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {left middle right : ResidualCutCochain atlas}
+    (hleft : CutNoiseEquivalent left middle)
+    (hright : CutNoiseEquivalent middle right) :
+    CutNoiseEquivalent left right := by
+  intro pair hcut
+  exact (hleft pair hcut).trans (hright pair hcut)
+
+/-- Cut-noise equivalence preserves cut-locus vanishing. -/
+theorem cutNoiseEquivalent_preserves_cutVanishes
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {left right : ResidualCutCochain atlas}
+    (hequiv : CutNoiseEquivalent left right) :
+    left.CutVanishes <-> right.CutVanishes := by
+  constructor
+  · intro hleft pair hcut hright
+    exact hleft pair hcut ((hequiv pair hcut).mpr hright)
+  · intro hright pair hcut hleft
+    exact hright pair hcut ((hequiv pair hcut).mp hleft)
+
+/-- Cut-noise equivalence preserves cut-locus nonzero support. -/
+theorem cutNoiseEquivalent_preserves_cutNonzero
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {left right : ResidualCutCochain atlas}
+    (hequiv : CutNoiseEquivalent left right) :
+    left.CutNonzero <-> right.CutNonzero := by
+  constructor
+  · intro hleft
+    rcases hleft with ⟨pair, hcut, hsupport⟩
+    exact ⟨pair, hcut, (hequiv pair hcut).mp hsupport⟩
+  · intro hright
+    rcases hright with ⟨pair, hcut, hsupport⟩
+    exact ⟨pair, hcut, (hequiv pair hcut).mpr hsupport⟩
+
+/-! ## Canonical cut class criteria -/
+
+/-- The canonical cochain support is exactly the residual cut-pair predicate. -/
+theorem canonicalResidualCutCochain_support_exact
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    (pair : Index × Index) :
+    (canonicalResidualCutCochain atlas).support pair <->
+      IsResidualTransitionCutPair atlas pair := by
+  rfl
+
+/--
+Vanishing of the canonical cut class is exactly absence of residual transition
+cut certificates.
+-/
+theorem canonicalResidualCutClass_vanishes_iff_no_cut
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom} :
+    (canonicalResidualCutCochain atlas).CutVanishes <->
+      Not (Nonempty (ResidualTransitionCut atlas)) := by
+  constructor
+  · intro hvanish hcut
+    rcases hcut with ⟨cut⟩
+    exact
+      hvanish
+        (cut.sourceIndex, cut.targetIndex)
+        (residualTransitionCut_pair_isCut cut)
+        (residualTransitionCut_pair_isCut cut)
+  · intro hnocut pair hcut _hsupport
+    exact hnocut ⟨residualTransitionCut_of_pair hcut⟩
+
+/-- Nonzero canonical cut class support is exactly existence of a residual cut. -/
+theorem canonicalResidualCutClass_nonzero_iff_cut
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom} :
+    (canonicalResidualCutCochain atlas).CutNonzero <->
+      Nonempty (ResidualTransitionCut atlas) := by
+  constructor
+  · intro hnonzero
+    rcases hnonzero with ⟨pair, hcut, _hsupport⟩
+    exact ⟨residualTransitionCut_of_pair hcut⟩
+  · intro hcut
+    rcases hcut with ⟨cut⟩
+    exact
+      ⟨(cut.sourceIndex, cut.targetIndex),
+        residualTransitionCut_pair_isCut cut,
+        residualTransitionCut_pair_isCut cut⟩
+
+/-- Any nonzero cut class obstructs residual transition closure. -/
+theorem residualCutClass_nonzero_obstructs_atlasTransitionClosure
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (cochain : ResidualCutCochain atlas)
+    (hnonzero : cochain.CutNonzero)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (AtlasResidualTransitionClosed atlas transition) := by
+  rcases hnonzero with ⟨pair, hcut, _hsupport⟩
+  exact
+    residualTransitionCut_obstructs_atlasTransitionClosure
+      (residualTransitionCut_of_pair hcut)
+      transition
+
+/-- Any nonzero cut class rules out transition-coherent atlas data. -/
+theorem residualCutClass_nonzero_obstructs_transitionCoherentData
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (cochain : ResidualCutCochain atlas)
+    (hnonzero : cochain.CutNonzero)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (Nonempty (TransitionCoherentAtlasData atlas transition)) := by
+  rcases hnonzero with ⟨pair, hcut, _hsupport⟩
+  exact
+    residualTransitionCut_obstructs_transitionCoherentData
+      (residualTransitionCut_of_pair hcut)
+      transition
+
+/-! ## Scanner measurements of the canonical cut class -/
+
+/-- A scanner hit makes the canonical cut class nonzero. -/
+theorem firstResidualTransitionCut?_some_cutClassNonzero
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    [DecidablePred (IsResidualTransitionCutPair atlas)]
+    {edgeOrder : List (Index × Index)}
+    {pair : Index × Index}
+    (hscan :
+      firstResidualTransitionCut? atlas edgeOrder = some pair) :
+    (canonicalResidualCutCochain atlas).CutNonzero := by
+  have hcut :
+      IsResidualTransitionCutPair atlas pair :=
+    firstResidualTransitionCut?_some_pairCut atlas hscan
+  exact ⟨pair, hcut, hcut⟩
+
+/--
+For a complete supplied edge order, scanner `none` is exact for vanishing of
+the canonical cut class.
+-/
+theorem firstResidualTransitionCut?_none_iff_canonicalCutClassVanishes
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    [DecidablePred (IsResidualTransitionCutPair atlas)]
+    {edgeOrder : List (Index × Index)}
+    (hcomplete : ListedAtlasEdgesComplete atlas edgeOrder) :
+    firstResidualTransitionCut? atlas edgeOrder = none <->
+      (canonicalResidualCutCochain atlas).CutVanishes := by
+  exact
+    (firstResidualTransitionCut?_none_iff_noResidualTransitionCut
+      hcomplete).trans
+      (canonicalResidualCutClass_vanishes_iff_no_cut).symm
+
+/-- A scanner hit obstructs residual transition closure via the cut class. -/
+theorem firstResidualTransitionCut?_some_obstructs_via_cutClass
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    [DecidablePred (IsResidualTransitionCutPair atlas)]
+    {edgeOrder : List (Index × Index)}
+    {pair : Index × Index}
+    (hscan :
+      firstResidualTransitionCut? atlas edgeOrder = some pair)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (AtlasResidualTransitionClosed atlas transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain atlas)
+      (firstResidualTransitionCut?_some_cutClassNonzero hscan)
+      transition
+
+/-! ## Selected noisy representative -/
+
+/-- The selected reverse edge is not a residual transition cut pair. -/
+theorem selected_flatFrontier_not_residualCutPair :
+    Not
+      (IsResidualTransitionCutPair
+        selectedFrontierFlatAtlasSkeleton
+        (SelectedSemanticOverlapIndex.flat,
+          SelectedSemanticOverlapIndex.repairFrontier)) := by
+  intro hcut
+  exact
+    (by
+      simpa [IsResidualTransitionCutPair,
+        selectedFrontierFlatAtlasSkeleton,
+        selectedFrontierToFlatEdge] using hcut.1)
+
+/--
+The selected noisy representative adds raw support on the reverse, non-cut
+pair.  This raw support is diagnostic noise killed by cut-noise equivalence.
+-/
+def selectedBoundaryNoisyResidualCutCochain :
+    ResidualCutCochain selectedFrontierFlatAtlasSkeleton where
+  support pair :=
+    (canonicalResidualCutCochain
+      selectedFrontierFlatAtlasSkeleton).support pair \/
+      pair =
+        (SelectedSemanticOverlapIndex.flat,
+          SelectedSemanticOverlapIndex.repairFrontier)
+
+/--
+The selected noisy representative differs from the canonical raw support on
+the reverse non-cut pair.
+-/
+theorem selectedBoundaryNoisy_rawSupport_differs_from_canonical :
+    selectedBoundaryNoisyResidualCutCochain.support
+        (SelectedSemanticOverlapIndex.flat,
+          SelectedSemanticOverlapIndex.repairFrontier) /\
+      Not
+        ((canonicalResidualCutCochain
+          selectedFrontierFlatAtlasSkeleton).support
+          (SelectedSemanticOverlapIndex.flat,
+            SelectedSemanticOverlapIndex.repairFrontier)) := by
+  constructor
+  · dsimp [selectedBoundaryNoisyResidualCutCochain]
+    exact Or.inr rfl
+  · exact selected_flatFrontier_not_residualCutPair
+
+/--
+The selected noisy representative has the same residual cut class as the
+canonical representative.
+-/
+theorem selectedBoundaryNoisy_cutNoiseEquivalent_canonical :
+    CutNoiseEquivalent
+      selectedBoundaryNoisyResidualCutCochain
+      (canonicalResidualCutCochain
+        selectedFrontierFlatAtlasSkeleton) := by
+  intro pair hcut
+  constructor
+  · intro _hsupport
+    exact hcut
+  · intro hcanonical
+    dsimp [selectedBoundaryNoisyResidualCutCochain]
+    exact Or.inl hcanonical
+
+/-- The selected canonical cut class is nonzero. -/
+theorem selected_canonicalResidualCutClass_nonzero :
+    (canonicalResidualCutCochain
+      selectedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    firstResidualTransitionCut?_some_cutClassNonzero
+      selected_firstResidualTransitionCut
+
+/-- The selected noisy cut class is nonzero. -/
+theorem selectedBoundaryNoisy_residualCutClass_nonzero :
+    selectedBoundaryNoisyResidualCutCochain.CutNonzero := by
+  exact
+    (cutNoiseEquivalent_preserves_cutNonzero
+      selectedBoundaryNoisy_cutNoiseEquivalent_canonical).mpr
+      selected_canonicalResidualCutClass_nonzero
+
+/-- The selected noisy cut class obstructs frontier-to-flat transition closure. -/
+theorem selectedBoundaryNoisy_residualCutClass_obstructs_transitionClosure
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      selectedBoundaryNoisyResidualCutCochain
+      selectedBoundaryNoisy_residualCutClass_nonzero
+      transition
+
+/-- The selected noisy cut class obstructs transition-coherent atlas data. -/
+theorem selectedBoundaryNoisy_residualCutClass_obstructs_transitionCoherentData
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      selectedBoundaryNoisyResidualCutCochain
+      selectedBoundaryNoisy_residualCutClass_nonzero
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-92 theorem package: residual cut cochains have a cut-locus class reading
+that ignores off-cut raw support noise.  The canonical class vanishes exactly
+when there is no residual cut certificate; nonzero class support obstructs
+transition closure and transition-coherent data; the selected noisy
+representative differs from canonical raw support while remaining class
+equivalent.
+-/
+theorem semanticResidualObstructionClass_package :
+    (forall {Index : Type w}
+      {Atom : Type u}
+      {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+      forall cochain : ResidualCutCochain atlas,
+        CutNoiseEquivalent cochain cochain) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall left right : ResidualCutCochain atlas,
+          CutNoiseEquivalent left right ->
+            CutNoiseEquivalent right left) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall left middle right : ResidualCutCochain atlas,
+          CutNoiseEquivalent left middle ->
+            CutNoiseEquivalent middle right ->
+              CutNoiseEquivalent left right) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall left right : ResidualCutCochain atlas,
+          CutNoiseEquivalent left right ->
+            (left.CutVanishes <-> right.CutVanishes)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall left right : ResidualCutCochain atlas,
+          CutNoiseEquivalent left right ->
+            (left.CutNonzero <-> right.CutNonzero)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        (canonicalResidualCutCochain atlas).CutVanishes <->
+          Not (Nonempty (ResidualTransitionCut atlas))) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        (canonicalResidualCutCochain atlas).CutNonzero <->
+          Nonempty (ResidualTransitionCut atlas)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall cochain : ResidualCutCochain atlas,
+          cochain.CutNonzero ->
+            forall transition : Index -> Index -> Atom -> Atom,
+              Not (AtlasResidualTransitionClosed atlas transition)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall cochain : ResidualCutCochain atlas,
+          cochain.CutNonzero ->
+            forall transition : Index -> Index -> Atom -> Atom,
+              Not (Nonempty (TransitionCoherentAtlasData atlas transition))) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        [DecidablePred (IsResidualTransitionCutPair atlas)]
+        {edgeOrder : List (Index × Index)}
+        {pair : Index × Index},
+        firstResidualTransitionCut? atlas edgeOrder = some pair ->
+          (canonicalResidualCutCochain atlas).CutNonzero) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        [DecidablePred (IsResidualTransitionCutPair atlas)]
+        {edgeOrder : List (Index × Index)},
+        ListedAtlasEdgesComplete atlas edgeOrder ->
+          (firstResidualTransitionCut? atlas edgeOrder = none <->
+            (canonicalResidualCutCochain atlas).CutVanishes)) /\
+      selectedBoundaryNoisyResidualCutCochain.support
+        (SelectedSemanticOverlapIndex.flat,
+          SelectedSemanticOverlapIndex.repairFrontier) /\
+      Not
+        ((canonicalResidualCutCochain
+          selectedFrontierFlatAtlasSkeleton).support
+          (SelectedSemanticOverlapIndex.flat,
+            SelectedSemanticOverlapIndex.repairFrontier)) /\
+      CutNoiseEquivalent
+        selectedBoundaryNoisyResidualCutCochain
+        (canonicalResidualCutCochain
+          selectedFrontierFlatAtlasSkeleton) /\
+      selectedBoundaryNoisyResidualCutCochain.CutNonzero /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_Index} {_Atom} {_atlas} cochain =>
+        cutNoiseEquivalent_refl cochain,
+      fun {_Index} {_Atom} {_atlas} left right hequiv =>
+        cutNoiseEquivalent_symm (left := left) (right := right) hequiv,
+      fun {_Index} {_Atom} {_atlas} left middle right hleft hright =>
+        cutNoiseEquivalent_trans
+          (left := left) (middle := middle) (right := right)
+          hleft hright,
+      fun {_Index} {_Atom} {_atlas} left right hequiv =>
+        cutNoiseEquivalent_preserves_cutVanishes
+          (left := left) (right := right) hequiv,
+      fun {_Index} {_Atom} {_atlas} left right hequiv =>
+        cutNoiseEquivalent_preserves_cutNonzero
+          (left := left) (right := right) hequiv,
+      fun {_Index} {_Atom} {_atlas} =>
+        canonicalResidualCutClass_vanishes_iff_no_cut,
+      fun {_Index} {_Atom} {_atlas} =>
+        canonicalResidualCutClass_nonzero_iff_cut,
+      fun {_Index} {_Atom} {_atlas} cochain hnonzero transition =>
+        residualCutClass_nonzero_obstructs_atlasTransitionClosure
+          cochain hnonzero transition,
+      fun {_Index} {_Atom} {_atlas} cochain hnonzero transition =>
+        residualCutClass_nonzero_obstructs_transitionCoherentData
+          cochain hnonzero transition,
+      fun {_Index} {_Atom} {_atlas} {_inst} {_edgeOrder} {_pair} hscan =>
+        firstResidualTransitionCut?_some_cutClassNonzero hscan,
+      fun {_Index} {_Atom} {_atlas} {_inst} {_edgeOrder} hcomplete =>
+        firstResidualTransitionCut?_none_iff_canonicalCutClassVanishes
+          hcomplete,
+      selectedBoundaryNoisy_rawSupport_differs_from_canonical.1,
+      selectedBoundaryNoisy_rawSupport_differs_from_canonical.2,
+      selectedBoundaryNoisy_cutNoiseEquivalent_canonical,
+      selectedBoundaryNoisy_residualCutClass_nonzero,
+      selectedBoundaryNoisy_residualCutClass_obstructs_transitionClosure,
+      selectedBoundaryNoisy_residualCutClass_obstructs_transitionCoherentData⟩
+
+end SemanticResidualObstructionClass
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-obstruction-class.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-obstruction-class.md
@@ -1,0 +1,155 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: obstruction-class / cut-noise quotient-style reading / genius-support convergence
+candidate_type: obstruction-class-support / cut-locus equivalence / projection-noise
+capability_category: semantic-obstruction / finite-atlas-transition / obstruction-class-support / projection-nonfaithfulness / genius-support
+expected_base_score: 82
+expected_evidence_multiplier: 2.0
+expected_final_score: 164
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can report raw diagnostic support, but they do not distinguish off-cut raw support noise from residual cut-locus obstruction class data with Lean-proved invariance and no-go theorems.
+origin: cycle-92
+tags: [quality-surface, semantic-repair, residual-cut, obstruction-class, cut-noise, genius-support]
+created: 2026-06-23
+cycle: 92
+lean: proved-in-research
+planned_report_section: "Cycle 92: Semantic residual obstruction class modulo cut-noise"
+---
+
+# Semantic Residual Obstruction Class Modulo Cut-Noise
+
+## 主張
+
+Cycle 91 の `ResidualObstructionOnePreclass` を、finite semantic repair atlas 上の raw cochain と cut-locus class reading に分ける。
+`ResidualCutCochain` は raw support を持ち、その raw support には residual transition cut ではない pair への diagnostic noise が混じりうる。
+`CutNoiseEquivalent` は `IsResidualTransitionCutPair` 上だけで support を比較し、off-cut noise を class reading から消す。
+
+この class reading で、cut-locus 相対の `CutVanishes` / `CutNonzero` を定義し、canonical cochain の vanishing は `ResidualTransitionCut` 不在と同値、nonzero は `ResidualTransitionCut` 存在と同値であることを Lean で固定する。
+さらに、selected frontier-to-flat atlas では `(flat, repairFrontier)` に余計な raw support を持つ noisy representative が canonical raw support と異なる一方、cut-locus class としては canonical と同値であり、nonzero class が residual transition closure と transition-coherent atlas data を阻む。
+
+この主張は、Cech `H^1` class、coboundary quotient、true cohomology quotient、一般 sheaf gluing、`class vanishes -> transition closure`、global minimal representative、source extraction completeness、ArchMap correctness、runtime repair synthesis、whole-codebase quality を含まない。
+
+## 候補種別
+
+`obstruction-class-support` / `cut-locus equivalence` / `projection-noise`
+
+## 依拠
+
+- Cycle 89: finite semantic atlas residual transition cut certificate。
+- Cycle 90: supplied-order residual transition cut scanner exactness。
+- Cycle 91: residual obstruction one-preclass、vanishing/nonzero criterion、scanner measurement。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+単なる `SameResidualObstructionSupport` の rename なら低価値である。
+この候補では、raw support と cut-locus class support を明示的に分離し、selected noisy representative が canonical raw support と実際に異なることを Lean で示す。
+そのうえで、off-cut raw noise があっても residual cut class、cut-locus vanishing/nonzero、transition obstruction は変わらないことを theorem package に置く。
+
+## 数学的興味
+
+semantic residual transition failure を、edge-local cut witness や preclass support predicate から、noise-invariant finite obstruction class reading へ一段上げる。
+これはまだ Cech cohomology ではないが、H1-style obstruction theorem の手前で必要な「representative と class の分離」を Lean artifact として固定する。
+
+## GOAL への前進
+
+open genius target の `finite obstruction class` frontier に向け、preclass support から cut-noise invariant class reading へ進める。
+dashboard / scanner / AI summary が持ちうる raw diagnostic noise を切り落とし、AAT 側が守るべき residual cut-locus obstruction data を theorem object として分離した。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、conformance dashboard、AI summary は raw edge diagnostics や suspected failure を表示できる。
+この候補の差分は、raw support の余計な off-cut entry を許しながら、それを residual cut class から消す同値と、その同値が cut-locus vanishing/nonzero を保存することを Lean で証明する点にある。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 91 の preclass を、off-cut raw support noise を殺す finite class reading へ上げる。open genius target への support node だが、true H1 にはまだ到達していない。
+- `dullness_risk`: noisy representative の raw support difference がなければ wrapper になる。selected noisy representative、cut-locus predicates、equivalence preservation、canonical iff、scanner bridge、closure/data obstruction を揃えて wrapper risk を下げる。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualObstructionClass.lean` で raw cochain、cut-noise equivalence、canonical criteria、scanner bridge、selected noisy representative、theorem package を証明する。
+
+## CS / SWE への帰結
+
+finite atlas diagnostic では、UI row や scanner output の raw support はそのまま obstruction class ではない。
+off-cut diagnostic noise を含む representation から residual cut-locus support だけを class data として読むことで、green-looking local surface や noisy dashboard representation と、AAT の nonzero obstruction theorem を分離できる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualObstructionClass.lean` に固定した。
+
+- `ResidualCutCochain`
+- `canonicalResidualCutCochain`
+- `CutNoiseEquivalent`
+- `ResidualCutCochain.CutVanishes`
+- `ResidualCutCochain.CutNonzero`
+- `cutNoiseEquivalent_refl`
+- `cutNoiseEquivalent_symm`
+- `cutNoiseEquivalent_trans`
+- `cutNoiseEquivalent_preserves_cutVanishes`
+- `cutNoiseEquivalent_preserves_cutNonzero`
+- `canonicalResidualCutCochain_support_exact`
+- `canonicalResidualCutClass_vanishes_iff_no_cut`
+- `canonicalResidualCutClass_nonzero_iff_cut`
+- `residualCutClass_nonzero_obstructs_atlasTransitionClosure`
+- `residualCutClass_nonzero_obstructs_transitionCoherentData`
+- `firstResidualTransitionCut?_some_cutClassNonzero`
+- `firstResidualTransitionCut?_none_iff_canonicalCutClassVanishes`
+- `firstResidualTransitionCut?_some_obstructs_via_cutClass`
+- `selected_flatFrontier_not_residualCutPair`
+- `selectedBoundaryNoisyResidualCutCochain`
+- `selectedBoundaryNoisy_rawSupport_differs_from_canonical`
+- `selectedBoundaryNoisy_cutNoiseEquivalent_canonical`
+- `selected_canonicalResidualCutClass_nonzero`
+- `selectedBoundaryNoisy_residualCutClass_nonzero`
+- `selectedBoundaryNoisy_residualCutClass_obstructs_transitionClosure`
+- `selectedBoundaryNoisy_residualCutClass_obstructs_transitionCoherentData`
+- `semanticResidualObstructionClass_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualObstructionClass.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: `cutNoiseEquivalent_preserves_cutVanishes`、`cutNoiseEquivalent_preserves_cutNonzero`、`canonicalResidualCutClass_vanishes_iff_no_cut`、`canonicalResidualCutClass_nonzero_iff_cut` は axiom-free。scanner bridge と selected noisy equivalence は標準 `propext`。selected noisy nonzero と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、finite semantic repair atlas、selected semantic atom vocabulary、residual transition cut predicate、cut-locus class equivalence、supplied finite edge-order scanner measurement に限定する。
+unchecked: true H1 cohomology class、Cech quotient、coboundary quotient、vanishing-to-closure theorem、general sheaf gluing、source extraction completeness、ArchMap correctness、runtime repair synthesis、whole-codebase quality、tooling runtime extraction。
+
+## 審判メモ
+
+- G1 A: accept in narrowed form。preclass から finite obstruction class へ上げる候補として推奨。ただし H1 / coboundary quotient は除外。
+- G1 B: mismatch minimality を推奨。Cycle 92 本体ではなく、次候補または rival separation に回す。
+- G1 C: pre-H1 boundary criterion を推奨。H1 本体ではなく境界・保存・非零 obstruction を固定する方針。
+- G1 D: local-pass/global-fail taxonomy を推奨。Cycle 92 では class reading を優先し、taxonomy は次 frontier とする。
+- G2 A: accept / base 80。boundary-noisy representative が必須。なければ wrapper。
+- G2 B: revise / base 78-84。`Vanishes` / `Nonzero` は raw support ではなく cut-locus 相対に定義すること。
+- G2 C: revise / base 82。raw support vanishing preservation は偽なので、class-level predicates に限定すること。
+- G2 D: revise / base 82。selected noisy witness は `(flat, repairFrontier)` の off-cut raw support difference と class equivalence を両方持つこと。
+- G2 revise 解決: `CutVanishes` / `CutNonzero` を cut-locus 相対に定義し、selected noisy representative の raw support difference と `CutNoiseEquivalent` を Lean package に入れた。
+
+## 追加 required fields
+
+- `mathematical_interest`: residual transition cut support を raw representative と cut-locus class reading に分離する。
+- `goal_advancement`: preclass support predicate から noise-invariant finite obstruction class reading へ上げる。
+- `planned_theorem_names`: `cutNoiseEquivalent_preserves_cutNonzero`, `canonicalResidualCutClass_nonzero_iff_cut`, `selectedBoundaryNoisy_cutNoiseEquivalent_canonical`, `semanticResidualObstructionClass_package`
+- `visible_projection`: raw diagnostic support / scanner output / dashboard-like edge row。
+- `protected_structure`: residual cut locus、cut-locus vanishing/nonzero、off-cut raw support noise、transition-coherent data obstruction。
+- `exactness_or_minimality_claim`: cut-noise equivalence preserves cut-locus vanishing/nonzero; canonical cut class is exact for residual cut existence。global minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: raw diagnostic support may differ while residual cut class is unchanged。
+- `previous_cycle_delta`: Cycle 91 の preclass support exactnessを、off-cut raw noise を消す class reading へ拡張した。
+- `rival_stress_test`: rival は raw diagnostic row を出せても、off-cut noise と obstruction class support の同値不変性を theorem artifact として保持しない。
+- `genius_potential`: support-cycle。1000 点 unlock ではなく、future finite H1-style obstruction theorem への support node。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: representative/class 分離を導入し、obstruction-class frontier に必要な finite cut-locus equivalence layer を置く。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-obstruction-preclass.md`
+- `research/ideas/g-aat-quality-surface-01-residual-transition-cut-scanner.md`
+- `research/ideas/g-aat-quality-surface-01-residual-transition-cut-theorem.md`
+- planned report section: `Cycle 92: Semantic residual obstruction class modulo cut-noise`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 92 G1/G2 で cut-noise invariant residual obstruction class reading を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualObstructionClass.lean` に固定し、単体 `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 12482
+- total SCORE: 12646
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -96,8 +96,9 @@
   - semantic-obstruction / finite-atlas-transition / repair-coherence / genius-support: 130
   - semantic-obstruction / finite-atlas-transition / computability / genius-support: 144
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / genius-support: 156
+  - semantic-obstruction / finite-atlas-transition / obstruction-class-support / projection-nonfaithfulness / genius-support: 164
 - evidence portfolio:
-  - proved-in-research: 91
+  - proved-in-research: 92
 
 ## Phase synthesis
 
@@ -113,7 +114,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-91 件の Lean-proved research artifacts は、次の paper seed を形成している。
+92 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -133,6 +134,7 @@ certificate の基本単位は
 - semantic support projection kernel は、residual fiber singleton なら component projection が semantic repair closure を反映すること、そして non-singleton fiber では同じ component projection / local adequacy surface から semantic residual closure が分かれることを示す。
 - component clearance semantic obstruction は、declared component-level repair clearance と semantic residual emptiness を分離し、component repair row が green でも semantic exactness が認証されたわけではないことを示す。
 - visible/local semantic gluing obstruction は、visible/local repair-transport profile と declared component clearance があっても finite semantic repair-gluing exactness を反映できないことを selected finite atlas theorem として示す。
+- semantic residual obstruction class modulo cut-noise は、raw diagnostic support に off-cut noise が混じっても residual cut-locus class reading が不変であることを示し、preclass support から finite obstruction class frontier へ進める。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -184,8 +186,9 @@ tracking Issue の active threshold は 12000 に更新され、Cycle 88 後の 
 その後、tracking Issue の active threshold は 15000 に更新され、Cycle 89 後の total SCORE は 12182 である。
 Cycle 90 後の total SCORE は 12326 であり、tracking Issue active threshold 15000 までは残り 2674 SCORE である。
 Cycle 91 後の total SCORE は 12482 であり、tracking Issue active threshold 15000 までは残り 2518 SCORE である。
+Cycle 92 後の total SCORE は 12646 であり、tracking Issue active threshold 15000 までは残り 2354 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 91 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 92 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -209,7 +212,8 @@ semantic residual indexed transport theorem、
 semantic residual edge transition obstruction theorem、
 semantic residual transition cut theorem、
 semantic residual transition cut scanner exactness theorem、
-semantic residual obstruction one-preclass theorem を含む。
+semantic residual obstruction one-preclass theorem、
+semantic residual obstruction class modulo cut-noise theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -4694,4 +4698,78 @@ penalty 0 / final +156.
 
 Cycle 91 後の total SCORE は 12482 であり、tracking Issue active threshold 15000 までは残り 2518 SCORE である。
 次 cycle では、finite residual obstruction class beyond preclass、coboundary-like equivalence、local-pass/global-fail taxonomy、または finite H^1-style vanishing/nonvanishing criterion を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 92: Semantic residual obstruction class modulo cut-noise
+
+```text
+candidate: Semantic residual obstruction class modulo cut-noise
+candidate_type: obstruction-class-support / cut-locus equivalence / projection-noise
+evidence_stage: proved-in-research
+base_score: 82
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 164
+category: semantic-obstruction / finite-atlas-transition / obstruction-class-support / projection-nonfaithfulness / genius-support
+goal_delta: Cycle 91 の residual obstruction one-preclass を、raw cochain representative と cut-locus class reading に分離し、off-cut raw support noise を消す有限同値として固定した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、`CutNoiseEquivalent`、cut-locus vanishing/nonzero preservation、canonical cut class iff、scanner bridge、selected noisy representative の raw/class separation package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は raw diagnostic rows を返せるが、off-cut noise を含む representative と residual cut-locus obstruction class の同値不変性を Lean artifact として保持しない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualObstructionClass.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass`, and `lake build FormalAGResearch` passed. Axiom probe reported `cutNoiseEquivalent_preserves_cutVanishes`, `cutNoiseEquivalent_preserves_cutNonzero`, `canonicalResidualCutClass_vanishes_iff_no_cut`, and `canonicalResidualCutClass_nonzero_iff_cut` axiom-free; scanner bridge and selected noisy equivalence use standard `propext`; selected noisy nonzero and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: residual-present/residual-free mismatch minimality; local-pass/global-fail taxonomy; finite residual obstruction class with stronger morphism/gauge equivalence; true H1-style adapter for the open genius target.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualObstructionClass.lean`
+turns Cycle 91 の preclass support layer into a finite cut-locus obstruction
+class reading.  A `ResidualCutCochain` carries raw support over index pairs.
+`CutNoiseEquivalent` compares representatives only on
+`IsResidualTransitionCutPair`; therefore off-cut diagnostic noise is ignored
+by the obstruction class reading.  `CutVanishes` and `CutNonzero` are
+cut-locus relative predicates, not raw-support emptiness predicates.
+
+Lean proves:
+
+- `ResidualCutCochain`: raw support over a finite semantic repair atlas.
+- `canonicalResidualCutCochain`: canonical representative supported exactly on residual transition cut pairs.
+- `CutNoiseEquivalent`: class equivalence comparing support only on the residual cut locus.
+- `ResidualCutCochain.CutVanishes`: no raw support on residual cut pairs.
+- `ResidualCutCochain.CutNonzero`: support on some residual cut pair.
+- `cutNoiseEquivalent_refl`, `cutNoiseEquivalent_symm`, `cutNoiseEquivalent_trans`: equivalence laws.
+- `cutNoiseEquivalent_preserves_cutVanishes`: cut-noise equivalence preserves class vanishing.
+- `cutNoiseEquivalent_preserves_cutNonzero`: cut-noise equivalence preserves class nonzero support.
+- `canonicalResidualCutCochain_support_exact`: canonical support is exactly the residual cut-pair predicate.
+- `canonicalResidualCutClass_vanishes_iff_no_cut`: canonical class vanishing is equivalent to absence of residual transition cuts.
+- `canonicalResidualCutClass_nonzero_iff_cut`: canonical class nonzero is equivalent to existence of a residual transition cut.
+- `residualCutClass_nonzero_obstructs_atlasTransitionClosure`: any nonzero cut class obstructs residual transition closure.
+- `residualCutClass_nonzero_obstructs_transitionCoherentData`: any nonzero cut class rules out transition-coherent atlas data.
+- `firstResidualTransitionCut?_some_cutClassNonzero`: scanner `some` makes the canonical cut class nonzero.
+- `firstResidualTransitionCut?_none_iff_canonicalCutClassVanishes`: complete supplied edge-order scanner `none` is exact for canonical cut-class vanishing.
+- `firstResidualTransitionCut?_some_obstructs_via_cutClass`: scanner `some` obstructs closure via class nonzero.
+- `selected_flatFrontier_not_residualCutPair`: selected reverse pair is not a residual cut pair.
+- `selectedBoundaryNoisyResidualCutCochain`: selected noisy representative adding raw support on the reverse non-cut pair.
+- `selectedBoundaryNoisy_rawSupport_differs_from_canonical`: selected noisy representative differs from canonical raw support.
+- `selectedBoundaryNoisy_cutNoiseEquivalent_canonical`: selected noisy representative is cut-noise equivalent to canonical.
+- `selected_canonicalResidualCutClass_nonzero`: selected canonical class is nonzero.
+- `selectedBoundaryNoisy_residualCutClass_nonzero`: selected noisy class is nonzero.
+- `selectedBoundaryNoisy_residualCutClass_obstructs_transitionClosure`: selected noisy class obstructs transition closure.
+- `selectedBoundaryNoisy_residualCutClass_obstructs_transitionCoherentData`: selected noisy class obstructs transition-coherent atlas data.
+- `semanticResidualObstructionClass_package`: theorem package.
+
+This cycle is a support node, not a `genius unlock`.  It is a quotient-style
+cut-locus class reading, not a true `H^1` class, Cech quotient, coboundary
+quotient, or coboundary calculus.  It does not claim `class vanishes ->
+transition closure`, global minimal representative, source extraction
+completeness, ArchMap correctness, runtime repair synthesis, tooling runtime
+extraction, UI correctness, or whole-codebase quality.  G2 required the
+central revision that vanishing/nonzero be cut-locus relative, because raw
+support emptiness is not preserved by an equivalence that ignores off-cut
+pairs.  G3 passed after confirming the selected noisy representative has
+genuinely different raw support while remaining cut-noise equivalent to the
+canonical representative.
+
+### Next Frontier
+
+Cycle 92 後の total SCORE は 12646 であり、tracking Issue active threshold 15000 までは残り 2354 SCORE である。
+次 cycle では、residual-present/residual-free mismatch minimality、local-pass/global-fail taxonomy、support-preserving atlas morphism / gauge equivalence、または finite H1-style adapter を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の research-loop Cycle 92 として、semantic residual obstruction preclass を cut-noise invariant な finite class reading へ上げました。
raw diagnostic support と residual cut-locus class data を分離し、off-cut raw support noise を含む representative が canonical representative と raw support では異なっても、cut-locus class として同値であることを Lean で固定しています。

tracking Issue #2348 は active threshold 15000 まで継続するため、意図的に `Closes #2348` は書いていません。

## 証明した定理

- `ResidualCutCochain`
- `canonicalResidualCutCochain`
- `CutNoiseEquivalent`
- `ResidualCutCochain.CutVanishes`
- `ResidualCutCochain.CutNonzero`
- `cutNoiseEquivalent_refl`
- `cutNoiseEquivalent_symm`
- `cutNoiseEquivalent_trans`
- `cutNoiseEquivalent_preserves_cutVanishes`
- `cutNoiseEquivalent_preserves_cutNonzero`
- `canonicalResidualCutCochain_support_exact`
- `canonicalResidualCutClass_vanishes_iff_no_cut`
- `canonicalResidualCutClass_nonzero_iff_cut`
- `residualCutClass_nonzero_obstructs_atlasTransitionClosure`
- `residualCutClass_nonzero_obstructs_transitionCoherentData`
- `firstResidualTransitionCut?_some_cutClassNonzero`
- `firstResidualTransitionCut?_none_iff_canonicalCutClassVanishes`
- `firstResidualTransitionCut?_some_obstructs_via_cutClass`
- `selected_flatFrontier_not_residualCutPair`
- `selectedBoundaryNoisyResidualCutCochain`
- `selectedBoundaryNoisy_rawSupport_differs_from_canonical`
- `selectedBoundaryNoisy_cutNoiseEquivalent_canonical`
- `selected_canonicalResidualCutClass_nonzero`
- `selectedBoundaryNoisy_residualCutClass_nonzero`
- `selectedBoundaryNoisy_residualCutClass_obstructs_transitionClosure`
- `selectedBoundaryNoisy_residualCutClass_obstructs_transitionCoherentData`
- `semanticResidualObstructionClass_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-obstruction-class.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualObstructionClass.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms`（core preservation/canonical iff は axiom-free、scanner/selected/package は標準 `propext` / `Quot.sound` のみ）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: proved-in-research。

Claim boundary: これは quotient-style cut-locus class reading であり、true H1 theorem、Cech quotient、coboundary quotient、`class vanishes -> transition closure`、global minimality、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、UI correctness、whole-codebase quality は主張しません。
