### PR TITLE
研究ループ Cycle 94 の cut-locus transport を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -90,3 +90,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualTransitionCutScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualObstructionPreclass
 import Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass
 import Formal.AG.Research.QualitySurface.SemanticResidualAtlasGauge
+import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMorphism

--- a/Formal/AG/Research/QualitySurface/SemanticResidualAtlasMorphism.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualAtlasMorphism.lean
@@ -1,0 +1,716 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualAtlasGauge
+
+/-!
+Cycle 94 evidence for `G-aat-quality-surface-01`.
+
+This file transports finite residual obstruction classes across explicitly
+supplied residual cut-locus maps between finite semantic repair atlas
+skeletons with possibly different index carriers.  A cut-locus embedding maps
+source residual cut pairs to target residual cut pairs; a cut-locus
+equivalence additionally covers every target residual cut.  Under these
+finite hypotheses, cut-supported cochains push forward, nonzero obstruction
+readings transport, and canonical vanishing/nonzero is invariant for
+cut-surjective equivalences.
+
+The result is cut-locus transport for supplied finite maps.  It does not
+construct a category of atlases, arbitrary atlas morphisms, functorial sheaf
+transport, a Cech `H^1` class, a coboundary quotient, a vanishing-to-closure
+theorem, source extraction completeness, ArchMap correctness, runtime repair
+synthesis, tooling runtime extraction, UI correctness, or whole-codebase
+quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualAtlasMorphism
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasGauge
+
+/-! ## Residual cut-locus maps -/
+
+/-- Map an index pair along an index map. -/
+def mapResidualPair
+    {LeftIndex : Type w}
+    {RightIndex : Type x}
+    (mapIndex : LeftIndex -> RightIndex)
+    (pair : LeftIndex × LeftIndex) :
+    RightIndex × RightIndex :=
+  (mapIndex pair.1, mapIndex pair.2)
+
+/--
+A finite residual cut-locus embedding transports every source residual cut pair
+to a target residual cut pair.
+-/
+structure ResidualCutLocusEmbedding
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    (left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom)
+    (right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom) where
+  mapIndex : LeftIndex -> RightIndex
+  cut_preserving :
+    forall pair,
+      IsResidualTransitionCutPair left pair ->
+        IsResidualTransitionCutPair right
+          (mapResidualPair mapIndex pair)
+
+/--
+A finite residual cut-locus equivalence is a cut-locus embedding whose image
+covers every target residual cut pair.
+-/
+structure ResidualCutLocusEquivalence
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    (left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom)
+    (right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom)
+    extends ResidualCutLocusEmbedding left right where
+  cut_surjective :
+    forall targetPair,
+      IsResidualTransitionCutPair right targetPair ->
+        exists sourcePair,
+          IsResidualTransitionCutPair left sourcePair /\
+            mapResidualPair mapIndex sourcePair = targetPair
+
+/-! ## Pushforward of cut-supported cochains -/
+
+/-- Push a raw residual cut cochain along a residual cut-locus embedding. -/
+def pushResidualCutCochain
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (embedding : ResidualCutLocusEmbedding left right)
+    (sourceC : ResidualCutCochain left) :
+    ResidualCutCochain right where
+  support targetPair :=
+    exists sourcePair,
+      IsResidualTransitionCutPair left sourcePair /\
+        sourceC.support sourcePair /\
+          mapResidualPair embedding.mapIndex sourcePair = targetPair
+
+/-- Source nonzero support pushes forward to target nonzero support. -/
+theorem pushResidualCutCochain_nonzero_of_sourceNonzero
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (embedding : ResidualCutLocusEmbedding left right)
+    {sourceC : ResidualCutCochain left}
+    (hnonzero : sourceC.CutNonzero) :
+    (pushResidualCutCochain embedding sourceC).CutNonzero := by
+  rcases hnonzero with ⟨sourcePair, hsourceCut, hsourceSupport⟩
+  exact
+    ⟨mapResidualPair embedding.mapIndex sourcePair,
+      embedding.cut_preserving sourcePair hsourceCut,
+      ⟨sourcePair, hsourceCut, hsourceSupport, rfl⟩⟩
+
+/-- If the pushed target class vanishes, then the source class vanishes. -/
+theorem pushResidualCutCochain_targetVanishes_to_sourceVanishes
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (embedding : ResidualCutLocusEmbedding left right)
+    {sourceC : ResidualCutCochain left}
+    (htarget :
+      (pushResidualCutCochain embedding sourceC).CutVanishes) :
+    sourceC.CutVanishes := by
+  intro sourcePair hsourceCut hsourceSupport
+  exact
+    htarget
+      (mapResidualPair embedding.mapIndex sourcePair)
+      (embedding.cut_preserving sourcePair hsourceCut)
+      ⟨sourcePair, hsourceCut, hsourceSupport, rfl⟩
+
+/-- If the source class vanishes, then its pushed target class vanishes. -/
+theorem pushResidualCutCochain_sourceVanishes_to_targetVanishes
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (embedding : ResidualCutLocusEmbedding left right)
+    {sourceC : ResidualCutCochain left}
+    (hsource : sourceC.CutVanishes) :
+    (pushResidualCutCochain embedding sourceC).CutVanishes := by
+  intro _targetPair _htargetCut hpush
+  rcases hpush with ⟨sourcePair, hsourceCut, hsourceSupport, _hmap⟩
+  exact hsource sourcePair hsourceCut hsourceSupport
+
+/-- Pushforward preserves cut-locus vanishing exactly. -/
+theorem pushResidualCutCochain_cutVanishes_iff
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (embedding : ResidualCutLocusEmbedding left right)
+    {sourceC : ResidualCutCochain left} :
+    (pushResidualCutCochain embedding sourceC).CutVanishes <->
+      sourceC.CutVanishes := by
+  constructor
+  · exact pushResidualCutCochain_targetVanishes_to_sourceVanishes
+      embedding
+  · exact pushResidualCutCochain_sourceVanishes_to_targetVanishes
+      embedding
+
+/-- Pushforward preserves cut-locus nonzero support exactly. -/
+theorem pushResidualCutCochain_cutNonzero_iff
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (embedding : ResidualCutLocusEmbedding left right)
+    {sourceC : ResidualCutCochain left} :
+    (pushResidualCutCochain embedding sourceC).CutNonzero <->
+      sourceC.CutNonzero := by
+  constructor
+  · intro htarget
+    rcases htarget with ⟨_targetPair, _htargetCut, hpush⟩
+    rcases hpush with ⟨sourcePair, hsourceCut, hsourceSupport, _hmap⟩
+    exact ⟨sourcePair, hsourceCut, hsourceSupport⟩
+  · exact pushResidualCutCochain_nonzero_of_sourceNonzero
+      embedding
+
+/-- Source nonzero support obstructs target transition closure after pushforward. -/
+theorem pushResidualCutCochain_nonzero_obstructs_targetTransitionClosure
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (embedding : ResidualCutLocusEmbedding left right)
+    {sourceC : ResidualCutCochain left}
+    (hnonzero : sourceC.CutNonzero)
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (AtlasResidualTransitionClosed right transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (pushResidualCutCochain embedding sourceC)
+      (pushResidualCutCochain_nonzero_of_sourceNonzero
+        embedding hnonzero)
+      transition
+
+/-- Source nonzero support rules out target transition-coherent data after pushforward. -/
+theorem pushResidualCutCochain_nonzero_obstructs_targetTransitionCoherentData
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (embedding : ResidualCutLocusEmbedding left right)
+    {sourceC : ResidualCutCochain left}
+    (hnonzero : sourceC.CutNonzero)
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (Nonempty (TransitionCoherentAtlasData right transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (pushResidualCutCochain embedding sourceC)
+      (pushResidualCutCochain_nonzero_of_sourceNonzero
+        embedding hnonzero)
+      transition
+
+/-! ## Canonical class transport under cut-surjective equivalences -/
+
+/--
+Under a cut-surjective equivalence, the pushforward of the canonical source
+cochain agrees with the canonical target cochain on target cut pairs.
+-/
+theorem residualCutLocusEquivalence_pushCanonical_agrees_targetCanonical_onCut
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (equiv : ResidualCutLocusEquivalence left right)
+    {targetPair : RightIndex × RightIndex}
+    (htargetCut : IsResidualTransitionCutPair right targetPair) :
+    (pushResidualCutCochain
+        equiv.toResidualCutLocusEmbedding
+        (canonicalResidualCutCochain left)).support targetPair <->
+      (canonicalResidualCutCochain right).support targetPair := by
+  constructor
+  · intro hpush
+    rcases hpush with ⟨sourcePair, hsourceCut, _hsourceSupport, hmap⟩
+    exact
+      by
+        simpa [hmap] using
+          equiv.cut_preserving sourcePair hsourceCut
+  · intro _htargetSupport
+    rcases equiv.cut_surjective targetPair htargetCut with
+      ⟨sourcePair, hsourceCut, hmap⟩
+    exact ⟨sourcePair, hsourceCut, hsourceCut, hmap⟩
+
+/-- A cut-surjective equivalence preserves canonical cut-class vanishing. -/
+theorem residualCutLocusEquivalence_preserves_canonicalCutVanishes
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (equiv : ResidualCutLocusEquivalence left right) :
+    (canonicalResidualCutCochain left).CutVanishes <->
+      (canonicalResidualCutCochain right).CutVanishes := by
+  constructor
+  · intro hleft targetPair htargetCut _htargetSupport
+    rcases equiv.cut_surjective targetPair htargetCut with
+      ⟨sourcePair, hsourceCut, _hmap⟩
+    exact hleft sourcePair hsourceCut hsourceCut
+  · intro hright sourcePair hsourceCut _hsourceSupport
+    exact
+      hright
+        (mapResidualPair equiv.mapIndex sourcePair)
+        (equiv.cut_preserving sourcePair hsourceCut)
+        (equiv.cut_preserving sourcePair hsourceCut)
+
+/-- A cut-surjective equivalence preserves canonical cut-class nonzero support. -/
+theorem residualCutLocusEquivalence_preserves_canonicalCutNonzero
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (equiv : ResidualCutLocusEquivalence left right) :
+    (canonicalResidualCutCochain left).CutNonzero <->
+      (canonicalResidualCutCochain right).CutNonzero := by
+  constructor
+  · intro hleft
+    rcases hleft with ⟨sourcePair, hsourceCut, _hsourceSupport⟩
+    exact
+      ⟨mapResidualPair equiv.mapIndex sourcePair,
+        equiv.cut_preserving sourcePair hsourceCut,
+        equiv.cut_preserving sourcePair hsourceCut⟩
+  · intro hright
+    rcases hright with ⟨targetPair, htargetCut, _htargetSupport⟩
+    rcases equiv.cut_surjective targetPair htargetCut with
+      ⟨sourcePair, hsourceCut, _hmap⟩
+    exact ⟨sourcePair, hsourceCut, hsourceCut⟩
+
+/-! ## Selected extended-carrier witness -/
+
+/-- A selected atlas carrier with one isolated extra presentation index. -/
+abbrev SelectedExtendedOverlapIndex :=
+  Option SelectedSemanticOverlapIndex
+
+/-- Embed the selected two-index carrier into the extended carrier. -/
+def selectedToExtendedIndex
+    (index : SelectedSemanticOverlapIndex) :
+    SelectedExtendedOverlapIndex :=
+  some index
+
+/-- Read an extended index back through the selected presentation. -/
+def selectedExtendedToSelectedIndex :
+    SelectedExtendedOverlapIndex -> SelectedSemanticOverlapIndex
+  | none => SelectedSemanticOverlapIndex.flat
+  | some index => index
+
+/-- The extended selected edge family has no active edges involving `none`. -/
+def selectedExtendedFrontierFlatEdge
+    (source target : SelectedExtendedOverlapIndex) : Prop :=
+  match source, target with
+  | some sourceIndex, some targetIndex =>
+      selectedFrontierToFlatEdge sourceIndex targetIndex
+  | _, _ => False
+
+/--
+The selected extended-carrier atlas adds an isolated presentation index while
+reusing the selected projection and cover through `selectedExtendedToSelectedIndex`.
+-/
+def selectedExtendedFrontierFlatAtlasSkeleton :
+    FiniteSemanticRepairAtlasSkeleton
+      SelectedExtendedOverlapIndex
+      RefinedSemanticRepairAtom where
+  indexOrder :=
+    [none,
+      some SelectedSemanticOverlapIndex.flat,
+      some SelectedSemanticOverlapIndex.repairFrontier]
+  index_complete := by
+    intro index
+    cases index with
+    | none => simp
+    | some selected =>
+        cases selected <;> simp
+  atomOrder := selectedFrontierFlatAtlasSkeleton.atomOrder
+  atom_complete := selectedFrontierFlatAtlasSkeleton.atom_complete
+  edge := selectedExtendedFrontierFlatEdge
+  projection index :=
+    selectedIndexedProjection (selectedExtendedToSelectedIndex index)
+  cover index :=
+    selectedIndexedCover (selectedExtendedToSelectedIndex index)
+
+/-- The isolated `none` index has no outgoing active edge. -/
+theorem selectedExtended_none_no_outgoing_edge
+    (target : SelectedExtendedOverlapIndex) :
+    Not (selectedExtendedFrontierFlatAtlasSkeleton.edge none target) := by
+  cases target <;> simp [selectedExtendedFrontierFlatAtlasSkeleton,
+    selectedExtendedFrontierFlatEdge]
+
+/-- The isolated `none` index has no incoming active edge. -/
+theorem selectedExtended_none_no_incoming_edge
+    (source : SelectedExtendedOverlapIndex) :
+    Not (selectedExtendedFrontierFlatAtlasSkeleton.edge source none) := by
+  cases source <;> simp [selectedExtendedFrontierFlatAtlasSkeleton,
+    selectedExtendedFrontierFlatEdge]
+
+/-- The isolated `none` index is never the source of a residual cut pair. -/
+theorem selectedExtended_none_not_cut_source
+    (target : SelectedExtendedOverlapIndex) :
+    Not
+      (IsResidualTransitionCutPair
+        selectedExtendedFrontierFlatAtlasSkeleton
+        (none, target)) := by
+  intro hcut
+  exact selectedExtended_none_no_outgoing_edge target hcut.1
+
+/-- The isolated `none` index is never the target of a residual cut pair. -/
+theorem selectedExtended_none_not_cut_target
+    (source : SelectedExtendedOverlapIndex) :
+    Not
+      (IsResidualTransitionCutPair
+        selectedExtendedFrontierFlatAtlasSkeleton
+        (source, none)) := by
+  intro hcut
+  exact selectedExtended_none_no_incoming_edge source hcut.1
+
+/-- The selected source cut locus embeds into the extended-carrier target. -/
+def selectedToExtendedResidualCutEmbedding :
+    ResidualCutLocusEmbedding
+      selectedFrontierFlatAtlasSkeleton
+      selectedExtendedFrontierFlatAtlasSkeleton where
+  mapIndex := selectedToExtendedIndex
+  cut_preserving := by
+    intro pair hcut
+    cases pair with
+    | mk source target =>
+        exact
+          ⟨by
+              simpa [mapResidualPair, selectedToExtendedIndex,
+                selectedFrontierFlatAtlasSkeleton,
+                selectedExtendedFrontierFlatAtlasSkeleton,
+                selectedExtendedFrontierFlatEdge]
+                using hcut.1,
+            by
+              simpa [mapResidualPair, selectedToExtendedIndex,
+                selectedFrontierFlatAtlasSkeleton,
+                selectedExtendedFrontierFlatAtlasSkeleton,
+                selectedExtendedToSelectedIndex]
+                using hcut.2.1,
+            by
+              simpa [mapResidualPair, selectedToExtendedIndex,
+                selectedFrontierFlatAtlasSkeleton,
+                selectedExtendedFrontierFlatAtlasSkeleton,
+                selectedExtendedToSelectedIndex]
+                using hcut.2.2⟩
+
+/-- Every extended target residual cut comes from a selected source cut. -/
+theorem selectedToExtended_cut_surjective :
+    forall targetPair,
+      IsResidualTransitionCutPair
+        selectedExtendedFrontierFlatAtlasSkeleton targetPair ->
+        exists sourcePair,
+          IsResidualTransitionCutPair
+            selectedFrontierFlatAtlasSkeleton sourcePair /\
+            mapResidualPair selectedToExtendedIndex sourcePair =
+              targetPair := by
+  intro targetPair htargetCut
+  cases targetPair with
+  | mk source target =>
+      cases source with
+      | none =>
+          exact False.elim
+            ((selectedExtended_none_no_outgoing_edge target)
+              htargetCut.1)
+      | some sourceIndex =>
+          cases target with
+          | none =>
+              exact False.elim
+                ((selectedExtended_none_no_incoming_edge
+                  (some sourceIndex)) htargetCut.1)
+          | some targetIndex =>
+              refine ⟨(sourceIndex, targetIndex), ?_, ?_⟩
+              · exact
+                  ⟨by
+                      simpa [selectedFrontierFlatAtlasSkeleton,
+                        selectedExtendedFrontierFlatAtlasSkeleton,
+                        selectedExtendedFrontierFlatEdge]
+                        using htargetCut.1,
+                    by
+                      simpa [selectedFrontierFlatAtlasSkeleton,
+                        selectedExtendedFrontierFlatAtlasSkeleton,
+                        selectedExtendedToSelectedIndex]
+                        using htargetCut.2.1,
+                    by
+                      simpa [selectedFrontierFlatAtlasSkeleton,
+                        selectedExtendedFrontierFlatAtlasSkeleton,
+                        selectedExtendedToSelectedIndex]
+                        using htargetCut.2.2⟩
+              · rfl
+
+/-- The selected source and extended target have equivalent residual cut loci. -/
+def selectedToExtendedResidualCutEquivalence :
+    ResidualCutLocusEquivalence
+      selectedFrontierFlatAtlasSkeleton
+      selectedExtendedFrontierFlatAtlasSkeleton where
+  mapIndex := selectedToExtendedIndex
+  cut_preserving :=
+    selectedToExtendedResidualCutEmbedding.cut_preserving
+  cut_surjective :=
+    selectedToExtended_cut_surjective
+
+/-- The selected nonzero canonical class pushes to the extended target. -/
+theorem selectedExtended_pushCanonicalCutClass_nonzero :
+    (pushResidualCutCochain
+      selectedToExtendedResidualCutEmbedding
+      (canonicalResidualCutCochain
+        selectedFrontierFlatAtlasSkeleton)).CutNonzero := by
+  exact
+    pushResidualCutCochain_nonzero_of_sourceNonzero
+      selectedToExtendedResidualCutEmbedding
+      selected_canonicalResidualCutClass_nonzero
+
+/-- The selected extended canonical cut class is nonzero. -/
+theorem selectedExtended_canonicalCutClass_nonzero :
+    (canonicalResidualCutCochain
+      selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    (residualCutLocusEquivalence_preserves_canonicalCutNonzero
+      selectedToExtendedResidualCutEquivalence).mp
+      selected_canonicalResidualCutClass_nonzero
+
+/-- The selected extended canonical class obstructs target transition closure. -/
+theorem selectedExtended_canonicalCutClass_obstructs_transitionClosure
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedExtendedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton)
+      selectedExtended_canonicalCutClass_nonzero
+      transition
+
+/-- The selected extended canonical class rules out transition-coherent data. -/
+theorem selectedExtended_canonicalCutClass_obstructs_transitionCoherentData
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedExtendedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton)
+      selectedExtended_canonicalCutClass_nonzero
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-94 theorem package: finite residual cut-locus embeddings push nonzero
+cut-supported obstruction classes to target obstructions, and cut-surjective
+equivalences preserve canonical vanishing/nonzero.  The selected extended
+carrier witness adds an isolated index and transports the selected
+frontier-to-flat obstruction across the carrier change.
+-/
+theorem semanticResidualAtlasMorphism_package :
+    (forall {LeftIndex : Type w}
+      {LeftAtom : Type u}
+      {RightIndex : Type x}
+      {RightAtom : Type v}
+      {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+      {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+      forall embedding : ResidualCutLocusEmbedding left right,
+      forall sourceC : ResidualCutCochain left,
+        sourceC.CutNonzero ->
+          (pushResidualCutCochain embedding sourceC).CutNonzero) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall embedding : ResidualCutLocusEmbedding left right,
+        forall sourceC : ResidualCutCochain left,
+          (pushResidualCutCochain embedding sourceC).CutVanishes ->
+            sourceC.CutVanishes) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall embedding : ResidualCutLocusEmbedding left right,
+        forall sourceC : ResidualCutCochain left,
+          sourceC.CutVanishes ->
+            (pushResidualCutCochain embedding sourceC).CutVanishes) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall embedding : ResidualCutLocusEmbedding left right,
+        forall sourceC : ResidualCutCochain left,
+          ((pushResidualCutCochain embedding sourceC).CutNonzero <->
+            sourceC.CutNonzero)) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall _embedding : ResidualCutLocusEmbedding left right,
+        forall sourceC : ResidualCutCochain left,
+          sourceC.CutNonzero ->
+            forall transition : RightIndex -> RightIndex -> RightAtom -> RightAtom,
+              Not (AtlasResidualTransitionClosed right transition)) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall _embedding : ResidualCutLocusEmbedding left right,
+        forall sourceC : ResidualCutCochain left,
+          sourceC.CutNonzero ->
+            forall transition : RightIndex -> RightIndex -> RightAtom -> RightAtom,
+              Not (Nonempty (TransitionCoherentAtlasData right transition))) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall _equiv : ResidualCutLocusEquivalence left right,
+        (canonicalResidualCutCochain left).CutVanishes <->
+          (canonicalResidualCutCochain right).CutVanishes) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall _equiv : ResidualCutLocusEquivalence left right,
+        (canonicalResidualCutCochain left).CutNonzero <->
+          (canonicalResidualCutCochain right).CutNonzero) /\
+      (forall target : SelectedExtendedOverlapIndex,
+        Not (selectedExtendedFrontierFlatAtlasSkeleton.edge none target)) /\
+      (forall source : SelectedExtendedOverlapIndex,
+        Not (selectedExtendedFrontierFlatAtlasSkeleton.edge source none)) /\
+      (forall target : SelectedExtendedOverlapIndex,
+        Not
+          (IsResidualTransitionCutPair
+            selectedExtendedFrontierFlatAtlasSkeleton
+            (none, target))) /\
+      (forall source : SelectedExtendedOverlapIndex,
+        Not
+          (IsResidualTransitionCutPair
+            selectedExtendedFrontierFlatAtlasSkeleton
+            (source, none))) /\
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (pushResidualCutCochain
+        selectedToExtendedResidualCutEmbedding
+        (canonicalResidualCutCochain
+          selectedFrontierFlatAtlasSkeleton)).CutNonzero /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedExtendedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedExtendedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} embedding sourceC hnonzero =>
+        pushResidualCutCochain_nonzero_of_sourceNonzero
+          embedding hnonzero,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} embedding sourceC htarget =>
+        pushResidualCutCochain_targetVanishes_to_sourceVanishes
+          embedding htarget,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} embedding sourceC hsource =>
+        pushResidualCutCochain_sourceVanishes_to_targetVanishes
+          embedding hsource,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} embedding sourceC =>
+        pushResidualCutCochain_cutNonzero_iff
+          (sourceC := sourceC) embedding,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} embedding sourceC hnonzero transition =>
+        pushResidualCutCochain_nonzero_obstructs_targetTransitionClosure
+          embedding hnonzero transition,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} embedding sourceC hnonzero transition =>
+        pushResidualCutCochain_nonzero_obstructs_targetTransitionCoherentData
+          embedding hnonzero transition,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} equiv =>
+        residualCutLocusEquivalence_preserves_canonicalCutVanishes
+          equiv,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} equiv =>
+      residualCutLocusEquivalence_preserves_canonicalCutNonzero
+          equiv,
+      selectedExtended_none_no_outgoing_edge,
+      selectedExtended_none_no_incoming_edge,
+      selectedExtended_none_not_cut_source,
+      selectedExtended_none_not_cut_target,
+      selectedExtended_canonicalCutClass_nonzero,
+      selectedExtended_pushCanonicalCutClass_nonzero,
+      selectedExtended_canonicalCutClass_obstructs_transitionClosure,
+      selectedExtended_canonicalCutClass_obstructs_transitionCoherentData⟩
+
+end SemanticResidualAtlasMorphism
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-morphism.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-morphism.md
@@ -1,0 +1,158 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: cut-locus transport / carrier-change invariance / genius-support convergence
+candidate_type: finite cut-locus transport / obstruction-class-support / carrier-change
+capability_category: semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-invariance / genius-support
+expected_base_score: 88
+expected_evidence_multiplier: 2.0
+expected_final_score: 176
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can move diagnostics between presentations, but they do not prove cut-locus obstruction-class transport across finite carrier changes.
+origin: cycle-94
+tags: [quality-surface, semantic-repair, residual-cut, atlas-transport, carrier-change, genius-support]
+created: 2026-06-23
+cycle: 94
+lean: proved-in-research
+planned_report_section: "Cycle 94: Semantic residual cut-locus transport beyond same carrier"
+---
+
+# Semantic Residual Cut-Locus Transport Beyond Same Carrier
+
+## 主張
+
+Cycle 93 の same-carrier atlas gauge invariance を、異なる finite index carrier 間の supplied residual cut-locus transport へ上げる。
+`ResidualCutLocusEmbedding` は source residual cut pair を target residual cut pair へ送る有限 map であり、`pushResidualCutCochain` は source cochain の cut-supported support を target cochain へ push する。
+source class が nonzero なら push target class も nonzero であり、target residual transition closure と transition-coherent atlas data を阻む。
+
+さらに `ResidualCutLocusEquivalence` は target cut pair が source cut preimage を持つ cut-surjective map である。
+この仮定の下で、canonical residual cut class の `CutVanishes` / `CutNonzero` は source/target 間で同値になる。
+
+selected witness では、`SelectedExtendedOverlapIndex := Option SelectedSemanticOverlapIndex` を使って extra isolated index `none` を持つ target atlas を作る。
+`none` は active edge に参加せず、target residual cuts はすべて original selected atlas の cut の image である。
+これにより、selected frontier-to-flat obstruction class が carrier change 後の extended atlas へ transport され、target closure/data obstruction として残る。
+
+この主張は finite residual cut-locus transport に限定する。
+arbitrary atlas category、general atlas morphism functoriality、atom-map semantic completeness、true `H^1`、Cech quotient、coboundary quotient、`vanishing -> closure`、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、UI correctness、whole-codebase quality は含まない。
+
+## 候補種別
+
+`finite cut-locus transport` / `obstruction-class-support` / `carrier-change`
+
+## 依拠
+
+- Cycle 92: cut-noise invariant residual obstruction class reading。
+- Cycle 93: same-carrier residual atlas gauge invariance。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+単なる `cut_preserving` field だけなら wrapper になる。
+この候補では、pushforward cochain、vanishing/nonzero iff、target obstruction theorem、cut-surjective canonical equivalence、そして `Option` carrier の concrete selected witness を揃える。
+selected witness は same carrier alias ではなく、extra isolated index を持つ target carrier であり、target cuts が source cuts の image だけであることを Lean で示す。
+
+## 数学的興味
+
+semantic residual obstruction class が chosen finite carrier の artifact ではなく、supplied finite cut-locus transport に沿って移送できることを示す。
+これは H1-style theorem そのものではないが、future repair-gluing obstruction theorem が presentation/refinement/reindexing に耐えるための carrier-change invariance を与える。
+
+## GOAL への前進
+
+open genius target の `finite atom-supported quality atlases` に向け、obstruction class を single carrier / same-carrier gauge から cross-carrier finite transport へ上げた。
+これにより、finite atlas presentation が変わっても、residual cut-locus obstruction reading を transport できる。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は diagnostics を別表示や別 index schema へ移せる。
+しかし、それらは source cut nonzero が target cut nonzero と target closure/data obstruction を theorem-level に transport する条件を持たない。
+AAT 側では、cut-preserving / cut-surjective finite maps の下で obstruction class data を移送できる。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 93 の same-carrier invariance を cross-carrier cut-locus transport へ上げる。open genius target への強い support node だが、arbitrary atlas morphism や H1 本体ではない。
+- `dullness_risk`: `cut_preserving` だけなら仮定を言い換えるだけになる。push cochain、canonical iff、selected extended carrier witness、`none` isolation、target obstruction を揃える。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualAtlasMorphism.lean` で embedding/equivalence、pushforward、canonical transport、selected extended carrier witness、theorem package を証明する。
+
+## CS / SWE への帰結
+
+finite architecture diagnostics を別 schema / presentation / carrier へ移すとき、単なる row copy ではなく residual cut-locus transport condition が必要になる。
+source diagnostic が residual cut nonzero を持ち、その cut locus が target に transport されるなら、target 側でも transition closure/data obstruction として読むことができる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualAtlasMorphism.lean` に固定した。
+
+- `mapResidualPair`
+- `ResidualCutLocusEmbedding`
+- `ResidualCutLocusEquivalence`
+- `pushResidualCutCochain`
+- `pushResidualCutCochain_nonzero_of_sourceNonzero`
+- `pushResidualCutCochain_targetVanishes_to_sourceVanishes`
+- `pushResidualCutCochain_sourceVanishes_to_targetVanishes`
+- `pushResidualCutCochain_cutVanishes_iff`
+- `pushResidualCutCochain_cutNonzero_iff`
+- `pushResidualCutCochain_nonzero_obstructs_targetTransitionClosure`
+- `pushResidualCutCochain_nonzero_obstructs_targetTransitionCoherentData`
+- `residualCutLocusEquivalence_pushCanonical_agrees_targetCanonical_onCut`
+- `residualCutLocusEquivalence_preserves_canonicalCutVanishes`
+- `residualCutLocusEquivalence_preserves_canonicalCutNonzero`
+- `SelectedExtendedOverlapIndex`
+- `selectedToExtendedIndex`
+- `selectedExtendedToSelectedIndex`
+- `selectedExtendedFrontierFlatEdge`
+- `selectedExtendedFrontierFlatAtlasSkeleton`
+- `selectedExtended_none_no_outgoing_edge`
+- `selectedExtended_none_no_incoming_edge`
+- `selectedExtended_none_not_cut_source`
+- `selectedExtended_none_not_cut_target`
+- `selectedToExtendedResidualCutEmbedding`
+- `selectedToExtended_cut_surjective`
+- `selectedToExtendedResidualCutEquivalence`
+- `selectedExtended_pushCanonicalCutClass_nonzero`
+- `selectedExtended_canonicalCutClass_nonzero`
+- `selectedExtended_canonicalCutClass_obstructs_transitionClosure`
+- `selectedExtended_canonicalCutClass_obstructs_transitionCoherentData`
+- `semanticResidualAtlasMorphism_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualAtlasMorphism.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualAtlasMorphism`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic push/transport/canonical theorem は axiom-free。selected cut-surjectivity は標準 `propext`。selected nonzero と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、finite semantic repair atlas skeleton 間の supplied residual cut-locus embedding/equivalence、pushforward cochains、canonical vanishing/nonzero transport、selected extended carrier witness に限定する。
+unchecked: arbitrary atlas morphism category、atom-map semantic completeness、projection/cover naturality、functorial sheaf transport、true H1 cohomology class、Cech quotient、coboundary quotient、vanishing-to-closure theorem、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、whole-codebase quality。
+
+## 審判メモ
+
+- G1 A/B/C/D: いずれも beyond-same-carrier cut-locus transport を推奨。H1-style adapter はまだ早く、carrier-change invariance を先に固定すべきと判定。
+- G2 A: accept / base 88。`ResidualCutLocusEmbedding` は forward transport、canonical iff は cut-surjective equivalence に限定すること。
+- G2 B: accept / base 88-90。`finite cut-locus preserving maps beyond same carrier` と表現し、arbitrary morphism と書かないこと。
+- G2 revise 解決: pushforward の vanishing/nonzero を iff まで補強し、`none` の edge/cut 不参加 theorem と selected extended carrier witness を theorem package に入れた。
+
+## 追加 required fields
+
+- `mathematical_interest`: residual obstruction class を finite carrier change に沿って transport する。
+- `goal_advancement`: same-carrier gauge invariance から cross-carrier finite cut-locus transport へ上げる。
+- `planned_theorem_names`: `pushResidualCutCochain_cutNonzero_iff`, `residualCutLocusEquivalence_preserves_canonicalCutNonzero`, `semanticResidualAtlasMorphism_package`
+- `visible_projection`: finite index carrier / diagnostic schema / atlas presentation。
+- `protected_structure`: residual transition cut locus、cut-supported cochain pushforward、canonical vanishing/nonzero、target transition closure obstruction。
+- `exactness_or_minimality_claim`: cut-surjective equivalence preserves canonical vanishing/nonzero。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: carrier/schema changes do not preserve obstruction unless residual cut-locus transport conditions are supplied。
+- `previous_cycle_delta`: Cycle 93 の same-carrier gauge invariance を beyond-same-carrier transport へ拡張した。
+- `rival_stress_test`: rival は diagnostics を copy/rename できても、cut-locus transport と target obstruction theorem を持たない。
+- `genius_potential`: strong support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem への carrier-change invariance node。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: obstruction class が finite carrier/presentation change に耐えることを supplied cut-locus transport で固定する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-gauge.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-obstruction-class.md`
+- planned report section: `Cycle 94: Semantic residual cut-locus transport beyond same carrier`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 94 G1/G2 で beyond-same-carrier residual cut-locus transport を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualAtlasMorphism.lean` に固定し、単体 `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 12818
+- total SCORE: 12994
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -98,8 +98,9 @@
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / genius-support: 156
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / projection-nonfaithfulness / genius-support: 164
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / invariance / genius-support: 172
+  - semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-invariance / genius-support: 176
 - evidence portfolio:
-  - proved-in-research: 93
+  - proved-in-research: 94
 
 ## Phase synthesis
 
@@ -115,7 +116,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-93 件の Lean-proved research artifacts は、次の paper seed を形成している。
+94 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -137,6 +138,7 @@ certificate の基本単位は
 - visible/local semantic gluing obstruction は、visible/local repair-transport profile と declared component clearance があっても finite semantic repair-gluing exactness を反映できないことを selected finite atlas theorem として示す。
 - semantic residual obstruction class modulo cut-noise は、raw diagnostic support に off-cut noise が混じっても residual cut-locus class reading が不変であることを示し、preclass support から finite obstruction class frontier へ進める。
 - semantic residual atlas gauge invariance は、raw edge family に harmless reverse-edge noise が混じっても same residual cut locus なら canonical obstruction class と nonzero obstruction reading が保存されることを示す。
+- semantic residual cut-locus transport は、finite carrier が変わっても supplied cut-preserving / cut-surjective map の下で canonical obstruction class と target no-go reading が移送されることを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -190,8 +192,9 @@ Cycle 90 後の total SCORE は 12326 であり、tracking Issue active threshol
 Cycle 91 後の total SCORE は 12482 であり、tracking Issue active threshold 15000 までは残り 2518 SCORE である。
 Cycle 92 後の total SCORE は 12646 であり、tracking Issue active threshold 15000 までは残り 2354 SCORE である。
 Cycle 93 後の total SCORE は 12818 であり、tracking Issue active threshold 15000 までは残り 2182 SCORE である。
+Cycle 94 後の total SCORE は 12994 であり、tracking Issue active threshold 15000 までは残り 2006 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 93 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 94 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -217,7 +220,8 @@ semantic residual transition cut theorem、
 semantic residual transition cut scanner exactness theorem、
 semantic residual obstruction one-preclass theorem、
 semantic residual obstruction class modulo cut-noise theorem、
-semantic residual atlas gauge invariance theorem を含む。
+semantic residual atlas gauge invariance theorem、
+semantic residual cut-locus transport theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -4846,4 +4850,87 @@ is not a residual cut pair because `flat` is residual-free.
 
 Cycle 93 後の total SCORE は 12818 であり、tracking Issue active threshold 15000 までは残り 2182 SCORE である。
 次 cycle では、support-preserving atlas morphisms beyond same carrier、residual-present/residual-free mismatch minimality、local-pass/global-fail taxonomy、または finite H1-style adapter を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 94: Semantic residual cut-locus transport beyond same carrier
+
+```text
+candidate: Semantic residual cut-locus transport beyond same carrier
+candidate_type: finite cut-locus transport / obstruction-class-support / carrier-change
+evidence_stage: proved-in-research
+base_score: 88
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 176
+category: semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-invariance / genius-support
+goal_delta: Cycle 93 の same-carrier atlas gauge invariance を、異なる finite index carrier 間の supplied residual cut-locus transport へ上げた。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、cut-locus embedding/equivalence、cut-supported cochain pushforward、canonical vanishing/nonzero transport、selected extended carrier witness、target obstruction package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は diagnostics を別 schema へ移せるが、cut-preserving / cut-surjective finite map の下で obstruction class と target no-go theorem を transport する Lean artifact は持たない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualAtlasMorphism.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualAtlasMorphism`, and `lake build FormalAGResearch` passed. Axiom probe reported generic push/transport/canonical theorem axiom-free; selected cut-surjectivity uses standard `propext`; selected nonzero and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: finite cut-locus transport induced from explicit edge/present/free maps; local-pass/global-fail taxonomy; residual-present/residual-free mismatch minimality; finite H1-style adapter toward the open genius target.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualAtlasMorphism.lean`
+transports residual cut-locus obstruction classes across finite maps whose
+source and target atlas skeletons may have different index carriers.
+`ResidualCutLocusEmbedding` maps source residual cut pairs to target residual
+cut pairs.  `pushResidualCutCochain` pushes source cut-supported support to a
+target cochain and preserves `CutVanishes` / `CutNonzero` exactly.  Nonzero
+source support therefore produces a target nonzero obstruction and rules out
+target residual transition closure / transition-coherent data.
+
+`ResidualCutLocusEquivalence` adds target cut-surjectivity.  Under that
+stronger hypothesis, the pushforward of the canonical source cochain agrees
+with the canonical target cochain on target cut pairs, and canonical
+`CutVanishes` / `CutNonzero` are equivalent.
+
+Lean proves:
+
+- `mapResidualPair`: index-pair map induced by an index map.
+- `ResidualCutLocusEmbedding`: finite map preserving residual cut pairs.
+- `ResidualCutLocusEquivalence`: cut-preserving map covering every target cut.
+- `pushResidualCutCochain`: pushforward of cut-supported source cochains.
+- `pushResidualCutCochain_nonzero_of_sourceNonzero`: source nonzero pushes to target nonzero.
+- `pushResidualCutCochain_targetVanishes_to_sourceVanishes`: target push vanishing implies source vanishing.
+- `pushResidualCutCochain_sourceVanishes_to_targetVanishes`: source vanishing implies target push vanishing.
+- `pushResidualCutCochain_cutVanishes_iff`: pushforward preserves vanishing exactly.
+- `pushResidualCutCochain_cutNonzero_iff`: pushforward preserves nonzero exactly.
+- `pushResidualCutCochain_nonzero_obstructs_targetTransitionClosure`: source nonzero obstructs target transition closure through pushforward.
+- `pushResidualCutCochain_nonzero_obstructs_targetTransitionCoherentData`: source nonzero rules out target transition-coherent data through pushforward.
+- `residualCutLocusEquivalence_pushCanonical_agrees_targetCanonical_onCut`: pushed canonical source cochain agrees with target canonical support on target cuts.
+- `residualCutLocusEquivalence_preserves_canonicalCutVanishes`: cut-surjective equivalence preserves canonical vanishing.
+- `residualCutLocusEquivalence_preserves_canonicalCutNonzero`: cut-surjective equivalence preserves canonical nonzero.
+- `SelectedExtendedOverlapIndex`: `Option SelectedSemanticOverlapIndex` carrier with isolated `none`.
+- `selectedToExtendedIndex`: selected index embedding into the extended carrier.
+- `selectedExtendedToSelectedIndex`: readback for projection/cover reuse.
+- `selectedExtendedFrontierFlatEdge`: target edge family with no active edge involving `none`.
+- `selectedExtendedFrontierFlatAtlasSkeleton`: extended selected atlas.
+- `selectedExtended_none_no_outgoing_edge`: `none` has no outgoing active edge.
+- `selectedExtended_none_no_incoming_edge`: `none` has no incoming active edge.
+- `selectedExtended_none_not_cut_source`: `none` is never the source of a residual cut pair.
+- `selectedExtended_none_not_cut_target`: `none` is never the target of a residual cut pair.
+- `selectedToExtendedResidualCutEmbedding`: selected source cut locus embeds into the extended target.
+- `selectedToExtended_cut_surjective`: every extended target cut comes from a selected source cut.
+- `selectedToExtendedResidualCutEquivalence`: selected source and extended target are cut-locus equivalent.
+- `selectedExtended_pushCanonicalCutClass_nonzero`: pushed selected canonical class is nonzero in the extended target.
+- `selectedExtended_canonicalCutClass_nonzero`: extended target canonical class is nonzero.
+- `selectedExtended_canonicalCutClass_obstructs_transitionClosure`: extended canonical class obstructs target transition closure.
+- `selectedExtended_canonicalCutClass_obstructs_transitionCoherentData`: extended canonical class rules out target transition-coherent data.
+- `semanticResidualAtlasMorphism_package`: theorem package.
+
+This cycle is a support node, not a `genius unlock`.  It proves finite
+residual cut-locus transport for supplied maps, not an arbitrary atlas
+category, atom-map semantic completeness, projection/cover naturality,
+functorial sheaf transport, true `H^1`, Cech quotient, coboundary quotient,
+or vanishing-to-closure theorem.  The selected witness genuinely changes the
+index carrier by adding isolated `none`; all target cuts are still images of
+selected source cuts, so the selected obstruction class transports to the
+extended atlas.
+
+### Next Frontier
+
+Cycle 94 後の total SCORE は 12994 であり、tracking Issue active threshold 15000 までは残り 2006 SCORE である。
+次 cycle では、cut-locus transport induced from edge/present/free preservation、local-pass/global-fail taxonomy、residual-present/residual-free mismatch minimality、または finite H1-style adapter を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の research-loop Cycle 94 として、finite residual cut-locus transport beyond same carrier を追加しました。
Cycle 93 の same-carrier gauge invariance を、異なる finite index carrier 間の supplied cut-preserving / cut-surjective map による obstruction class transport へ上げています。

tracking Issue #2348 は active threshold 15000 まで継続するため、意図的に `Closes #2348` は書いていません。

## 証明した定理

- `mapResidualPair`
- `ResidualCutLocusEmbedding`
- `ResidualCutLocusEquivalence`
- `pushResidualCutCochain`
- `pushResidualCutCochain_nonzero_of_sourceNonzero`
- `pushResidualCutCochain_targetVanishes_to_sourceVanishes`
- `pushResidualCutCochain_sourceVanishes_to_targetVanishes`
- `pushResidualCutCochain_cutVanishes_iff`
- `pushResidualCutCochain_cutNonzero_iff`
- `pushResidualCutCochain_nonzero_obstructs_targetTransitionClosure`
- `pushResidualCutCochain_nonzero_obstructs_targetTransitionCoherentData`
- `residualCutLocusEquivalence_pushCanonical_agrees_targetCanonical_onCut`
- `residualCutLocusEquivalence_preserves_canonicalCutVanishes`
- `residualCutLocusEquivalence_preserves_canonicalCutNonzero`
- `SelectedExtendedOverlapIndex`
- `selectedToExtendedIndex`
- `selectedExtendedToSelectedIndex`
- `selectedExtendedFrontierFlatEdge`
- `selectedExtendedFrontierFlatAtlasSkeleton`
- `selectedExtended_none_no_outgoing_edge`
- `selectedExtended_none_no_incoming_edge`
- `selectedExtended_none_not_cut_source`
- `selectedExtended_none_not_cut_target`
- `selectedToExtendedResidualCutEmbedding`
- `selectedToExtended_cut_surjective`
- `selectedToExtendedResidualCutEquivalence`
- `selectedExtended_pushCanonicalCutClass_nonzero`
- `selectedExtended_canonicalCutClass_nonzero`
- `selectedExtended_canonicalCutClass_obstructs_transitionClosure`
- `selectedExtended_canonicalCutClass_obstructs_transitionCoherentData`
- `semanticResidualAtlasMorphism_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-morphism.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualAtlasMorphism.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualAtlasMorphism`
- [x] `lake build FormalAGResearch`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] private path scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms`（generic push/transport/canonical theorem は axiom-free、selected/package は標準 `propext` / `Quot.sound` のみ）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: proved-in-research。

Claim boundary: これは supplied finite cut-locus transport であり、arbitrary atlas category、arbitrary morphism functoriality、atom-map semantic completeness、true H1、Cech quotient、coboundary quotient、global minimality、`vanishing -> closure`、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、UI correctness、whole-codebase quality は主張しません。
