### PR TITLE
研究ループCycle96: residual cut repair hittingを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -92,3 +92,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass
 import Formal.AG.Research.QualitySurface.SemanticResidualAtlasGauge
 import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMorphism
 import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMapLaws
+import Formal.AG.Research.QualitySurface.SemanticResidualCutRepairHitting

--- a/Formal/AG/Research/QualitySurface/SemanticResidualCutRepairHitting.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualCutRepairHitting.lean
@@ -1,0 +1,503 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMapLaws
+
+/-!
+Cycle 96 evidence for `G-aat-quality-surface-01`.
+
+This file turns the residual cut obstruction class into a repair-hitting
+necessity theorem.  For same-carrier old/new finite semantic repair atlas
+skeletons, explicit hit predicates mark the places a repair touched: active
+edges, residual-present source indices, and residual-free target indices.  If
+old residual cuts persist outside those hit loci, then vanishing of the new
+canonical residual cut class forces every old residual cut to be hit somewhere.
+
+The result is a necessary condition only.  It does not assert that hitting a
+cut synthesizes a repair, that vanishing implies transition closure, that the
+hit set is globally minimal, that an arbitrary atlas category exists, that a
+true Cech/H1 quotient has been constructed, or that source extraction,
+ArchMap correctness, runtime repair synthesis, tooling runtime extraction, UI
+correctness, or whole-codebase quality has been established.
+-/
+
+universe u w
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualCutRepairHitting
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasMorphism
+open SemanticResidualAtlasMapLaws
+
+/-! ## Repair-hit predicates for residual cut loci -/
+
+/--
+A residual cut is hit when it is not simultaneously untouched at the edge,
+source-index, and target-index loci.  This constructive form avoids building a
+classical disjunction from the impossibility of all three misses.
+-/
+def ResidualCutHit
+    {Index : Type w}
+    (edgeHit : Index × Index -> Prop)
+    (sourceHit targetHit : Index -> Prop)
+    (pair : Index × Index) : Prop :=
+  Not
+    (Not (edgeHit pair) /\
+      Not (sourceHit pair.1) /\
+        Not (targetHit pair.2))
+
+/-- An explicit edge hit hits the residual cut. -/
+theorem residualCutHit_of_edgeHit
+    {Index : Type w}
+    {edgeHit : Index × Index -> Prop}
+    {sourceHit targetHit : Index -> Prop}
+    {pair : Index × Index}
+    (hhit : edgeHit pair) :
+    ResidualCutHit edgeHit sourceHit targetHit pair := by
+  intro hunhit
+  exact hunhit.1 hhit
+
+/-- An explicit source-index hit hits the residual cut. -/
+theorem residualCutHit_of_sourceHit
+    {Index : Type w}
+    {edgeHit : Index × Index -> Prop}
+    {sourceHit targetHit : Index -> Prop}
+    {pair : Index × Index}
+    (hhit : sourceHit pair.1) :
+    ResidualCutHit edgeHit sourceHit targetHit pair := by
+  intro hunhit
+  exact hunhit.2.1 hhit
+
+/-- An explicit target-index hit hits the residual cut. -/
+theorem residualCutHit_of_targetHit
+    {Index : Type w}
+    {edgeHit : Index × Index -> Prop}
+    {sourceHit targetHit : Index -> Prop}
+    {pair : Index × Index}
+    (hhit : targetHit pair.2) :
+    ResidualCutHit edgeHit sourceHit targetHit pair := by
+  intro hunhit
+  exact hunhit.2.2 hhit
+
+/--
+Old residual cuts persist into the new atlas when no repair hit touches their
+edge, residual-present source, or residual-free target loci.
+-/
+def UnhitResidualCutPersists
+    {Index : Type w}
+    {Atom : Type u}
+    (old new : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    (edgeHit : Index × Index -> Prop)
+    (sourceHit targetHit : Index -> Prop) : Prop :=
+  forall pair,
+    IsResidualTransitionCutPair old pair ->
+      Not (edgeHit pair) ->
+        Not (sourceHit pair.1) ->
+          Not (targetHit pair.2) ->
+            IsResidualTransitionCutPair new pair
+
+/-- Every old residual cut is hit by the supplied repair-hit predicates. -/
+def AllOldResidualCutsHit
+    {Index : Type w}
+    {Atom : Type u}
+    (old : FiniteSemanticRepairAtlasSkeleton Index Atom)
+    (edgeHit : Index × Index -> Prop)
+    (sourceHit targetHit : Index -> Prop) : Prop :=
+  forall pair,
+    IsResidualTransitionCutPair old pair ->
+      ResidualCutHit edgeHit sourceHit targetHit pair
+
+/-! ## Persistence and repair necessity -/
+
+/-- An unhit old residual cut persists as a new residual cut. -/
+theorem unhit_oldResidualCut_persists_newCut
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {edgeHit : Index × Index -> Prop}
+    {sourceHit targetHit : Index -> Prop}
+    (hpersist :
+      UnhitResidualCutPersists old new edgeHit sourceHit targetHit)
+    {pair : Index × Index}
+    (hcut : IsResidualTransitionCutPair old pair)
+    (hedge : Not (edgeHit pair))
+    (hsource : Not (sourceHit pair.1))
+    (htarget : Not (targetHit pair.2)) :
+    IsResidualTransitionCutPair new pair := by
+  exact hpersist pair hcut hedge hsource htarget
+
+/--
+If an old residual cut is untouched at all three repair loci, the new canonical
+residual cut class is nonzero.
+-/
+theorem unhit_oldResidualCut_preserves_newCanonicalNonzero
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {edgeHit : Index × Index -> Prop}
+    {sourceHit targetHit : Index -> Prop}
+    (hpersist :
+      UnhitResidualCutPersists old new edgeHit sourceHit targetHit)
+    {pair : Index × Index}
+    (hcut : IsResidualTransitionCutPair old pair)
+    (hedge : Not (edgeHit pair))
+    (hsource : Not (sourceHit pair.1))
+    (htarget : Not (targetHit pair.2)) :
+    (canonicalResidualCutCochain new).CutNonzero := by
+  have hnewCut :
+      IsResidualTransitionCutPair new pair :=
+    unhit_oldResidualCut_persists_newCut
+      hpersist hcut hedge hsource htarget
+  exact ⟨pair, hnewCut, hnewCut⟩
+
+/--
+If the new canonical residual cut class vanishes, each old residual cut must be
+hit at its edge, source, or target locus.
+-/
+theorem newCanonicalVanishes_forces_oldResidualCutHit
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {edgeHit : Index × Index -> Prop}
+    {sourceHit targetHit : Index -> Prop}
+    (hpersist :
+      UnhitResidualCutPersists old new edgeHit sourceHit targetHit)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes)
+    {pair : Index × Index}
+    (hcut : IsResidualTransitionCutPair old pair) :
+    ResidualCutHit edgeHit sourceHit targetHit pair := by
+  intro hunhit
+  have hnewCut :
+      IsResidualTransitionCutPair new pair :=
+    hpersist pair hcut hunhit.1 hunhit.2.1 hunhit.2.2
+  exact hvanish pair hnewCut hnewCut
+
+/-- Vanishing of the new canonical class forces all old residual cuts to be hit. -/
+theorem newCanonicalVanishes_forces_allOldResidualCutsHit
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {edgeHit : Index × Index -> Prop}
+    {sourceHit targetHit : Index -> Prop}
+    (hpersist :
+      UnhitResidualCutPersists old new edgeHit sourceHit targetHit)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes) :
+    AllOldResidualCutsHit old edgeHit sourceHit targetHit := by
+  intro pair hcut
+  exact newCanonicalVanishes_forces_oldResidualCutHit
+    hpersist hvanish hcut
+
+/-- An unhit old residual cut obstructs new transition closure. -/
+theorem unhit_oldResidualCut_obstructs_newTransitionClosure
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {edgeHit : Index × Index -> Prop}
+    {sourceHit targetHit : Index -> Prop}
+    (hpersist :
+      UnhitResidualCutPersists old new edgeHit sourceHit targetHit)
+    {pair : Index × Index}
+    (hcut : IsResidualTransitionCutPair old pair)
+    (hedge : Not (edgeHit pair))
+    (hsource : Not (sourceHit pair.1))
+    (htarget : Not (targetHit pair.2))
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (AtlasResidualTransitionClosed new transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain new)
+      (unhit_oldResidualCut_preserves_newCanonicalNonzero
+        hpersist hcut hedge hsource htarget)
+      transition
+
+/-- An unhit old residual cut rules out new transition-coherent atlas data. -/
+theorem unhit_oldResidualCut_obstructs_newTransitionCoherentData
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {edgeHit : Index × Index -> Prop}
+    {sourceHit targetHit : Index -> Prop}
+    (hpersist :
+      UnhitResidualCutPersists old new edgeHit sourceHit targetHit)
+    {pair : Index × Index}
+    (hcut : IsResidualTransitionCutPair old pair)
+    (hedge : Not (edgeHit pair))
+    (hsource : Not (sourceHit pair.1))
+    (htarget : Not (targetHit pair.2))
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (Nonempty (TransitionCoherentAtlasData new transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (canonicalResidualCutCochain new)
+      (unhit_oldResidualCut_preserves_newCanonicalNonzero
+        hpersist hcut hedge hsource htarget)
+      transition
+
+/-! ## Selected frontier-to-flat witness -/
+
+/-- The selected frontier-to-flat residual cut pair. -/
+def selectedFrontierFlatResidualCutPair :
+    SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex :=
+  (SelectedSemanticOverlapIndex.repairFrontier,
+    SelectedSemanticOverlapIndex.flat)
+
+/-- The selected frontier-to-flat pair is a residual cut. -/
+theorem selectedFrontierFlatResidualCutPair_isCut :
+    IsResidualTransitionCutPair
+      selectedFrontierFlatAtlasSkeleton
+      selectedFrontierFlatResidualCutPair := by
+  exact
+    residualTransitionCut_pair_isCut
+      selectedFrontierFlatResidualTransitionCut
+
+/-- No selected edge is hit. -/
+def selectedNoEdgeHit
+    (_pair : SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex) :
+    Prop :=
+  False
+
+/-- No selected residual-present source index is hit. -/
+def selectedNoSourceHit
+    (_index : SelectedSemanticOverlapIndex) :
+    Prop :=
+  False
+
+/-- No selected residual-free target index is hit. -/
+def selectedNoTargetHit
+    (_index : SelectedSemanticOverlapIndex) :
+    Prop :=
+  False
+
+/-- With no hit loci and identical old/new atlas, every old cut persists. -/
+theorem selectedNoHit_unhitResidualCutPersists :
+    UnhitResidualCutPersists
+      selectedFrontierFlatAtlasSkeleton
+      selectedFrontierFlatAtlasSkeleton
+      selectedNoEdgeHit
+      selectedNoSourceHit
+      selectedNoTargetHit := by
+  intro pair hcut _hedge _hsource _htarget
+  exact hcut
+
+/-- With no hit loci, the selected canonical residual cut class remains nonzero. -/
+theorem selectedNoHit_preserves_canonicalNonzero :
+    (canonicalResidualCutCochain
+      selectedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    unhit_oldResidualCut_preserves_newCanonicalNonzero
+      selectedNoHit_unhitResidualCutPersists
+      selectedFrontierFlatResidualCutPair_isCut
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+
+/--
+For any same-carrier new selected atlas, vanishing of the new canonical class
+requires the selected frontier-to-flat cut to be hit somewhere.
+-/
+theorem selected_newCanonicalVanishes_requires_frontierFlatCutHit
+    {new :
+      FiniteSemanticRepairAtlasSkeleton
+        SelectedSemanticOverlapIndex
+        RefinedSemanticRepairAtom}
+    {edgeHit :
+      SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+    {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop}
+    (hpersist :
+      UnhitResidualCutPersists
+        selectedFrontierFlatAtlasSkeleton
+        new
+        edgeHit
+        sourceHit
+        targetHit)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes) :
+    ResidualCutHit
+      edgeHit
+      sourceHit
+      targetHit
+      selectedFrontierFlatResidualCutPair := by
+  exact
+    newCanonicalVanishes_forces_oldResidualCutHit
+      hpersist
+      hvanish
+      selectedFrontierFlatResidualCutPair_isCut
+
+/-- No-hit persistence obstructs selected transition closure. -/
+theorem selectedNoHit_obstructs_transitionClosure
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    unhit_oldResidualCut_obstructs_newTransitionClosure
+      selectedNoHit_unhitResidualCutPersists
+      selectedFrontierFlatResidualCutPair_isCut
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+      transition
+
+/-- No-hit persistence rules out selected transition-coherent atlas data. -/
+theorem selectedNoHit_obstructs_transitionCoherentData
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    unhit_oldResidualCut_obstructs_newTransitionCoherentData
+      selectedNoHit_unhitResidualCutPersists
+      selectedFrontierFlatResidualCutPair_isCut
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-96 theorem package: if old residual cuts persist outside explicit repair
+hit loci, then vanishing of the new canonical residual cut class forces every
+old residual cut to be hit; otherwise an unhit old cut persists as a nonzero
+new obstruction.
+-/
+theorem semanticResidualCutRepairHitting_package :
+    (forall {Index : Type w}
+      {Atom : Type u}
+      {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+      {edgeHit : Index × Index -> Prop}
+      {sourceHit targetHit : Index -> Prop},
+      UnhitResidualCutPersists old new edgeHit sourceHit targetHit ->
+        forall pair : Index × Index,
+          IsResidualTransitionCutPair old pair ->
+            Not (edgeHit pair) ->
+              Not (sourceHit pair.1) ->
+                Not (targetHit pair.2) ->
+                  (canonicalResidualCutCochain new).CutNonzero) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {edgeHit : Index × Index -> Prop}
+        {sourceHit targetHit : Index -> Prop},
+        UnhitResidualCutPersists old new edgeHit sourceHit targetHit ->
+          (canonicalResidualCutCochain new).CutVanishes ->
+            AllOldResidualCutsHit old edgeHit sourceHit targetHit) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {edgeHit : Index × Index -> Prop}
+        {sourceHit targetHit : Index -> Prop},
+        UnhitResidualCutPersists old new edgeHit sourceHit targetHit ->
+          forall pair : Index × Index,
+            IsResidualTransitionCutPair old pair ->
+              Not (edgeHit pair) ->
+                Not (sourceHit pair.1) ->
+                  Not (targetHit pair.2) ->
+                    forall transition : Index -> Index -> Atom -> Atom,
+                      Not (AtlasResidualTransitionClosed new transition)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {edgeHit : Index × Index -> Prop}
+        {sourceHit targetHit : Index -> Prop},
+        UnhitResidualCutPersists old new edgeHit sourceHit targetHit ->
+          forall pair : Index × Index,
+            IsResidualTransitionCutPair old pair ->
+              Not (edgeHit pair) ->
+                Not (sourceHit pair.1) ->
+                  Not (targetHit pair.2) ->
+                    forall transition : Index -> Index -> Atom -> Atom,
+                      Not
+                        (Nonempty
+                          (TransitionCoherentAtlasData new transition))) /\
+      UnhitResidualCutPersists
+        selectedFrontierFlatAtlasSkeleton
+        selectedFrontierFlatAtlasSkeleton
+        selectedNoEdgeHit
+        selectedNoSourceHit
+        selectedNoTargetHit /\
+      (canonicalResidualCutCochain
+        selectedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (forall
+        {new :
+          FiniteSemanticRepairAtlasSkeleton
+            SelectedSemanticOverlapIndex
+            RefinedSemanticRepairAtom}
+        {edgeHit :
+          SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+        {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop},
+        UnhitResidualCutPersists
+          selectedFrontierFlatAtlasSkeleton
+          new
+          edgeHit
+          sourceHit
+          targetHit ->
+            (canonicalResidualCutCochain new).CutVanishes ->
+              ResidualCutHit
+                edgeHit
+                sourceHit
+                targetHit
+                selectedFrontierFlatResidualCutPair) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_Index} {_Atom} {_old} {_new} {_edgeHit}
+        {_sourceHit} {_targetHit} hpersist pair hcut hedge hsource htarget =>
+        unhit_oldResidualCut_preserves_newCanonicalNonzero
+          hpersist hcut hedge hsource htarget,
+      fun {_Index} {_Atom} {_old} {_new} {_edgeHit}
+        {_sourceHit} {_targetHit} hpersist hvanish =>
+        newCanonicalVanishes_forces_allOldResidualCutsHit
+          hpersist hvanish,
+      fun {_Index} {_Atom} {_old} {_new} {_edgeHit}
+        {_sourceHit} {_targetHit} hpersist pair hcut hedge hsource htarget
+        transition =>
+        unhit_oldResidualCut_obstructs_newTransitionClosure
+          hpersist hcut hedge hsource htarget transition,
+      fun {_Index} {_Atom} {_old} {_new} {_edgeHit}
+        {_sourceHit} {_targetHit} hpersist pair hcut hedge hsource htarget
+        transition =>
+        unhit_oldResidualCut_obstructs_newTransitionCoherentData
+          hpersist hcut hedge hsource htarget transition,
+      selectedNoHit_unhitResidualCutPersists,
+      selectedNoHit_preserves_canonicalNonzero,
+      fun {_new} {_edgeHit} {_sourceHit} {_targetHit} hpersist hvanish =>
+        selected_newCanonicalVanishes_requires_frontierFlatCutHit
+          hpersist hvanish,
+      selectedNoHit_obstructs_transitionClosure,
+      selectedNoHit_obstructs_transitionCoherentData⟩
+
+end SemanticResidualCutRepairHitting
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-cut-repair-hitting.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-cut-repair-hitting.md
@@ -1,0 +1,148 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: repair necessity / residual cut persistence / genius-support convergence
+candidate_type: finite residual repair-hitting theorem / obstruction-class-support / repair-necessity
+capability_category: semantic-obstruction / repair-necessity / finite-atlas-transition / obstruction-class-support / genius-support
+expected_base_score: 88
+expected_evidence_multiplier: 2.0
+expected_final_score: 176
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can report residual-looking edges, but they do not prove that making a residual cut class vanish requires hitting the old cut at edge, source, or target loci under an explicit persistence law.
+origin: cycle-96
+tags: [quality-surface, semantic-repair, residual-cut, repair-hitting, obstruction-persistence, genius-support]
+created: 2026-06-23
+cycle: 96
+lean: proved-in-research
+planned_report_section: "Cycle 96: Residual cut obstruction repair-hitting theorem"
+---
+
+# Residual Cut Obstruction Repair-Hitting Theorem
+
+## 主張
+
+same-carrier の old/new finite semantic repair atlas skeleton に対して、repair が触った場所を `edgeHit`、`sourceHit`、`targetHit` として明示する。
+これらの hit predicates は supplied bookkeeping predicates であり、実装差分から抽出された repair operation そのものではない。
+old residual transition cut が edge/source/target のどこにも hit されていないなら new atlas にも residual cut として残る、という `UnhitResidualCutPersists` law を仮定する。
+この仮定の下で、new canonical residual cut class が vanishes するなら、old residual cut は edge/source/target の少なくとも一箇所で hit されていなければならない。
+
+反対に、unhit old residual cut が存在するなら、new canonical residual cut class は nonzero のまま残り、new transition closure と transition-coherent atlas data を阻む。
+
+この主張は repair-hitting の必要条件である。
+hit すれば repair が成功する、canonical vanishing が transition closure を含意する、actual repair synthesis がある、global minimal repair set がある、true `H^1` / Cech quotient / coboundary quotient がある、arbitrary atlas category がある、source extraction completeness や ArchMap correctness がある、とは主張しない。
+
+## 候補種別
+
+`finite residual repair-hitting theorem` / `obstruction-class-support` / `repair-necessity`
+
+## 依拠
+
+- Cycle 89: residual transition cut obstruction。
+- Cycle 92: residual obstruction class modulo cut-noise。
+- Cycle 95: residual cut-locus transport induced by atlas map laws。
+- Cycle 1: support-local repair hitting theorem の設計パターン。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+Cycle 92-95 は residual obstruction class の existence、noise-invariance、gauge/carrier transport、map-law induction を固定した。
+この候補は、その class を repair necessity へ戻す。
+new canonical class を vanish させるためには、old cut が unhit のまま persistence law で残っていてはならない。
+したがって repair は cut の active edge、residual-present source、residual-free target の少なくとも一箇所を触る必要がある。
+
+`ResidualCutHit` は constructive に「三箇所すべてが unhit ではない」と定義する。
+classical disjunction や repair success sufficiency は使わない。
+
+## 数学的興味
+
+semantic residual obstruction class を、単なる no-go certificate から repair hitting condition へ変換する。
+これは true cohomology theorem ではないが、nonzero obstruction が repair に強制する局所条件を finite atlas 上で証明するため、future semantic repair-gluing obstruction theorem の repair 側の中核補題になる。
+
+## GOAL への前進
+
+open genius target に対して、obstruction class が「局所的に何を hit しなければ消えないか」を theorem として固定した。
+transport/invariance tower から repair necessity へ一段進めた。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は residual-looking edge や violation を表示できる。
+しかし、それらは old/new atlas の persistence law の下で、new cut class vanishing が old residual cut hit を必要とすることを証明しない。
+AAT 側では、repair が residual obstruction を消したと主張するために、edge/source/target のどこを hit したかを証明可能な条件として要求できる。
+
+## SCORE 見込み
+
+- `score_reason`: obstruction class を repair hitting necessity へ進める。Cycle 92-95 の invariant/transport tower より repair 側に踏み込む strong genius-support node。
+- `dullness_risk`: persistence law を仮定しているため、repair success theorem ではない。selected witness と no-hit persistence、new nonzero obstruction、vanishing-forces-hit theorem を揃えて wrapper risk を下げる。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualCutRepairHitting.lean` で generic same-carrier theorem、selected frontier-to-flat witness、theorem package を証明する。
+
+## CS / SWE への帰結
+
+architecture repair が residual cut obstruction を解消したと主張するには、old cut の active edge、residual-present source、residual-free target のどこを変えたかを説明する必要がある。
+単に new dashboard が green になったという observation だけでは、old cut が unhit で persistence law を満たす場合に nonzero obstruction が残る。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualCutRepairHitting.lean` に固定した。
+
+- `ResidualCutHit`
+- `residualCutHit_of_edgeHit`
+- `residualCutHit_of_sourceHit`
+- `residualCutHit_of_targetHit`
+- `UnhitResidualCutPersists`
+- `AllOldResidualCutsHit`
+- `unhit_oldResidualCut_persists_newCut`
+- `unhit_oldResidualCut_preserves_newCanonicalNonzero`
+- `newCanonicalVanishes_forces_oldResidualCutHit`
+- `newCanonicalVanishes_forces_allOldResidualCutsHit`
+- `unhit_oldResidualCut_obstructs_newTransitionClosure`
+- `unhit_oldResidualCut_obstructs_newTransitionCoherentData`
+- `selectedFrontierFlatResidualCutPair`
+- `selectedFrontierFlatResidualCutPair_isCut`
+- `selectedNoHit_unhitResidualCutPersists`
+- `selectedNoHit_preserves_canonicalNonzero`
+- `selected_newCanonicalVanishes_requires_frontierFlatCutHit`
+- `selectedNoHit_obstructs_transitionClosure`
+- `selectedNoHit_obstructs_transitionCoherentData`
+- `semanticResidualCutRepairHitting_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualCutRepairHitting.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualCutRepairHitting`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic repair-hitting theorem 群は axiom-free。selected witness と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、same-carrier old/new finite semantic repair atlas skeleton、supplied bookkeeping predicates としての explicit `edgeHit` / `sourceHit` / `targetHit`、supplied unhit persistence law、vanishing implies old residual cuts are hit、unhit old cut preserves new nonzero obstruction、new closure/data no-go に限定する。
+unchecked: hit sufficiency、actual repair synthesis、global minimal repair set、vanishing-to-closure theorem、arbitrary atlas category/functoriality、true H1/Cech/coboundary quotient、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、whole-codebase quality。
+
+## 審判メモ
+
+- G1 A/B/C/D: local-pass/global-fail taxonomy と pre-H1 adapter も候補に上がったが、repair necessity に踏み込む residual cut repair-hitting theorem が breakthrough pressure に最も合うと判断。
+- G2 A/B/C: Candidate B を accept。Candidate A は wrapper risk が高く defer。base 86-90、expected final 176。genius unlock ではなく strong genius-support。
+- G2 revise 解決: `ResidualCutHit` を constructive no-unhit 形式にし、persistence outside hit loci は仮定として明記し、hit sufficiency / repair synthesis は主張しない境界に固定した。
+
+## 追加 required fields
+
+- `mathematical_interest`: residual obstruction class を repair hitting necessity へ変換する。
+- `goal_advancement`: transport/invariance tower から repair が必ず触るべき edge/source/target locus へ進めた。
+- `planned_theorem_names`: `newCanonicalVanishes_forces_allOldResidualCutsHit`, `unhit_oldResidualCut_preserves_newCanonicalNonzero`, `semanticResidualCutRepairHitting_package`
+- `visible_projection`: old/new finite atlas skeleton、repair-hit predicates、residual cut class vanishing。
+- `protected_structure`: residual transition cut locus、canonical residual cut class、unhit persistence、transition closure/data obstruction。
+- `exactness_or_minimality_claim`: vanishing forces hit under persistence。global minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: repair report that does not hit an old persistent residual cut cannot justify disappearance of the residual cut obstruction。
+- `previous_cycle_delta`: Cycle 95 の transport law induction の後、obstruction class を repair necessity theorem へ戻した。
+- `rival_stress_test`: rival は residual-looking edges を list できても、vanishing-to-hit necessity を theorem として要求できない。
+- `genius_potential`: strong support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の repair-hitting core lemma。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: nonzero residual obstruction が repair の hit locus を強制することを固定する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-map-laws.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-obstruction-class.md`
+- planned report section: `Cycle 96: Residual cut obstruction repair-hitting theorem`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 96 G1/G2 で residual cut obstruction repair-hitting theorem を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualCutRepairHitting.lean` に固定し、単体 `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 13166
+- total SCORE: 13342
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -100,8 +100,9 @@
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / invariance / genius-support: 172
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-invariance / genius-support: 176
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-induction / genius-support: 172
+  - semantic-obstruction / repair-necessity / finite-atlas-transition / obstruction-class-support / genius-support: 176
 - evidence portfolio:
-  - proved-in-research: 95
+  - proved-in-research: 96
 
 ## Phase synthesis
 
@@ -117,7 +118,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-95 件の Lean-proved research artifacts は、次の paper seed を形成している。
+96 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -141,6 +142,7 @@ certificate の基本単位は
 - semantic residual atlas gauge invariance は、raw edge family に harmless reverse-edge noise が混じっても same residual cut locus なら canonical obstruction class と nonzero obstruction reading が保存されることを示す。
 - semantic residual cut-locus transport は、finite carrier が変わっても supplied cut-preserving / cut-surjective map の下で canonical obstruction class と target no-go reading が移送されることを示す。
 - semantic residual atlas map laws は、edge preservation、residual-present preservation、residual-free preservation、target cut-data lift から residual cut-locus transport と canonical obstruction transport を誘導できることを示す。
+- semantic residual cut repair hitting は、old/new atlas 間で unhit cuts が persistence law を満たすなら、new canonical residual cut class の vanishing が old residual cut の edge/source/target hit を必要とすることを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -196,8 +198,9 @@ Cycle 92 後の total SCORE は 12646 であり、tracking Issue active threshol
 Cycle 93 後の total SCORE は 12818 であり、tracking Issue active threshold 15000 までは残り 2182 SCORE である。
 Cycle 94 後の total SCORE は 12994 であり、tracking Issue active threshold 15000 までは残り 2006 SCORE である。
 Cycle 95 後の total SCORE は 13166 であり、tracking Issue active threshold 15000 までは残り 1834 SCORE である。
+Cycle 96 後の total SCORE は 13342 であり、tracking Issue active threshold 15000 までは残り 1658 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 95 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 96 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -225,7 +228,8 @@ semantic residual obstruction one-preclass theorem、
 semantic residual obstruction class modulo cut-noise theorem、
 semantic residual atlas gauge invariance theorem、
 semantic residual cut-locus transport theorem、
-semantic residual atlas map law induction theorem を含む。
+semantic residual atlas map law induction theorem、
+semantic residual cut repair-hitting theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5021,4 +5025,84 @@ tooling runtime extraction, UI correctness, or whole-codebase quality.
 
 Cycle 95 後の total SCORE は 13166 であり、tracking Issue active threshold 15000 までは残り 1834 SCORE である。
 次 cycle では、residual-present/residual-free mismatch minimality、local-pass/global-fail taxonomy、finite H1-style adapter、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 96: Residual cut obstruction repair-hitting theorem
+
+```text
+candidate: Residual cut obstruction repair-hitting theorem
+candidate_type: finite residual repair-hitting theorem / obstruction-class-support / repair-necessity
+evidence_stage: proved-in-research
+base_score: 88
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 176
+category: semantic-obstruction / repair-necessity / finite-atlas-transition / obstruction-class-support / genius-support
+goal_delta: Cycle 92-95 の residual obstruction class / transport tower を、same-carrier old/new atlas 上の repair-hitting 必要条件へ戻した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、unhit residual cut persistence、new canonical vanishing forces old cut hit、unhit old cut preserves new nonzero obstruction、selected frontier-to-flat witness、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は residual-looking edges を list できるが、new residual cut class vanishing が old cut の edge/source/target hit を必要とすることを theorem として要求できない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualCutRepairHitting.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualCutRepairHitting`, and `lake build FormalAGResearch` passed. Axiom probe reported the generic repair-hitting theorem family axiom-free; selected witness and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: cross-carrier repair hitting via Cycle 95 map laws; local-pass/global-fail taxonomy after repair necessity; finite pre-H1 adapter; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualCutRepairHitting.lean`
+turns the residual cut obstruction class into a repair-hitting necessity
+theorem.  For same-carrier old/new finite semantic repair atlas skeletons,
+`edgeHit`, `sourceHit`, and `targetHit` mark the loci touched by a repair.
+These hit predicates are supplied bookkeeping predicates, not repair
+operations extracted from implementation diffs.
+`UnhitResidualCutPersists` says that an old residual cut survives into the new
+atlas if none of those three loci is hit.
+
+Under this explicit persistence law, Lean proves that an unhit old residual
+cut makes the new canonical residual cut class nonzero.  Therefore, if the new
+canonical residual cut class vanishes, every old residual cut must be hit at
+the edge, source, or target locus.  The theorem is stated constructively:
+`ResidualCutHit` means the three miss predicates cannot all hold at once.
+
+Lean also proves that an unhit old residual cut obstructs new transition
+closure and rules out new transition-coherent atlas data.  The selected
+witness specializes this to the frontier-to-flat residual cut: for any new
+selected-carrier atlas, vanishing of the new canonical residual cut class
+requires hitting the selected frontier-to-flat cut somewhere.
+
+Lean proves:
+
+- `ResidualCutHit`: constructive repair-hit predicate for a residual cut.
+- `residualCutHit_of_edgeHit`: an edge hit hits the residual cut.
+- `residualCutHit_of_sourceHit`: a source-index hit hits the residual cut.
+- `residualCutHit_of_targetHit`: a target-index hit hits the residual cut.
+- `UnhitResidualCutPersists`: unhit old cuts persist into the new atlas.
+- `AllOldResidualCutsHit`: all old residual cuts are hit.
+- `unhit_oldResidualCut_persists_newCut`: an unhit old cut persists as a new cut.
+- `unhit_oldResidualCut_preserves_newCanonicalNonzero`: an unhit old cut keeps the new canonical class nonzero.
+- `newCanonicalVanishes_forces_oldResidualCutHit`: new vanishing forces a given old cut to be hit.
+- `newCanonicalVanishes_forces_allOldResidualCutsHit`: new vanishing forces every old cut to be hit.
+- `unhit_oldResidualCut_obstructs_newTransitionClosure`: an unhit old cut obstructs new transition closure.
+- `unhit_oldResidualCut_obstructs_newTransitionCoherentData`: an unhit old cut rules out new transition-coherent data.
+- `selectedFrontierFlatResidualCutPair`: selected frontier-to-flat cut pair.
+- `selectedFrontierFlatResidualCutPair_isCut`: selected pair is a residual cut.
+- `selectedNoHit_unhitResidualCutPersists`: identity selected atlas with no hit loci preserves cuts.
+- `selectedNoHit_preserves_canonicalNonzero`: no-hit selected witness remains nonzero.
+- `selected_newCanonicalVanishes_requires_frontierFlatCutHit`: selected new vanishing requires hitting the frontier-to-flat cut.
+- `selectedNoHit_obstructs_transitionClosure`: no-hit selected witness obstructs transition closure.
+- `selectedNoHit_obstructs_transitionCoherentData`: no-hit selected witness rules out coherent data.
+- `semanticResidualCutRepairHitting_package`: theorem package.
+
+This cycle is a strong support node, not a `genius unlock`.  It proves a
+necessary repair-hitting condition under a supplied persistence law.  It does
+not prove that hits suffice for repair success, that canonical vanishing
+implies transition closure, that a global minimal repair set exists, that an
+actual repair can be synthesized, that an arbitrary atlas category exists, or
+that a true `H^1` / Cech / coboundary quotient has been built.  It does not
+claim source extraction completeness, ArchMap correctness, runtime repair
+synthesis, tooling runtime extraction, UI correctness, or whole-codebase
+quality.
+
+### Next Frontier
+
+Cycle 96 後の total SCORE は 13342 であり、tracking Issue active threshold 15000 までは残り 1658 SCORE である。
+次 cycle では、cross-carrier repair hitting via Cycle 95 map laws、local-pass/global-fail taxonomy after repair necessity、finite pre-H1 adapter、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 96 として、same-carrier old/new finite semantic repair atlas skeleton 上の residual cut repair-hitting theorem を追加します。old residual cut が edge/source/target hit loci の外で persistence law を満たすなら、new canonical residual cut class の vanishing は old residual cut hit を必要とします。tracking Issue は threshold 15000 継続のため close しません。

score ledger: +176、total 13166 -> 13342、remaining 1658。G3 formalization audit: pass。G3.5 ledger audit: pass。G4 score audit: accept +176 / strong genius-support node。

## 証明した定理

- `ResidualCutHit`
- `residualCutHit_of_edgeHit`
- `residualCutHit_of_sourceHit`
- `residualCutHit_of_targetHit`
- `UnhitResidualCutPersists`
- `AllOldResidualCutsHit`
- `unhit_oldResidualCut_persists_newCut`
- `unhit_oldResidualCut_preserves_newCanonicalNonzero`
- `newCanonicalVanishes_forces_oldResidualCutHit`
- `newCanonicalVanishes_forces_allOldResidualCutsHit`
- `unhit_oldResidualCut_obstructs_newTransitionClosure`
- `unhit_oldResidualCut_obstructs_newTransitionCoherentData`
- `selectedFrontierFlatResidualCutPair`
- `selectedFrontierFlatResidualCutPair_isCut`
- `selectedNoHit_unhitResidualCutPersists`
- `selectedNoHit_preserves_canonicalNonzero`
- `selected_newCanonicalVanishes_requires_frontierFlatCutHit`
- `selectedNoHit_obstructs_transitionClosure`
- `selectedNoHit_obstructs_transitionCoherentData`
- `semanticResidualCutRepairHitting_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-cut-repair-hitting.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualCutRepairHitting.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualCutRepairHitting`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check` / `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] Lean forbidden-token scan
- [x] `#print axioms` probe: generic repair-hitting theorem family は axiom-free。selected witness と package は標準 `propext` / `Quot.sound` のみ。

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

## Claim boundary

same-carrier old/new finite semantic repair atlas skeleton、supplied bookkeeping predicates としての explicit `edgeHit` / `sourceHit` / `targetHit`、supplied unhit persistence law、vanishing implies old residual cuts are hit、unhit old cut preserves new nonzero obstruction、new closure/data no-go に限定します。hit sufficiency、actual repair synthesis、global minimal repair set、vanishing-to-closure theorem、arbitrary atlas category/functoriality、true H1/Cech/coboundary quotient、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、whole-codebase quality は主張しません。