### PR TITLE
研究ループCycle95: atlas map law誘導を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -91,3 +91,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualObstructionPreclass
 import Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass
 import Formal.AG.Research.QualitySurface.SemanticResidualAtlasGauge
 import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMorphism
+import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMapLaws

--- a/Formal/AG/Research/QualitySurface/SemanticResidualAtlasMapLaws.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualAtlasMapLaws.lean
@@ -1,0 +1,571 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMorphism
+
+/-!
+Cycle 95 evidence for `G-aat-quality-surface-01`.
+
+This file derives the Cycle 94 residual cut-locus transport from decomposed
+finite atlas laws.  A residual cut-inducing atlas map preserves active edges,
+residual-present indices, and residual-free indices; these three laws imply
+that residual cut pairs transport.  A residual cut-covering atlas map also
+lifts target edge/present/free cut data to source data; this induces the
+cut-surjectivity needed for canonical vanishing/nonzero equivalence.
+
+The result is an induction layer for finite cut-locus transport.  It does not
+construct arbitrary atlas categories, atom maps, projection/cover naturality,
+functorial sheaf transport, a Cech `H^1` class, a coboundary quotient,
+vanishing-to-closure, source extraction completeness, ArchMap correctness,
+runtime repair synthesis, tooling runtime extraction, UI correctness, or
+whole-codebase quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualAtlasMapLaws
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasGauge
+open SemanticResidualAtlasMorphism
+
+/-! ## Atlas laws inducing residual cut transport -/
+
+/--
+A residual cut-inducing atlas map preserves the three pieces of residual cut
+data: active edge, residual-present source, and residual-free target.
+-/
+structure ResidualCutInducingAtlasMap
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    (left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom)
+    (right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom) where
+  mapIndex : LeftIndex -> RightIndex
+  edge_preserving :
+    forall source target,
+      left.edge source target ->
+        right.edge (mapIndex source) (mapIndex target)
+  residual_present_preserving :
+    forall index,
+      IndexedResidualPresentAt left.projection left.cover index ->
+        IndexedResidualPresentAt right.projection right.cover
+          (mapIndex index)
+  residual_free_preserving :
+    forall index,
+      IndexedResidualFreeAt left.projection left.cover index ->
+        IndexedResidualFreeAt right.projection right.cover
+          (mapIndex index)
+
+/-- The three preservation laws induce residual cut-pair preservation. -/
+theorem residualCutInducingAtlasMap_preserves_residualCutPair
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutInducingAtlasMap left right)
+    {pair : LeftIndex × LeftIndex}
+    (hcut : IsResidualTransitionCutPair left pair) :
+    IsResidualTransitionCutPair right
+      (mapResidualPair atlasMap.mapIndex pair) := by
+  exact
+    ⟨atlasMap.edge_preserving pair.1 pair.2 hcut.1,
+      atlasMap.residual_present_preserving pair.1 hcut.2.1,
+      atlasMap.residual_free_preserving pair.2 hcut.2.2⟩
+
+/-- A residual cut-inducing atlas map gives a Cycle-94 cut-locus embedding. -/
+def residualCutInducingAtlasMap_to_cutLocusEmbedding
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutInducingAtlasMap left right) :
+    ResidualCutLocusEmbedding left right where
+  mapIndex := atlasMap.mapIndex
+  cut_preserving := by
+    intro pair hcut
+    exact residualCutInducingAtlasMap_preserves_residualCutPair
+      atlasMap hcut
+
+/-- A cut-inducing map pushes source nonzero support to target nonzero support. -/
+theorem residualCutInducingAtlasMap_push_nonzero
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutInducingAtlasMap left right)
+    {sourceC : ResidualCutCochain left}
+    (hnonzero : sourceC.CutNonzero) :
+    (pushResidualCutCochain
+      (residualCutInducingAtlasMap_to_cutLocusEmbedding atlasMap)
+      sourceC).CutNonzero := by
+  exact
+    pushResidualCutCochain_nonzero_of_sourceNonzero
+      (residualCutInducingAtlasMap_to_cutLocusEmbedding atlasMap)
+      hnonzero
+
+/-- A cut-inducing map transports source nonzero support to target closure obstruction. -/
+theorem residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionClosure
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutInducingAtlasMap left right)
+    {sourceC : ResidualCutCochain left}
+    (hnonzero : sourceC.CutNonzero)
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (AtlasResidualTransitionClosed right transition) := by
+  exact
+    pushResidualCutCochain_nonzero_obstructs_targetTransitionClosure
+      (residualCutInducingAtlasMap_to_cutLocusEmbedding atlasMap)
+      hnonzero
+      transition
+
+/-- A cut-inducing map transports source nonzero support to target data obstruction. -/
+theorem residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionCoherentData
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutInducingAtlasMap left right)
+    {sourceC : ResidualCutCochain left}
+    (hnonzero : sourceC.CutNonzero)
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (Nonempty (TransitionCoherentAtlasData right transition)) := by
+  exact
+    pushResidualCutCochain_nonzero_obstructs_targetTransitionCoherentData
+      (residualCutInducingAtlasMap_to_cutLocusEmbedding atlasMap)
+      hnonzero
+      transition
+
+/-! ## Covering laws inducing cut-surjective equivalences -/
+
+/--
+A residual cut-covering atlas map also lifts each target edge/present/free cut
+datum to source edge/present/free data.
+-/
+structure ResidualCutCoveringAtlasMap
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    (left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom)
+    (right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom)
+    extends ResidualCutInducingAtlasMap left right where
+  target_cut_data_lift :
+    forall targetSource targetTarget,
+      right.edge targetSource targetTarget ->
+        IndexedResidualPresentAt right.projection right.cover targetSource ->
+          IndexedResidualFreeAt right.projection right.cover targetTarget ->
+            exists sourceSource sourceTarget,
+              left.edge sourceSource sourceTarget /\
+                IndexedResidualPresentAt left.projection left.cover sourceSource /\
+                  IndexedResidualFreeAt left.projection left.cover sourceTarget /\
+                    mapIndex sourceSource = targetSource /\
+                      mapIndex sourceTarget = targetTarget
+
+/-- The covering law supplies target cut-surjectivity. -/
+theorem residualCutCoveringAtlasMap_cut_surjective
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutCoveringAtlasMap left right) :
+    forall targetPair,
+      IsResidualTransitionCutPair right targetPair ->
+        exists sourcePair,
+          IsResidualTransitionCutPair left sourcePair /\
+            mapResidualPair atlasMap.mapIndex sourcePair =
+              targetPair := by
+  intro targetPair htargetCut
+  rcases
+      atlasMap.target_cut_data_lift
+        targetPair.1 targetPair.2
+        htargetCut.1 htargetCut.2.1 htargetCut.2.2 with
+    ⟨sourceSource, sourceTarget, hedge, hpresent, hfree, hsource, htarget⟩
+  refine
+    ⟨(sourceSource, sourceTarget),
+      ⟨hedge, hpresent, hfree⟩, ?_⟩
+  simp [mapResidualPair, hsource, htarget]
+
+/-- A cut-covering map gives a Cycle-94 cut-locus equivalence. -/
+def residualCutCoveringAtlasMap_to_cutLocusEquivalence
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutCoveringAtlasMap left right) :
+    ResidualCutLocusEquivalence left right where
+  mapIndex := atlasMap.mapIndex
+  cut_preserving := by
+    intro pair hcut
+    exact residualCutInducingAtlasMap_preserves_residualCutPair
+      atlasMap.toResidualCutInducingAtlasMap hcut
+  cut_surjective :=
+    residualCutCoveringAtlasMap_cut_surjective atlasMap
+
+/-- A cut-covering map preserves canonical cut-class vanishing. -/
+theorem residualCutCoveringAtlasMap_preserves_canonicalCutVanishes
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutCoveringAtlasMap left right) :
+    (canonicalResidualCutCochain left).CutVanishes <->
+      (canonicalResidualCutCochain right).CutVanishes := by
+  exact
+    residualCutLocusEquivalence_preserves_canonicalCutVanishes
+      (residualCutCoveringAtlasMap_to_cutLocusEquivalence atlasMap)
+
+/-- A cut-covering map preserves canonical cut-class nonzero support. -/
+theorem residualCutCoveringAtlasMap_preserves_canonicalCutNonzero
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutCoveringAtlasMap left right) :
+    (canonicalResidualCutCochain left).CutNonzero <->
+      (canonicalResidualCutCochain right).CutNonzero := by
+  exact
+    residualCutLocusEquivalence_preserves_canonicalCutNonzero
+      (residualCutCoveringAtlasMap_to_cutLocusEquivalence atlasMap)
+
+/-! ## Selected extended-carrier structural map -/
+
+/-- The selected-to-extended index map preserves raw edges. -/
+theorem selectedToExtended_edge_preserving :
+    forall source target,
+      selectedFrontierFlatAtlasSkeleton.edge source target ->
+        selectedExtendedFrontierFlatAtlasSkeleton.edge
+          (selectedToExtendedIndex source)
+          (selectedToExtendedIndex target) := by
+  intro source target hedge
+  simpa [selectedFrontierFlatAtlasSkeleton,
+    selectedExtendedFrontierFlatAtlasSkeleton,
+    selectedExtendedFrontierFlatEdge,
+    selectedToExtendedIndex]
+    using hedge
+
+/-- The selected-to-extended map preserves residual-present indices. -/
+theorem selectedToExtended_residual_present_preserving :
+    forall index,
+      IndexedResidualPresentAt
+          selectedFrontierFlatAtlasSkeleton.projection
+          selectedFrontierFlatAtlasSkeleton.cover
+          index ->
+        IndexedResidualPresentAt
+          selectedExtendedFrontierFlatAtlasSkeleton.projection
+          selectedExtendedFrontierFlatAtlasSkeleton.cover
+          (selectedToExtendedIndex index) := by
+  intro index hpresent
+  simpa [selectedFrontierFlatAtlasSkeleton,
+    selectedExtendedFrontierFlatAtlasSkeleton,
+    selectedExtendedToSelectedIndex,
+    selectedToExtendedIndex]
+    using hpresent
+
+/-- The selected-to-extended map preserves residual-free indices. -/
+theorem selectedToExtended_residual_free_preserving :
+    forall index,
+      IndexedResidualFreeAt
+          selectedFrontierFlatAtlasSkeleton.projection
+          selectedFrontierFlatAtlasSkeleton.cover
+          index ->
+        IndexedResidualFreeAt
+          selectedExtendedFrontierFlatAtlasSkeleton.projection
+          selectedExtendedFrontierFlatAtlasSkeleton.cover
+          (selectedToExtendedIndex index) := by
+  intro index hfree
+  simpa [selectedFrontierFlatAtlasSkeleton,
+    selectedExtendedFrontierFlatAtlasSkeleton,
+    selectedExtendedToSelectedIndex,
+    selectedToExtendedIndex]
+    using hfree
+
+/-- The selected-to-extended map is cut-inducing by structural laws. -/
+def selectedToExtendedResidualCutInducingMap :
+    ResidualCutInducingAtlasMap
+      selectedFrontierFlatAtlasSkeleton
+      selectedExtendedFrontierFlatAtlasSkeleton where
+  mapIndex := selectedToExtendedIndex
+  edge_preserving := selectedToExtended_edge_preserving
+  residual_present_preserving :=
+    selectedToExtended_residual_present_preserving
+  residual_free_preserving :=
+    selectedToExtended_residual_free_preserving
+
+/-- The selected-to-extended map lifts every target cut datum to source data. -/
+theorem selectedToExtended_target_cut_data_lift :
+    forall targetSource targetTarget,
+      selectedExtendedFrontierFlatAtlasSkeleton.edge targetSource targetTarget ->
+        IndexedResidualPresentAt
+          selectedExtendedFrontierFlatAtlasSkeleton.projection
+          selectedExtendedFrontierFlatAtlasSkeleton.cover
+          targetSource ->
+          IndexedResidualFreeAt
+            selectedExtendedFrontierFlatAtlasSkeleton.projection
+            selectedExtendedFrontierFlatAtlasSkeleton.cover
+            targetTarget ->
+            exists sourceSource sourceTarget,
+              selectedFrontierFlatAtlasSkeleton.edge sourceSource sourceTarget /\
+                IndexedResidualPresentAt
+                  selectedFrontierFlatAtlasSkeleton.projection
+                  selectedFrontierFlatAtlasSkeleton.cover
+                  sourceSource /\
+                  IndexedResidualFreeAt
+                    selectedFrontierFlatAtlasSkeleton.projection
+                    selectedFrontierFlatAtlasSkeleton.cover
+                    sourceTarget /\
+                    selectedToExtendedIndex sourceSource = targetSource /\
+                      selectedToExtendedIndex sourceTarget = targetTarget := by
+  intro targetSource targetTarget hedge hpresent hfree
+  cases targetSource with
+  | none =>
+      exact False.elim
+        ((selectedExtended_none_no_outgoing_edge targetTarget) hedge)
+  | some sourceSource =>
+      cases targetTarget with
+      | none =>
+          exact False.elim
+            ((selectedExtended_none_no_incoming_edge
+              (some sourceSource)) hedge)
+      | some sourceTarget =>
+          refine ⟨sourceSource, sourceTarget, ?_, ?_, ?_, rfl, rfl⟩
+          · simpa [selectedFrontierFlatAtlasSkeleton,
+              selectedExtendedFrontierFlatAtlasSkeleton,
+              selectedExtendedFrontierFlatEdge]
+              using hedge
+          · simpa [selectedFrontierFlatAtlasSkeleton,
+              selectedExtendedFrontierFlatAtlasSkeleton,
+              selectedExtendedToSelectedIndex]
+              using hpresent
+          · simpa [selectedFrontierFlatAtlasSkeleton,
+              selectedExtendedFrontierFlatAtlasSkeleton,
+              selectedExtendedToSelectedIndex]
+              using hfree
+
+/-- The selected-to-extended map is cut-covering by structural laws. -/
+def selectedToExtendedResidualCutCoveringMap :
+    ResidualCutCoveringAtlasMap
+      selectedFrontierFlatAtlasSkeleton
+      selectedExtendedFrontierFlatAtlasSkeleton where
+  mapIndex := selectedToExtendedIndex
+  edge_preserving := selectedToExtended_edge_preserving
+  residual_present_preserving :=
+    selectedToExtended_residual_present_preserving
+  residual_free_preserving :=
+    selectedToExtended_residual_free_preserving
+  target_cut_data_lift :=
+    selectedToExtended_target_cut_data_lift
+
+/-- The structural selected map induces the Cycle-94 cut-locus embedding. -/
+theorem selectedToExtended_structural_push_nonzero :
+    (pushResidualCutCochain
+      (residualCutInducingAtlasMap_to_cutLocusEmbedding
+        selectedToExtendedResidualCutInducingMap)
+      (canonicalResidualCutCochain
+        selectedFrontierFlatAtlasSkeleton)).CutNonzero := by
+  exact
+    residualCutInducingAtlasMap_push_nonzero
+      selectedToExtendedResidualCutInducingMap
+      selected_canonicalResidualCutClass_nonzero
+
+/-- The structural selected map preserves canonical nonzero support. -/
+theorem selectedToExtended_structural_canonicalCutClass_nonzero :
+    (canonicalResidualCutCochain
+      selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    (residualCutCoveringAtlasMap_preserves_canonicalCutNonzero
+      selectedToExtendedResidualCutCoveringMap).mp
+      selected_canonicalResidualCutClass_nonzero
+
+/-- The structurally induced extended canonical class obstructs closure. -/
+theorem selectedToExtended_structural_obstructs_transitionClosure
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedExtendedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionClosure
+      selectedToExtendedResidualCutInducingMap
+      selected_canonicalResidualCutClass_nonzero
+      transition
+
+/-- The structurally induced extended canonical class rules out coherent data. -/
+theorem selectedToExtended_structural_obstructs_transitionCoherentData
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedExtendedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionCoherentData
+      selectedToExtendedResidualCutInducingMap
+      selected_canonicalResidualCutClass_nonzero
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-95 theorem package: edge preservation, residual-present preservation,
+and residual-free preservation induce Cycle-94 cut-locus transport.  A
+covering law for target edge/present/free data induces cut-surjectivity and
+canonical vanishing/nonzero equivalence.  The selected extended-carrier map
+realizes these structural laws.
+-/
+theorem semanticResidualAtlasMapLaws_package :
+    (forall {LeftIndex : Type w}
+      {LeftAtom : Type u}
+      {RightIndex : Type x}
+      {RightAtom : Type v}
+      {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+      {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+      forall atlasMap : ResidualCutInducingAtlasMap left right,
+      forall pair : LeftIndex × LeftIndex,
+        IsResidualTransitionCutPair left pair ->
+          IsResidualTransitionCutPair right
+            (mapResidualPair atlasMap.mapIndex pair)) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall atlasMap : ResidualCutInducingAtlasMap left right,
+        forall sourceC : ResidualCutCochain left,
+          sourceC.CutNonzero ->
+            (pushResidualCutCochain
+              (residualCutInducingAtlasMap_to_cutLocusEmbedding atlasMap)
+              sourceC).CutNonzero) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall _atlasMap : ResidualCutInducingAtlasMap left right,
+        forall sourceC : ResidualCutCochain left,
+          sourceC.CutNonzero ->
+            forall transition : RightIndex -> RightIndex -> RightAtom -> RightAtom,
+              Not (AtlasResidualTransitionClosed right transition)) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall _atlasMap : ResidualCutInducingAtlasMap left right,
+        forall sourceC : ResidualCutCochain left,
+          sourceC.CutNonzero ->
+            forall transition : RightIndex -> RightIndex -> RightAtom -> RightAtom,
+              Not (Nonempty (TransitionCoherentAtlasData right transition))) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall _atlasMap : ResidualCutCoveringAtlasMap left right,
+        (canonicalResidualCutCochain left).CutVanishes <->
+          (canonicalResidualCutCochain right).CutVanishes) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {left : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {right : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall _atlasMap : ResidualCutCoveringAtlasMap left right,
+        (canonicalResidualCutCochain left).CutNonzero <->
+          (canonicalResidualCutCochain right).CutNonzero) /\
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (pushResidualCutCochain
+        (residualCutInducingAtlasMap_to_cutLocusEmbedding
+          selectedToExtendedResidualCutInducingMap)
+        (canonicalResidualCutCochain
+          selectedFrontierFlatAtlasSkeleton)).CutNonzero /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedExtendedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedExtendedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} atlasMap pair hcut =>
+        residualCutInducingAtlasMap_preserves_residualCutPair
+          atlasMap hcut,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} atlasMap sourceC hnonzero =>
+        residualCutInducingAtlasMap_push_nonzero
+          atlasMap hnonzero,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} atlasMap sourceC hnonzero transition =>
+        residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionClosure
+          atlasMap hnonzero transition,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} atlasMap sourceC hnonzero transition =>
+        residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionCoherentData
+          atlasMap hnonzero transition,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} atlasMap =>
+        residualCutCoveringAtlasMap_preserves_canonicalCutVanishes
+          atlasMap,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_left} {_right} atlasMap =>
+        residualCutCoveringAtlasMap_preserves_canonicalCutNonzero
+          atlasMap,
+      selectedToExtended_structural_canonicalCutClass_nonzero,
+      selectedToExtended_structural_push_nonzero,
+      selectedToExtended_structural_obstructs_transitionClosure,
+      selectedToExtended_structural_obstructs_transitionCoherentData⟩
+
+end SemanticResidualAtlasMapLaws
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-map-laws.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-map-laws.md
@@ -1,0 +1,151 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: cut-locus transport induction / decomposed atlas laws / genius-support convergence
+candidate_type: finite atlas law induction / obstruction-class-support / carrier-change
+capability_category: semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-induction / genius-support
+expected_base_score: 86
+expected_evidence_multiplier: 2.0
+expected_final_score: 172
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can remap diagnostics, but they do not prove that explicit edge/residual-present/residual-free preservation laws induce residual cut-locus transport and target obstruction transfer.
+origin: cycle-95
+tags: [quality-surface, semantic-repair, residual-cut, atlas-transport, map-laws, genius-support]
+created: 2026-06-23
+cycle: 95
+lean: proved-in-research
+planned_report_section: "Cycle 95: Semantic residual cut-locus transport induced by atlas map laws"
+---
+
+# Semantic Residual Cut-Locus Transport Induced by Atlas Map Laws
+
+## 主張
+
+Cycle 94 の supplied residual cut-locus transport を、より構造的な finite atlas laws から導く。
+`ResidualCutInducingAtlasMap` は index map に加えて、active edge preservation、residual-present preservation、residual-free preservation を持つ。
+これら三つの law だけで、source residual transition cut pair は target residual transition cut pair へ送られる。
+したがって Cycle 94 の `ResidualCutLocusEmbedding` が誘導され、source cut cochain の nonzero support は target nonzero obstruction と target transition closure / transition-coherent data の no-go theorem へ移送される。
+
+さらに `ResidualCutCoveringAtlasMap` は、target edge / present / free cut data を source data へ lift する covering law を持つ。
+この law から cut-surjectivity が導かれ、Cycle 94 の `ResidualCutLocusEquivalence` と canonical residual cut class の vanishing / nonzero equivalence が得られる。
+
+selected witness では Cycle 94 の `Option SelectedSemanticOverlapIndex` extended carrier を再利用する。
+selected index embedding は edge、residual-present、residual-free を保存し、target cut data を source に lift する。
+そのため selected frontier-to-flat obstruction は、arbitrary cut-locus field を直接仮定せず、explicit atlas laws から extended carrier 上へ transport される。
+
+この主張は finite atlas skeleton の edge/present/free preservation と covering law に限定する。
+arbitrary atlas category、general atom map semantics、projection/cover naturality、true `H^1`、Cech quotient、coboundary quotient、`vanishing -> closure`、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、UI correctness、whole-codebase quality は含まない。
+
+## 候補種別
+
+`finite atlas law induction` / `obstruction-class-support` / `carrier-change`
+
+## 依拠
+
+- Cycle 92: cut-noise invariant residual obstruction class reading。
+- Cycle 93: same-carrier residual atlas gauge invariance。
+- Cycle 94: beyond-same-carrier residual cut-locus transport。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+Cycle 94 の `ResidualCutLocusEmbedding` を field として直接持つだけでは transport theorem の入力を言い換えるだけになる。
+この候補では、edge preservation、residual-present preservation、residual-free preservation という atlas-level laws から cut-pair preservation を証明し、covering law から cut-surjectivity を導く。
+selected witness も same carrier alias ではなく、extended carrier への concrete embedding と lift law を Lean で示す。
+
+## 数学的興味
+
+semantic residual obstruction class の transport が、ad hoc な cut-locus relation だけでなく、finite atlas の decomposed structural laws から生成されることを示す。
+これは H1-style obstruction theorem そのものではないが、future repair-gluing obstruction theorem が atlas map / carrier refinement / diagnostic schema change に耐えるための induction layer を与える。
+
+## GOAL への前進
+
+open genius target に向けて、obstruction class transport を supplied cut relation から edge/present/free map laws へ引き下げた。
+finite atom-supported quality atlas の morphism-like structure をまだ一般 category として主張せず、必要な transport law だけを Lean theorem として固定した。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は diagnostics を別 schema へ写せる。
+しかし、それらは edge preservation、residual-present preservation、residual-free preservation、target cut-data lift から obstruction-class transport と target no-go theorem を導く証明を持たない。
+AAT 側では、diagnostic schema change を finite residual cut laws の保存問題として読める。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 94 の cut-locus transport を、explicit atlas map laws から誘導する。open genius target への support node として強いが、H1 obstruction 本体ではない。
+- `dullness_risk`: map law の wrapper に見える危険がある。cut-pair preservation、induced embedding、covering-to-surjectivity、selected extended witness、target obstruction package を揃えて避ける。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualAtlasMapLaws.lean` で inducing map、covering map、selected extended map laws、theorem package を証明する。
+
+## CS / SWE への帰結
+
+finite architecture diagnostics を schema / carrier / presentation 間で移すとき、単なる ID 変換では足りない。
+active edge、residual-present source、residual-free target を保存し、target cut data を source に lift できることが、semantic residual obstruction reading を保つための証明可能な条件になる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualAtlasMapLaws.lean` に固定した。
+
+- `ResidualCutInducingAtlasMap`
+- `residualCutInducingAtlasMap_preserves_residualCutPair`
+- `residualCutInducingAtlasMap_to_cutLocusEmbedding`
+- `residualCutInducingAtlasMap_push_nonzero`
+- `residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionClosure`
+- `residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionCoherentData`
+- `ResidualCutCoveringAtlasMap`
+- `residualCutCoveringAtlasMap_cut_surjective`
+- `residualCutCoveringAtlasMap_to_cutLocusEquivalence`
+- `residualCutCoveringAtlasMap_preserves_canonicalCutVanishes`
+- `residualCutCoveringAtlasMap_preserves_canonicalCutNonzero`
+- `selectedToExtended_edge_preserving`
+- `selectedToExtended_residual_present_preserving`
+- `selectedToExtended_residual_free_preserving`
+- `selectedToExtendedResidualCutInducingMap`
+- `selectedToExtended_target_cut_data_lift`
+- `selectedToExtendedResidualCutCoveringMap`
+- `selectedToExtended_structural_push_nonzero`
+- `selectedToExtended_structural_canonicalCutClass_nonzero`
+- `selectedToExtended_structural_obstructs_transitionClosure`
+- `selectedToExtended_structural_obstructs_transitionCoherentData`
+- `semanticResidualAtlasMapLaws_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualAtlasMapLaws.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualAtlasMapLaws`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: inducing-map preservation / push / obstruction theorem は axiom-free。covering/canonical transport と selected map laws は標準 `propext`、selected transported class と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、finite semantic repair atlas skeleton 間の edge/residual-present/residual-free preserving maps、target cut-data lift、induced cut-locus embedding/equivalence、selected extended carrier witness に限定する。
+unchecked: arbitrary atlas category、general atom-map semantic completeness、projection/cover naturality、functorial sheaf transport、true H1 cohomology class、Cech quotient、coboundary quotient、vanishing-to-closure theorem、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、whole-codebase quality。
+
+## 審判メモ
+
+- G1 A/B/C/D: Cycle 94 の next frontier として、cut-locus transport を explicit edge/present/free preservation laws から導く候補を推奨。H1-style adapter や arbitrary morphism category より先に induction layer を固定するべきと判定。
+- G2 A: accept / base 86。`ResidualCutInducingAtlasMap` は edge / residual-present / residual-free preservation から `ResidualCutLocusEmbedding` を導くこと。covering law は cut-surjective equivalence へ限定すること。
+- G2 B: accept / base 82-90。arbitrary atlas morphism、true H1、vanishing-to-closure を主張しないこと。
+- G2 revise 解決: selected extended carrier witness を map-law theorem package に入れ、Cycle 94 の arbitrary cut-preserving map assumption を structural laws へ引き下げた。
+
+## 追加 required fields
+
+- `mathematical_interest`: residual cut-locus transport を finite atlas map laws から導く。
+- `goal_advancement`: supplied cut relation から edge/present/free preservation と covering law へ transport condition を分解した。
+- `planned_theorem_names`: `residualCutInducingAtlasMap_preserves_residualCutPair`, `residualCutCoveringAtlasMap_cut_surjective`, `semanticResidualAtlasMapLaws_package`
+- `visible_projection`: finite index carrier / diagnostic schema / atlas map law。
+- `protected_structure`: residual transition cut locus、edge/present/free preservation、cut-data lift、target transition obstruction。
+- `exactness_or_minimality_claim`: covering law induces cut-surjective equivalence and canonical vanishing/nonzero equivalence。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: schema changes that do not preserve edge/present/free cut laws need not preserve semantic residual obstruction readings。
+- `previous_cycle_delta`: Cycle 94 の supplied cut-locus transport を structural map-law induction へ引き下げた。
+- `rival_stress_test`: rival は diagnostics を rename できても、edge/present/free laws から target obstruction theorem を導けない。
+- `genius_potential`: strong support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem への induction layer。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: obstruction class transport が finite atlas map laws から生成されることを固定する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-morphism.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-gauge.md`
+- planned report section: `Cycle 95: Semantic residual cut-locus transport induced by atlas map laws`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 95 G1/G2 で residual cut-locus transport induced by edge/present/free map laws を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualAtlasMapLaws.lean` に固定し、単体 `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 12994
+- total SCORE: 13166
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -99,8 +99,9 @@
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / projection-nonfaithfulness / genius-support: 164
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / invariance / genius-support: 172
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-invariance / genius-support: 176
+  - semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-induction / genius-support: 172
 - evidence portfolio:
-  - proved-in-research: 94
+  - proved-in-research: 95
 
 ## Phase synthesis
 
@@ -116,7 +117,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-94 件の Lean-proved research artifacts は、次の paper seed を形成している。
+95 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -139,6 +140,7 @@ certificate の基本単位は
 - semantic residual obstruction class modulo cut-noise は、raw diagnostic support に off-cut noise が混じっても residual cut-locus class reading が不変であることを示し、preclass support から finite obstruction class frontier へ進める。
 - semantic residual atlas gauge invariance は、raw edge family に harmless reverse-edge noise が混じっても same residual cut locus なら canonical obstruction class と nonzero obstruction reading が保存されることを示す。
 - semantic residual cut-locus transport は、finite carrier が変わっても supplied cut-preserving / cut-surjective map の下で canonical obstruction class と target no-go reading が移送されることを示す。
+- semantic residual atlas map laws は、edge preservation、residual-present preservation、residual-free preservation、target cut-data lift から residual cut-locus transport と canonical obstruction transport を誘導できることを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -193,8 +195,9 @@ Cycle 91 後の total SCORE は 12482 であり、tracking Issue active threshol
 Cycle 92 後の total SCORE は 12646 であり、tracking Issue active threshold 15000 までは残り 2354 SCORE である。
 Cycle 93 後の total SCORE は 12818 であり、tracking Issue active threshold 15000 までは残り 2182 SCORE である。
 Cycle 94 後の total SCORE は 12994 であり、tracking Issue active threshold 15000 までは残り 2006 SCORE である。
+Cycle 95 後の total SCORE は 13166 であり、tracking Issue active threshold 15000 までは残り 1834 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 94 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 95 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -221,7 +224,8 @@ semantic residual transition cut scanner exactness theorem、
 semantic residual obstruction one-preclass theorem、
 semantic residual obstruction class modulo cut-noise theorem、
 semantic residual atlas gauge invariance theorem、
-semantic residual cut-locus transport theorem を含む。
+semantic residual cut-locus transport theorem、
+semantic residual atlas map law induction theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -4933,4 +4937,88 @@ extended atlas.
 
 Cycle 94 後の total SCORE は 12994 であり、tracking Issue active threshold 15000 までは残り 2006 SCORE である。
 次 cycle では、cut-locus transport induced from edge/present/free preservation、local-pass/global-fail taxonomy、residual-present/residual-free mismatch minimality、または finite H1-style adapter を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 95: Semantic residual cut-locus transport induced by atlas map laws
+
+```text
+candidate: Semantic residual cut-locus transport induced by atlas map laws
+candidate_type: finite atlas law induction / obstruction-class-support / carrier-change
+evidence_stage: proved-in-research
+base_score: 86
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 172
+category: semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-induction / genius-support
+goal_delta: Cycle 94 の supplied cut-locus transport を、edge preservation、residual-present preservation、residual-free preservation、target cut-data lift から誘導する theorem へ引き下げた。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、residual cut-inducing atlas map、covering atlas map、induced cut-locus embedding/equivalence、selected extended carrier map-law witness、target obstruction package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は diagnostics を rename / remap できるが、edge/present/free preservation と cut-data lift から obstruction-class transport と target no-go theorem を導く Lean artifact は持たない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualAtlasMapLaws.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualAtlasMapLaws`, and `lake build FormalAGResearch` passed. Axiom probe reported inducing-map preservation / push / target obstruction theorem axiom-free; covering/canonical transport and selected map laws use standard `propext`; selected transported class and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: residual-present/residual-free mismatch minimality; local-pass/global-fail taxonomy; finite H1-style adapter; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualAtlasMapLaws.lean`
+derives Cycle 94 cut-locus transport from decomposed finite atlas laws.
+`ResidualCutInducingAtlasMap` contains an index map together with active-edge
+preservation, residual-present preservation, and residual-free preservation.
+These three laws imply that every source residual transition cut pair maps to
+a target residual transition cut pair, inducing a Cycle 94
+`ResidualCutLocusEmbedding`.
+
+The induced embedding pushes source cut cochains to target cut cochains.
+If the source support is nonzero on the residual cut locus, the pushed target
+support is nonzero and therefore rules out target residual transition closure
+and target transition-coherent atlas data.
+
+`ResidualCutCoveringAtlasMap` adds a target cut-data lift law.  From that law,
+Lean derives the cut-surjectivity needed for `ResidualCutLocusEquivalence`.
+Under the covering hypothesis, canonical residual cut class vanishing and
+nonzero are equivalent between source and target.
+
+The selected witness reuses Cycle 94's extended carrier
+`Option SelectedSemanticOverlapIndex`.  The selected-to-extended index map
+preserves edges, residual-present indices, and residual-free indices, and it
+lifts target cut data back to selected source cut data.  Thus the selected
+frontier-to-flat obstruction is transported to the extended carrier by
+structural atlas laws, not by directly postulating a cut-locus relation.
+
+Lean proves:
+
+- `ResidualCutInducingAtlasMap`: atlas map preserving edge, residual-present, and residual-free data.
+- `residualCutInducingAtlasMap_preserves_residualCutPair`: these laws preserve residual cut pairs.
+- `residualCutInducingAtlasMap_to_cutLocusEmbedding`: the laws induce a Cycle 94 cut-locus embedding.
+- `residualCutInducingAtlasMap_push_nonzero`: induced pushforward preserves nonzero source cut support.
+- `residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionClosure`: induced target nonzero support obstructs target transition closure.
+- `residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionCoherentData`: induced target nonzero support rules out target transition-coherent data.
+- `ResidualCutCoveringAtlasMap`: inducing map with target cut-data lift.
+- `residualCutCoveringAtlasMap_cut_surjective`: covering law induces cut-surjectivity.
+- `residualCutCoveringAtlasMap_to_cutLocusEquivalence`: covering law induces Cycle 94 cut-locus equivalence.
+- `residualCutCoveringAtlasMap_preserves_canonicalCutVanishes`: covering law preserves canonical vanishing.
+- `residualCutCoveringAtlasMap_preserves_canonicalCutNonzero`: covering law preserves canonical nonzero.
+- `selectedToExtended_edge_preserving`: selected-to-extended carrier map preserves active edges.
+- `selectedToExtended_residual_present_preserving`: selected-to-extended carrier map preserves residual-present indices.
+- `selectedToExtended_residual_free_preserving`: selected-to-extended carrier map preserves residual-free indices.
+- `selectedToExtendedResidualCutInducingMap`: selected-to-extended inducing atlas map.
+- `selectedToExtended_target_cut_data_lift`: selected-to-extended map lifts target cut data.
+- `selectedToExtendedResidualCutCoveringMap`: selected-to-extended covering atlas map.
+- `selectedToExtended_structural_push_nonzero`: selected canonical class pushes to a nonzero extended target class.
+- `selectedToExtended_structural_canonicalCutClass_nonzero`: extended target canonical class is nonzero.
+- `selectedToExtended_structural_obstructs_transitionClosure`: extended target canonical class obstructs transition closure.
+- `selectedToExtended_structural_obstructs_transitionCoherentData`: extended target canonical class rules out transition-coherent data.
+- `semanticResidualAtlasMapLaws_package`: theorem package.
+
+This cycle is a support node, not a `genius unlock`.  It proves that finite
+edge/present/free preservation laws induce residual cut-locus transport, not
+an arbitrary atlas category, general atom-map semantics, projection/cover
+naturality, functorial sheaf transport, true `H^1`, Cech quotient, coboundary
+quotient, or vanishing-to-closure theorem.  It does not claim source
+extraction completeness, ArchMap correctness, runtime repair synthesis,
+tooling runtime extraction, UI correctness, or whole-codebase quality.
+
+### Next Frontier
+
+Cycle 95 後の total SCORE は 13166 であり、tracking Issue active threshold 15000 までは残り 1834 SCORE である。
+次 cycle では、residual-present/residual-free mismatch minimality、local-pass/global-fail taxonomy、finite H1-style adapter、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 95 として、Cycle 94 の residual cut-locus transport を edge preservation / residual-present preservation / residual-free preservation / target cut-data lift から誘導する Lean 証拠を追加します。tracking Issue は threshold 15000 継続のため close しません。

score ledger: +172、total 12994 -> 13166、remaining 1834。G3 formalization audit: pass。G3.5 ledger audit: pass。G4 score audit: confirm +172 / genius-support node。

## 証明した定理

- `ResidualCutInducingAtlasMap`
- `residualCutInducingAtlasMap_preserves_residualCutPair`
- `residualCutInducingAtlasMap_to_cutLocusEmbedding`
- `residualCutInducingAtlasMap_push_nonzero`
- `residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionClosure`
- `residualCutInducingAtlasMap_nonzero_obstructs_targetTransitionCoherentData`
- `ResidualCutCoveringAtlasMap`
- `residualCutCoveringAtlasMap_cut_surjective`
- `residualCutCoveringAtlasMap_to_cutLocusEquivalence`
- `residualCutCoveringAtlasMap_preserves_canonicalCutVanishes`
- `residualCutCoveringAtlasMap_preserves_canonicalCutNonzero`
- `selectedToExtended_edge_preserving`
- `selectedToExtended_residual_present_preserving`
- `selectedToExtended_residual_free_preserving`
- `selectedToExtendedResidualCutInducingMap`
- `selectedToExtended_target_cut_data_lift`
- `selectedToExtendedResidualCutCoveringMap`
- `selectedToExtended_structural_push_nonzero`
- `selectedToExtended_structural_canonicalCutClass_nonzero`
- `selectedToExtended_structural_obstructs_transitionClosure`
- `selectedToExtended_structural_obstructs_transitionCoherentData`
- `semanticResidualAtlasMapLaws_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-map-laws.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualAtlasMapLaws.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualAtlasMapLaws`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check` / `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` probe: inducing-map preservation / push / target obstruction theorem は axiom-free。covering/canonical transport と selected map laws は標準 `propext`、selected transported class と package は標準 `propext` / `Quot.sound` のみ。

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

## Claim boundary

finite semantic repair atlas skeleton 間の edge/residual-present/residual-free preserving maps、target cut-data lift、induced cut-locus embedding/equivalence、selected extended carrier witness に限定します。arbitrary atlas category、general atom-map semantic completeness、projection/cover naturality、functorial sheaf transport、true H1 cohomology class、Cech quotient、coboundary quotient、vanishing-to-closure theorem、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、whole-codebase quality は主張しません。