### PR TITLE
研究ループ Cycle 93 の atlas gauge invariance を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -89,3 +89,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualTransitionCut
 import Formal.AG.Research.QualitySurface.SemanticResidualTransitionCutScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualObstructionPreclass
 import Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass
+import Formal.AG.Research.QualitySurface.SemanticResidualAtlasGauge

--- a/Formal/AG/Research/QualitySurface/SemanticResidualAtlasGauge.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualAtlasGauge.lean
@@ -1,0 +1,564 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass
+
+/-!
+Cycle 93 evidence for `G-aat-quality-surface-01`.
+
+This file lifts the Cycle 92 cut-noise class reading from raw cochain
+representatives to same-carrier atlas presentations.  Two finite semantic
+repair atlas skeletons may have different raw edge families while exposing
+the same residual transition cut locus.  Under that explicit same-carrier
+cut-locus gauge, cut-locus class vanishing, nonzero support, and nonzero
+obstruction readings are invariant.
+
+The result is a same-carrier cut-locus invariance theorem.  It does not
+construct arbitrary atlas morphisms, functorial sheaf transport, a Cech `H^1`
+class, a coboundary quotient, a vanishing-to-closure theorem, source extraction
+completeness, ArchMap correctness, runtime repair synthesis, tooling runtime
+extraction, UI correctness, or whole-codebase quality.
+-/
+
+universe u w
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualAtlasGauge
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+
+/-! ## Same-carrier residual cut-locus gauges -/
+
+/--
+Two same-carrier atlas skeletons expose the same residual transition cut locus
+when every index pair is a cut in one exactly when it is a cut in the other.
+-/
+def SameResidualCutLocus
+    {Index : Type w}
+    {Atom : Type u}
+    (left right : FiniteSemanticRepairAtlasSkeleton Index Atom) : Prop :=
+  forall pair,
+    IsResidualTransitionCutPair left pair <->
+      IsResidualTransitionCutPair right pair
+
+/--
+Two raw residual cut cochains over same-carrier atlases are gauge-related when
+their support agrees on the left residual cut locus.  A matching
+`SameResidualCutLocus` hypothesis is needed to transfer right-side class
+predicates.
+-/
+def SameResidualCutClassGaugeRelated
+    {Index : Type w}
+    {Atom : Type u}
+    {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (leftC : ResidualCutCochain left)
+    (rightC : ResidualCutCochain right) : Prop :=
+  forall pair,
+    IsResidualTransitionCutPair left pair ->
+      (leftC.support pair <-> rightC.support pair)
+
+/-- Same residual cut locus is reflexive. -/
+theorem sameResidualCutLocus_refl
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom) :
+    SameResidualCutLocus atlas atlas := by
+  intro pair
+  rfl
+
+/-- Same residual cut locus is symmetric. -/
+theorem sameResidualCutLocus_symm
+    {Index : Type w}
+    {Atom : Type u}
+    {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (hsame : SameResidualCutLocus left right) :
+    SameResidualCutLocus right left := by
+  intro pair
+  exact (hsame pair).symm
+
+/-- Same residual cut locus is transitive. -/
+theorem sameResidualCutLocus_trans
+    {Index : Type w}
+    {Atom : Type u}
+    {left middle right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (hleft : SameResidualCutLocus left middle)
+    (hright : SameResidualCutLocus middle right) :
+    SameResidualCutLocus left right := by
+  intro pair
+  exact (hleft pair).trans (hright pair)
+
+/-- Gauge-related classes preserve cut-locus vanishing across same cut loci. -/
+theorem sameResidualCutClassGaugeRelated_preserves_cutVanishes
+    {Index : Type w}
+    {Atom : Type u}
+    {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {leftC : ResidualCutCochain left}
+    {rightC : ResidualCutCochain right}
+    (hsame : SameResidualCutLocus left right)
+    (hrelated : SameResidualCutClassGaugeRelated leftC rightC) :
+    leftC.CutVanishes <-> rightC.CutVanishes := by
+  constructor
+  · intro hleft pair hrightCut hrightSupport
+    have hleftCut :
+        IsResidualTransitionCutPair left pair :=
+      (hsame pair).mpr hrightCut
+    exact hleft pair hleftCut ((hrelated pair hleftCut).mpr hrightSupport)
+  · intro hright pair hleftCut hleftSupport
+    have hrightCut :
+        IsResidualTransitionCutPair right pair :=
+      (hsame pair).mp hleftCut
+    exact hright pair hrightCut ((hrelated pair hleftCut).mp hleftSupport)
+
+/-- Gauge-related classes preserve cut-locus nonzero support across same cut loci. -/
+theorem sameResidualCutClassGaugeRelated_preserves_cutNonzero
+    {Index : Type w}
+    {Atom : Type u}
+    {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {leftC : ResidualCutCochain left}
+    {rightC : ResidualCutCochain right}
+    (hsame : SameResidualCutLocus left right)
+    (hrelated : SameResidualCutClassGaugeRelated leftC rightC) :
+    leftC.CutNonzero <-> rightC.CutNonzero := by
+  constructor
+  · intro hleft
+    rcases hleft with ⟨pair, hleftCut, hleftSupport⟩
+    exact
+      ⟨pair,
+        (hsame pair).mp hleftCut,
+        (hrelated pair hleftCut).mp hleftSupport⟩
+  · intro hright
+    rcases hright with ⟨pair, hrightCut, hrightSupport⟩
+    have hleftCut :
+        IsResidualTransitionCutPair left pair :=
+      (hsame pair).mpr hrightCut
+    exact
+      ⟨pair,
+        hleftCut,
+        (hrelated pair hleftCut).mpr hrightSupport⟩
+
+/-! ## Canonical class invariance -/
+
+/-- Canonical residual cut cochains are gauge-related under same cut locus. -/
+theorem sameResidualCutLocus_gaugeRelated_canonical
+    {Index : Type w}
+    {Atom : Type u}
+    {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (hsame : SameResidualCutLocus left right) :
+    SameResidualCutClassGaugeRelated
+      (canonicalResidualCutCochain left)
+      (canonicalResidualCutCochain right) := by
+  intro pair _hleftCut
+  exact hsame pair
+
+/-- Same residual cut locus preserves canonical cut-class vanishing. -/
+theorem sameResidualCutLocus_preserves_canonicalCutVanishes
+    {Index : Type w}
+    {Atom : Type u}
+    {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (hsame : SameResidualCutLocus left right) :
+    (canonicalResidualCutCochain left).CutVanishes <->
+      (canonicalResidualCutCochain right).CutVanishes := by
+  exact
+    sameResidualCutClassGaugeRelated_preserves_cutVanishes
+      hsame
+      (sameResidualCutLocus_gaugeRelated_canonical hsame)
+
+/-- Same residual cut locus preserves canonical cut-class nonzero support. -/
+theorem sameResidualCutLocus_preserves_canonicalCutNonzero
+    {Index : Type w}
+    {Atom : Type u}
+    {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (hsame : SameResidualCutLocus left right) :
+    (canonicalResidualCutCochain left).CutNonzero <->
+      (canonicalResidualCutCochain right).CutNonzero := by
+  exact
+    sameResidualCutClassGaugeRelated_preserves_cutNonzero
+      hsame
+      (sameResidualCutLocus_gaugeRelated_canonical hsame)
+
+/-- A nonzero gauge-related source class obstructs target transition closure. -/
+theorem gaugeRelated_nonzero_obstructs_targetTransitionClosure
+    {Index : Type w}
+    {Atom : Type u}
+    {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {leftC : ResidualCutCochain left}
+    {rightC : ResidualCutCochain right}
+    (hsame : SameResidualCutLocus left right)
+    (hrelated : SameResidualCutClassGaugeRelated leftC rightC)
+    (hnonzero : leftC.CutNonzero)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (AtlasResidualTransitionClosed right transition) := by
+  have htarget : rightC.CutNonzero :=
+    (sameResidualCutClassGaugeRelated_preserves_cutNonzero
+      hsame hrelated).mp hnonzero
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      rightC htarget transition
+
+/-- A nonzero gauge-related source class rules out target transition-coherent data. -/
+theorem gaugeRelated_nonzero_obstructs_targetTransitionCoherentData
+    {Index : Type w}
+    {Atom : Type u}
+    {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {leftC : ResidualCutCochain left}
+    {rightC : ResidualCutCochain right}
+    (hsame : SameResidualCutLocus left right)
+    (hrelated : SameResidualCutClassGaugeRelated leftC rightC)
+    (hnonzero : leftC.CutNonzero)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (Nonempty (TransitionCoherentAtlasData right transition)) := by
+  have htarget : rightC.CutNonzero :=
+    (sameResidualCutClassGaugeRelated_preserves_cutNonzero
+      hsame hrelated).mp hnonzero
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      rightC htarget transition
+
+/-! ## Selected raw-edge noisy atlas gauge -/
+
+/-- The selected raw-edge noisy atlas adds the reverse edge as presentation noise. -/
+def selectedEdgeNoisyFrontierFlatEdge
+    (source target : SelectedSemanticOverlapIndex) : Prop :=
+  selectedFrontierToFlatEdge source target \/
+    (source = SelectedSemanticOverlapIndex.flat /\
+      target = SelectedSemanticOverlapIndex.repairFrontier)
+
+/--
+The selected raw-edge noisy atlas has the same finite carrier, projection, and
+cover as the selected frontier-to-flat atlas, but a larger raw edge family.
+-/
+def selectedEdgeNoisyFrontierFlatAtlasSkeleton :
+    FiniteSemanticRepairAtlasSkeleton
+      SelectedSemanticOverlapIndex
+      RefinedSemanticRepairAtom where
+  indexOrder := selectedFrontierFlatAtlasSkeleton.indexOrder
+  index_complete := selectedFrontierFlatAtlasSkeleton.index_complete
+  atomOrder := selectedFrontierFlatAtlasSkeleton.atomOrder
+  atom_complete := selectedFrontierFlatAtlasSkeleton.atom_complete
+  edge := selectedEdgeNoisyFrontierFlatEdge
+  projection := selectedFrontierFlatAtlasSkeleton.projection
+  cover := selectedFrontierFlatAtlasSkeleton.cover
+
+/-- The selected noisy atlas has a reverse raw edge not present in the original atlas. -/
+theorem selectedEdgeNoisy_rawEdge_differs_from_selected :
+    selectedEdgeNoisyFrontierFlatAtlasSkeleton.edge
+        SelectedSemanticOverlapIndex.flat
+        SelectedSemanticOverlapIndex.repairFrontier /\
+      Not
+        (selectedFrontierFlatAtlasSkeleton.edge
+          SelectedSemanticOverlapIndex.flat
+          SelectedSemanticOverlapIndex.repairFrontier) := by
+  constructor
+  · dsimp [selectedEdgeNoisyFrontierFlatAtlasSkeleton,
+      selectedEdgeNoisyFrontierFlatEdge]
+    exact Or.inr ⟨rfl, rfl⟩
+  · intro hedge
+    simp [selectedFrontierFlatAtlasSkeleton,
+      selectedFrontierToFlatEdge] at hedge
+
+/-- The selected flat index is not residual-present. -/
+theorem selected_flatIndexedResidualNotPresent :
+    Not
+      (IndexedResidualPresentAt
+        selectedIndexedProjection
+        selectedIndexedCover
+        SelectedSemanticOverlapIndex.flat) := by
+  intro hpresent
+  rcases hpresent with ⟨residual, hresidual⟩
+  exact selected_flatIndexedResidualFree residual hresidual
+
+/--
+The reverse noisy edge is not a residual cut pair: it starts at the flat index,
+which is residual-free.
+-/
+theorem selectedEdgeNoisy_reverse_not_residualCutPair :
+    Not
+      (IsResidualTransitionCutPair
+        selectedEdgeNoisyFrontierFlatAtlasSkeleton
+        (SelectedSemanticOverlapIndex.flat,
+          SelectedSemanticOverlapIndex.repairFrontier)) := by
+  intro hcut
+  exact
+    selected_flatIndexedResidualNotPresent
+      (by
+        simpa [selectedEdgeNoisyFrontierFlatAtlasSkeleton]
+          using hcut.2.1)
+
+/--
+The selected raw-edge noisy atlas has the same residual cut locus as the
+original selected frontier-to-flat atlas.
+-/
+theorem selectedEdgeNoisy_sameResidualCutLocus_selected :
+    SameResidualCutLocus
+      selectedFrontierFlatAtlasSkeleton
+      selectedEdgeNoisyFrontierFlatAtlasSkeleton := by
+  intro pair
+  cases pair with
+  | mk source target =>
+      constructor
+      · intro hcut
+        exact
+          ⟨Or.inl
+              (by
+                simpa [selectedFrontierFlatAtlasSkeleton]
+                  using hcut.1),
+            by
+              simpa [selectedFrontierFlatAtlasSkeleton,
+                selectedEdgeNoisyFrontierFlatAtlasSkeleton]
+                using hcut.2.1,
+            by
+              simpa [selectedFrontierFlatAtlasSkeleton,
+                selectedEdgeNoisyFrontierFlatAtlasSkeleton]
+                using hcut.2.2⟩
+      · intro hcut
+        have hselectedEdge :
+            selectedFrontierFlatAtlasSkeleton.edge source target := by
+          rcases hcut.1 with hselected | hreverse
+          · simpa [selectedFrontierFlatAtlasSkeleton] using hselected
+          · rcases hreverse with ⟨hsource, htarget⟩
+            have hsource' :
+                source = SelectedSemanticOverlapIndex.flat := by
+              simpa using hsource
+            have htarget' :
+                target = SelectedSemanticOverlapIndex.repairFrontier := by
+              simpa using htarget
+            subst source
+            subst target
+            have hflatPresent :
+                IndexedResidualPresentAt
+                  selectedIndexedProjection
+                  selectedIndexedCover
+                  SelectedSemanticOverlapIndex.flat := by
+              simpa [selectedEdgeNoisyFrontierFlatAtlasSkeleton]
+                using hcut.2.1
+            exact False.elim
+              (selected_flatIndexedResidualNotPresent hflatPresent)
+        exact
+          ⟨hselectedEdge,
+            by
+              simpa [selectedFrontierFlatAtlasSkeleton,
+                selectedEdgeNoisyFrontierFlatAtlasSkeleton]
+                using hcut.2.1,
+            by
+              simpa [selectedFrontierFlatAtlasSkeleton,
+                selectedEdgeNoisyFrontierFlatAtlasSkeleton]
+                using hcut.2.2⟩
+
+/-- The selected noisy atlas canonical class is gauge-related to the original one. -/
+theorem selectedEdgeNoisy_canonicalGaugeRelated_selected :
+    SameResidualCutClassGaugeRelated
+      (canonicalResidualCutCochain selectedFrontierFlatAtlasSkeleton)
+      (canonicalResidualCutCochain selectedEdgeNoisyFrontierFlatAtlasSkeleton) := by
+  exact
+    sameResidualCutLocus_gaugeRelated_canonical
+      selectedEdgeNoisy_sameResidualCutLocus_selected
+
+/-- The selected noisy atlas has nonzero canonical residual cut class. -/
+theorem selectedEdgeNoisy_canonicalCutClass_nonzero :
+    (canonicalResidualCutCochain
+      selectedEdgeNoisyFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    (sameResidualCutLocus_preserves_canonicalCutNonzero
+      selectedEdgeNoisy_sameResidualCutLocus_selected).mp
+      selected_canonicalResidualCutClass_nonzero
+
+/-- The selected noisy canonical class obstructs residual transition closure. -/
+theorem selectedEdgeNoisy_canonicalCutClass_obstructs_transitionClosure
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedEdgeNoisyFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain
+        selectedEdgeNoisyFrontierFlatAtlasSkeleton)
+      selectedEdgeNoisy_canonicalCutClass_nonzero
+      transition
+
+/-- The selected noisy canonical class rules out transition-coherent atlas data. -/
+theorem selectedEdgeNoisy_canonicalCutClass_obstructs_transitionCoherentData
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedEdgeNoisyFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (canonicalResidualCutCochain
+        selectedEdgeNoisyFrontierFlatAtlasSkeleton)
+      selectedEdgeNoisy_canonicalCutClass_nonzero
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-93 theorem package: same-carrier atlas presentations with the same
+residual cut locus preserve gauge-related cut-class vanishing, nonzero
+support, and nonzero obstruction readings.  The selected raw-edge noisy atlas
+changes the raw edge family while preserving the residual cut locus.
+-/
+theorem semanticResidualAtlasGauge_package :
+    (forall {Index : Type w}
+      {Atom : Type u}
+      {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+      SameResidualCutLocus atlas atlas) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {left right : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        SameResidualCutLocus left right ->
+          SameResidualCutLocus right left) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {left middle right : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        SameResidualCutLocus left middle ->
+          SameResidualCutLocus middle right ->
+            SameResidualCutLocus left right) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {leftC : ResidualCutCochain left}
+        {rightC : ResidualCutCochain right},
+        SameResidualCutLocus left right ->
+          SameResidualCutClassGaugeRelated leftC rightC ->
+            (leftC.CutVanishes <-> rightC.CutVanishes)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {leftC : ResidualCutCochain left}
+        {rightC : ResidualCutCochain right},
+        SameResidualCutLocus left right ->
+          SameResidualCutClassGaugeRelated leftC rightC ->
+            (leftC.CutNonzero <-> rightC.CutNonzero)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {left right : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        SameResidualCutLocus left right ->
+          SameResidualCutClassGaugeRelated
+            (canonicalResidualCutCochain left)
+            (canonicalResidualCutCochain right)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {left right : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        SameResidualCutLocus left right ->
+          ((canonicalResidualCutCochain left).CutVanishes <->
+            (canonicalResidualCutCochain right).CutVanishes)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {left right : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        SameResidualCutLocus left right ->
+          ((canonicalResidualCutCochain left).CutNonzero <->
+            (canonicalResidualCutCochain right).CutNonzero)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {leftC : ResidualCutCochain left}
+        {rightC : ResidualCutCochain right},
+        SameResidualCutLocus left right ->
+          SameResidualCutClassGaugeRelated leftC rightC ->
+            leftC.CutNonzero ->
+              forall transition : Index -> Index -> Atom -> Atom,
+                Not (AtlasResidualTransitionClosed right transition)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {left right : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {leftC : ResidualCutCochain left}
+        {rightC : ResidualCutCochain right},
+        SameResidualCutLocus left right ->
+          SameResidualCutClassGaugeRelated leftC rightC ->
+            leftC.CutNonzero ->
+              forall transition : Index -> Index -> Atom -> Atom,
+                Not (Nonempty (TransitionCoherentAtlasData right transition))) /\
+      selectedEdgeNoisyFrontierFlatAtlasSkeleton.edge
+        SelectedSemanticOverlapIndex.flat
+        SelectedSemanticOverlapIndex.repairFrontier /\
+      Not
+        (selectedFrontierFlatAtlasSkeleton.edge
+          SelectedSemanticOverlapIndex.flat
+          SelectedSemanticOverlapIndex.repairFrontier) /\
+      Not
+        (IsResidualTransitionCutPair
+          selectedEdgeNoisyFrontierFlatAtlasSkeleton
+          (SelectedSemanticOverlapIndex.flat,
+            SelectedSemanticOverlapIndex.repairFrontier)) /\
+      SameResidualCutLocus
+        selectedFrontierFlatAtlasSkeleton
+        selectedEdgeNoisyFrontierFlatAtlasSkeleton /\
+      SameResidualCutClassGaugeRelated
+        (canonicalResidualCutCochain selectedFrontierFlatAtlasSkeleton)
+        (canonicalResidualCutCochain
+          selectedEdgeNoisyFrontierFlatAtlasSkeleton) /\
+      (canonicalResidualCutCochain
+        selectedEdgeNoisyFrontierFlatAtlasSkeleton).CutNonzero /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedEdgeNoisyFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedEdgeNoisyFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_Index} {_Atom} {_atlas} =>
+        sameResidualCutLocus_refl _,
+      fun {_Index} {_Atom} {_left} {_right} hsame =>
+        sameResidualCutLocus_symm hsame,
+      fun {_Index} {_Atom} {_left} {_middle} {_right} hleft hright =>
+        sameResidualCutLocus_trans hleft hright,
+      fun {_Index} {_Atom} {_left} {_right} {_leftC} {_rightC}
+          hsame hrelated =>
+        sameResidualCutClassGaugeRelated_preserves_cutVanishes
+          hsame hrelated,
+      fun {_Index} {_Atom} {_left} {_right} {_leftC} {_rightC}
+          hsame hrelated =>
+        sameResidualCutClassGaugeRelated_preserves_cutNonzero
+          hsame hrelated,
+      fun {_Index} {_Atom} {_left} {_right} hsame =>
+        sameResidualCutLocus_gaugeRelated_canonical hsame,
+      fun {_Index} {_Atom} {_left} {_right} hsame =>
+        sameResidualCutLocus_preserves_canonicalCutVanishes hsame,
+      fun {_Index} {_Atom} {_left} {_right} hsame =>
+        sameResidualCutLocus_preserves_canonicalCutNonzero hsame,
+      fun {_Index} {_Atom} {_left} {_right} {_leftC} {_rightC}
+          hsame hrelated hnonzero transition =>
+        gaugeRelated_nonzero_obstructs_targetTransitionClosure
+          hsame hrelated hnonzero transition,
+      fun {_Index} {_Atom} {_left} {_right} {_leftC} {_rightC}
+          hsame hrelated hnonzero transition =>
+        gaugeRelated_nonzero_obstructs_targetTransitionCoherentData
+          hsame hrelated hnonzero transition,
+      selectedEdgeNoisy_rawEdge_differs_from_selected.1,
+      selectedEdgeNoisy_rawEdge_differs_from_selected.2,
+      selectedEdgeNoisy_reverse_not_residualCutPair,
+      selectedEdgeNoisy_sameResidualCutLocus_selected,
+      selectedEdgeNoisy_canonicalGaugeRelated_selected,
+      selectedEdgeNoisy_canonicalCutClass_nonzero,
+      selectedEdgeNoisy_canonicalCutClass_obstructs_transitionClosure,
+      selectedEdgeNoisy_canonicalCutClass_obstructs_transitionCoherentData⟩
+
+end SemanticResidualAtlasGauge
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-gauge.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-gauge.md
@@ -1,0 +1,153 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: atlas-gauge / cut-locus invariance / genius-support convergence
+candidate_type: invariant-hardening / same-carrier atlas gauge / obstruction-class-support
+capability_category: semantic-obstruction / finite-atlas-transition / obstruction-class-support / invariance / genius-support
+expected_base_score: 86
+expected_evidence_multiplier: 2.0
+expected_final_score: 172
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can tolerate renamed or noisy edge rows, but they do not prove that semantic residual obstruction classes are invariant under same-carrier atlas edge-noise gauges.
+origin: cycle-93
+tags: [quality-surface, semantic-repair, residual-cut, atlas-gauge, invariance, genius-support]
+created: 2026-06-23
+cycle: 93
+lean: proved-in-research
+planned_report_section: "Cycle 93: Semantic residual atlas gauge invariance"
+---
+
+# Semantic Residual Atlas Gauge Invariance
+
+## 主張
+
+Cycle 92 の cut-noise obstruction class を、raw cochain representative の不変性から same-carrier atlas presentation の不変性へ上げる。
+同じ `Index` / `Atom` carrier 上の finite semantic repair atlas skeleton が異なる raw edge family を持っていても、`IsResidualTransitionCutPair` の cut locus が同じなら、canonical residual cut class の vanishing / nonzero と nonzero obstruction reading は保存される。
+
+selected witness では、`selectedFrontierFlatAtlasSkeleton` に reverse raw edge `(flat, repairFrontier)` を足した `selectedEdgeNoisyFrontierFlatAtlasSkeleton` を作る。
+この noisy atlas は raw edge family として元の atlas と異なるが、reverse pair は `flat` が residual-free であるため residual cut pair ではない。
+したがって selected original atlas と noisy atlas は同じ residual cut locus を持ち、canonical residual cut class の nonzero と closure/data obstruction が noisy atlas 側へ移る。
+
+この主張は same-carrier cut-locus gauge invariance に限定する。
+arbitrary atlas morphism、functorial sheaf transport、true `H^1`、Cech quotient、coboundary quotient、`vanishing -> closure`、global minimality、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、UI correctness、whole-codebase quality は含まない。
+
+## 候補種別
+
+`invariant-hardening` / `same-carrier atlas gauge` / `obstruction-class-support`
+
+## 依拠
+
+- Cycle 89: finite semantic atlas residual transition cut certificate。
+- Cycle 90: supplied-order residual transition cut scanner exactness。
+- Cycle 91: residual obstruction one-preclass。
+- Cycle 92: cut-noise invariant residual obstruction class reading。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+単なる `SameResidualCutLocus` preservation だけなら tautological に見える。
+この候補では、selected atlas の raw edge family を実際に変更し、追加された reverse edge が active であるにもかかわらず residual cut ではないことを Lean で証明する。
+raw edge presentation は違うが residual cut locus と obstruction class reading は変わらない、という atlas presentation レベルの witness を置く点が差分である。
+
+## 数学的興味
+
+obstruction class が選んだ finite atlas presentation の artifact ではなく、residual cut locus に相対化された invariant として読めることを固定する。
+これはまだ cohomology quotient ではないが、future finite H1-style obstruction theorem で必要な「representative / presentation 変更に対する不変性」を Lean artifact として先に置く。
+
+## GOAL への前進
+
+open genius target の `finite atom-supported quality atlases` という語に近づく。
+Cycle 92 では同一 atlas 内の cochain representative noise を殺した。
+Cycle 93 では atlas skeleton の raw edge family 自体に harmless noise が入っても、semantic residual obstruction class reading が保存されることを示す。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は edge row の追加・表示順変更・疑似 diagnostic を扱える。
+しかし、それらは「追加された raw edge が residual cut locus を変えないなら obstruction class は不変である」という theorem-level invariant を持たない。
+AAT 側では、raw presentation noise と residual obstruction class data を分離して扱える。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 92 の cochain-level cut-noise class reading を atlas presentation-level edge-noise gauge invariance へ上げる。open genius target の support node として強いが、arbitrary morphism や H1 本体ではない。
+- `dullness_risk`: `SameResidualCutLocus` を仮定した保存だけなら弱い。selected noisy atlas の raw edge difference、reverse edge active/non-cut、same cut locus、nonzero obstruction transfer を揃える。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualAtlasGauge.lean` で same cut locus、gauge-related cochains、canonical transfer、selected raw-edge noisy atlas witness、theorem package を証明する。
+
+## CS / SWE への帰結
+
+finite atlas diagnostic では、raw edge rows と obstruction class data を分けて読む必要がある。
+edge row が追加されても、それが residual-present source / residual-free target の cut locus を変えないなら、semantic residual obstruction class は同じである。
+これは noisy dashboard rows や ADL-level presentation differences に対する theorem-level robustness である。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualAtlasGauge.lean` に固定した。
+
+- `SameResidualCutLocus`
+- `SameResidualCutClassGaugeRelated`
+- `sameResidualCutLocus_refl`
+- `sameResidualCutLocus_symm`
+- `sameResidualCutLocus_trans`
+- `sameResidualCutClassGaugeRelated_preserves_cutVanishes`
+- `sameResidualCutClassGaugeRelated_preserves_cutNonzero`
+- `sameResidualCutLocus_gaugeRelated_canonical`
+- `sameResidualCutLocus_preserves_canonicalCutVanishes`
+- `sameResidualCutLocus_preserves_canonicalCutNonzero`
+- `gaugeRelated_nonzero_obstructs_targetTransitionClosure`
+- `gaugeRelated_nonzero_obstructs_targetTransitionCoherentData`
+- `selectedEdgeNoisyFrontierFlatEdge`
+- `selectedEdgeNoisyFrontierFlatAtlasSkeleton`
+- `selectedEdgeNoisy_rawEdge_differs_from_selected`
+- `selected_flatIndexedResidualNotPresent`
+- `selectedEdgeNoisy_reverse_not_residualCutPair`
+- `selectedEdgeNoisy_sameResidualCutLocus_selected`
+- `selectedEdgeNoisy_canonicalGaugeRelated_selected`
+- `selectedEdgeNoisy_canonicalCutClass_nonzero`
+- `selectedEdgeNoisy_canonicalCutClass_obstructs_transitionClosure`
+- `selectedEdgeNoisy_canonicalCutClass_obstructs_transitionCoherentData`
+- `semanticResidualAtlasGauge_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualAtlasGauge.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualAtlasGauge`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic preservation、canonical transfer、target obstruction は axiom-free。selected witness と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、same `Index` / `Atom` carrier の finite semantic repair atlas skeleton、supplied same residual cut locus、cut-locus class predicates、selected raw-edge noisy atlas witness に限定する。
+unchecked: arbitrary atlas morphism、functoriality、true H1 cohomology class、Cech quotient、coboundary quotient、vanishing-to-closure theorem、general sheaf gluing、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、whole-codebase quality。
+
+## 審判メモ
+
+- G1 A/B/C/D: いずれも atlas gauge invariance を推奨。Cycle 92 の cochain representative noise から atlas presentation noise へ上げるのが最大 leverage と判定。
+- G2 A: accept / base 84 range 80-86。selected reverse edge witness が critical。
+- G2 B: accept / base 86-88。same-carrier 限定は正しいが、selected raw-edge-different witness が必須。
+- G2 C: accept / base 86。`SameResidualCutClassGaugeRelated` は `SameResidualCutLocus` とセットで使うこと。
+- G2 D: accept / base 84-86。arbitrary morphism ではなく same-carrier cut-locus gauge と明記する条件。
+- G2 revise 解決: theorem は same-carrier に限定し、reverse raw edge が active だが `flat` residual-free のため non-cut である selected witness を package に入れた。
+
+## 追加 required fields
+
+- `mathematical_interest`: residual cut class を same-carrier atlas presentation noise に対する invariant として読む。
+- `goal_advancement`: cochain representative noise から atlas edge presentation noise へ不変性を上げる。
+- `planned_theorem_names`: `sameResidualCutClassGaugeRelated_preserves_cutNonzero`, `selectedEdgeNoisy_sameResidualCutLocus_selected`, `semanticResidualAtlasGauge_package`
+- `visible_projection`: raw atlas edge family / noisy diagnostic edge row。
+- `protected_structure`: residual transition cut locus、canonical cut class nonzero、same-carrier gauge-related support、transition closure obstruction。
+- `exactness_or_minimality_claim`: same residual cut locus preserves canonical vanishing/nonzero。global minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: raw edge family may differ while residual cut locus and obstruction class are unchanged。
+- `previous_cycle_delta`: Cycle 92 の cochain-level cut-noise equivalence を atlas presentation-level edge-noise gauge invariance へ上げた。
+- `rival_stress_test`: rival は noisy edge rows を持てても、same residual cut locus による obstruction class preservation theorem を持たない。
+- `genius_potential`: strong support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem への invariant-hardening node。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: obstruction class が chosen atlas presentation の artifact ではないことを same-carrier gauge と selected noisy witness で固定する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-obstruction-class.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-obstruction-preclass.md`
+- `research/ideas/g-aat-quality-surface-01-residual-transition-cut-scanner.md`
+- planned report section: `Cycle 93: Semantic residual atlas gauge invariance`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 93 G1/G2 で same-carrier residual atlas gauge invariance を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualAtlasGauge.lean` に固定し、単体 `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 12646
+- total SCORE: 12818
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -97,8 +97,9 @@
   - semantic-obstruction / finite-atlas-transition / computability / genius-support: 144
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / genius-support: 156
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / projection-nonfaithfulness / genius-support: 164
+  - semantic-obstruction / finite-atlas-transition / obstruction-class-support / invariance / genius-support: 172
 - evidence portfolio:
-  - proved-in-research: 92
+  - proved-in-research: 93
 
 ## Phase synthesis
 
@@ -114,7 +115,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-92 件の Lean-proved research artifacts は、次の paper seed を形成している。
+93 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -135,6 +136,7 @@ certificate の基本単位は
 - component clearance semantic obstruction は、declared component-level repair clearance と semantic residual emptiness を分離し、component repair row が green でも semantic exactness が認証されたわけではないことを示す。
 - visible/local semantic gluing obstruction は、visible/local repair-transport profile と declared component clearance があっても finite semantic repair-gluing exactness を反映できないことを selected finite atlas theorem として示す。
 - semantic residual obstruction class modulo cut-noise は、raw diagnostic support に off-cut noise が混じっても residual cut-locus class reading が不変であることを示し、preclass support から finite obstruction class frontier へ進める。
+- semantic residual atlas gauge invariance は、raw edge family に harmless reverse-edge noise が混じっても same residual cut locus なら canonical obstruction class と nonzero obstruction reading が保存されることを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -187,8 +189,9 @@ tracking Issue の active threshold は 12000 に更新され、Cycle 88 後の 
 Cycle 90 後の total SCORE は 12326 であり、tracking Issue active threshold 15000 までは残り 2674 SCORE である。
 Cycle 91 後の total SCORE は 12482 であり、tracking Issue active threshold 15000 までは残り 2518 SCORE である。
 Cycle 92 後の total SCORE は 12646 であり、tracking Issue active threshold 15000 までは残り 2354 SCORE である。
+Cycle 93 後の total SCORE は 12818 であり、tracking Issue active threshold 15000 までは残り 2182 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 92 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 93 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -213,7 +216,8 @@ semantic residual edge transition obstruction theorem、
 semantic residual transition cut theorem、
 semantic residual transition cut scanner exactness theorem、
 semantic residual obstruction one-preclass theorem、
-semantic residual obstruction class modulo cut-noise theorem を含む。
+semantic residual obstruction class modulo cut-noise theorem、
+semantic residual atlas gauge invariance theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -4772,4 +4776,74 @@ canonical representative.
 
 Cycle 92 後の total SCORE は 12646 であり、tracking Issue active threshold 15000 までは残り 2354 SCORE である。
 次 cycle では、residual-present/residual-free mismatch minimality、local-pass/global-fail taxonomy、support-preserving atlas morphism / gauge equivalence、または finite H1-style adapter を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 93: Semantic residual atlas gauge invariance
+
+```text
+candidate: Semantic residual atlas gauge invariance
+candidate_type: invariant-hardening / same-carrier atlas gauge / obstruction-class-support
+evidence_stage: proved-in-research
+base_score: 86
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 172
+category: semantic-obstruction / finite-atlas-transition / obstruction-class-support / invariance / genius-support
+goal_delta: Cycle 92 の cut-noise obstruction class を、raw cochain representative の不変性から same-carrier atlas edge presentation の不変性へ上げた。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、`SameResidualCutLocus`、gauge-related class preservation、canonical class transfer、selected raw-edge noisy atlas witness、noisy target obstruction package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は noisy edge rows や raw presentation differences を扱えるが、same residual cut locus による semantic residual obstruction class invariance と nonzero no-go theorem を Lean artifact として保持しない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualAtlasGauge.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualAtlasGauge`, and `lake build FormalAGResearch` passed. Axiom probe reported generic preservation, canonical transfer, and target obstruction theorems axiom-free; selected witness and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: support-preserving atlas morphisms beyond same carrier; residual-present/residual-free mismatch minimality; local-pass/global-fail taxonomy; finite H1-style adapter toward the open genius target.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualAtlasGauge.lean`
+turns the Cycle 92 cut-noise class reading into a same-carrier atlas gauge
+invariance theorem.  `SameResidualCutLocus` says that two finite semantic
+repair atlas skeletons over the same `Index` / `Atom` carrier expose exactly
+the same residual transition cut pairs.  `SameResidualCutClassGaugeRelated`
+then compares raw cochain supports on the left residual cut locus.  With both
+pieces, cut-locus `CutVanishes` and `CutNonzero` transfer across atlas
+presentations, and a nonzero source class obstructs target transition closure
+and transition-coherent atlas data.
+
+Lean proves:
+
+- `SameResidualCutLocus`: same-carrier atlases expose the same residual transition cut locus.
+- `SameResidualCutClassGaugeRelated`: cochain supports agree on the left cut locus.
+- `sameResidualCutLocus_refl`, `sameResidualCutLocus_symm`, `sameResidualCutLocus_trans`: same-cut-locus laws.
+- `sameResidualCutClassGaugeRelated_preserves_cutVanishes`: gauge-related classes preserve cut-locus vanishing.
+- `sameResidualCutClassGaugeRelated_preserves_cutNonzero`: gauge-related classes preserve cut-locus nonzero support.
+- `sameResidualCutLocus_gaugeRelated_canonical`: canonical cochains are gauge-related under same cut locus.
+- `sameResidualCutLocus_preserves_canonicalCutVanishes`: same cut locus preserves canonical vanishing.
+- `sameResidualCutLocus_preserves_canonicalCutNonzero`: same cut locus preserves canonical nonzero.
+- `gaugeRelated_nonzero_obstructs_targetTransitionClosure`: a gauge-related nonzero source class obstructs target transition closure.
+- `gaugeRelated_nonzero_obstructs_targetTransitionCoherentData`: a gauge-related nonzero source class rules out target transition-coherent data.
+- `selectedEdgeNoisyFrontierFlatEdge`: selected edge family with reverse raw edge noise.
+- `selectedEdgeNoisyFrontierFlatAtlasSkeleton`: selected raw-edge noisy atlas over the same carrier.
+- `selectedEdgeNoisy_rawEdge_differs_from_selected`: noisy atlas has a reverse raw edge absent from the original.
+- `selected_flatIndexedResidualNotPresent`: `flat` is not residual-present.
+- `selectedEdgeNoisy_reverse_not_residualCutPair`: reverse raw edge is active but not a residual cut pair because `flat` is residual-free.
+- `selectedEdgeNoisy_sameResidualCutLocus_selected`: original and noisy selected atlases expose the same residual cut locus.
+- `selectedEdgeNoisy_canonicalGaugeRelated_selected`: canonical classes are gauge-related for the selected original/noisy pair.
+- `selectedEdgeNoisy_canonicalCutClass_nonzero`: noisy selected atlas has nonzero canonical residual cut class.
+- `selectedEdgeNoisy_canonicalCutClass_obstructs_transitionClosure`: noisy selected canonical class obstructs transition closure.
+- `selectedEdgeNoisy_canonicalCutClass_obstructs_transitionCoherentData`: noisy selected canonical class rules out transition-coherent data.
+- `semanticResidualAtlasGauge_package`: theorem package.
+
+This cycle is a support node, not a `genius unlock`.  It is a same-carrier
+cut-locus gauge invariance theorem, not arbitrary atlas morphism
+functoriality, true `H^1`, Cech quotient, coboundary quotient, or
+vanishing-to-closure theorem.  It does not claim global minimality, source
+extraction completeness, ArchMap correctness, runtime repair synthesis,
+tooling runtime extraction, UI correctness, or whole-codebase quality.  The
+selected witness changes the raw edge family itself, not merely a cochain
+representative: `(flat, repairFrontier)` is active in the noisy atlas, but it
+is not a residual cut pair because `flat` is residual-free.
+
+### Next Frontier
+
+Cycle 93 後の total SCORE は 12818 であり、tracking Issue active threshold 15000 までは残り 2182 SCORE である。
+次 cycle では、support-preserving atlas morphisms beyond same carrier、residual-present/residual-free mismatch minimality、local-pass/global-fail taxonomy、または finite H1-style adapter を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の research-loop Cycle 93 として、semantic residual obstruction class の same-carrier atlas gauge invariance を追加しました。
Cycle 92 の cochain representative-level cut-noise invariance を、atlas presentation-level raw edge noise へ上げています。

tracking Issue #2348 は active threshold 15000 まで継続するため、意図的に `Closes #2348` は書いていません。

## 証明した定理

- `SameResidualCutLocus`
- `SameResidualCutClassGaugeRelated`
- `sameResidualCutLocus_refl`
- `sameResidualCutLocus_symm`
- `sameResidualCutLocus_trans`
- `sameResidualCutClassGaugeRelated_preserves_cutVanishes`
- `sameResidualCutClassGaugeRelated_preserves_cutNonzero`
- `sameResidualCutLocus_gaugeRelated_canonical`
- `sameResidualCutLocus_preserves_canonicalCutVanishes`
- `sameResidualCutLocus_preserves_canonicalCutNonzero`
- `gaugeRelated_nonzero_obstructs_targetTransitionClosure`
- `gaugeRelated_nonzero_obstructs_targetTransitionCoherentData`
- `selectedEdgeNoisyFrontierFlatEdge`
- `selectedEdgeNoisyFrontierFlatAtlasSkeleton`
- `selectedEdgeNoisy_rawEdge_differs_from_selected`
- `selected_flatIndexedResidualNotPresent`
- `selectedEdgeNoisy_reverse_not_residualCutPair`
- `selectedEdgeNoisy_sameResidualCutLocus_selected`
- `selectedEdgeNoisy_canonicalGaugeRelated_selected`
- `selectedEdgeNoisy_canonicalCutClass_nonzero`
- `selectedEdgeNoisy_canonicalCutClass_obstructs_transitionClosure`
- `selectedEdgeNoisy_canonicalCutClass_obstructs_transitionCoherentData`
- `semanticResidualAtlasGauge_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-gauge.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualAtlasGauge.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualAtlasGauge`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms`（generic preservation/canonical transfer/target obstruction は axiom-free、selected/package は標準 `propext` / `Quot.sound` のみ）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: proved-in-research。

Claim boundary: これは same-carrier cut-locus gauge invariance であり、arbitrary atlas morphism functoriality、true H1、Cech quotient、coboundary quotient、global minimality、`vanishing -> closure`、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、UI correctness、whole-codebase quality は主張しません。
