### PR TITLE
研究ループCycle97: mapped repair hittingを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -93,3 +93,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualAtlasGauge
 import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMorphism
 import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMapLaws
 import Formal.AG.Research.QualitySurface.SemanticResidualCutRepairHitting
+import Formal.AG.Research.QualitySurface.SemanticResidualMappedRepairHitting

--- a/Formal/AG/Research/QualitySurface/SemanticResidualMappedRepairHitting.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualMappedRepairHitting.lean
@@ -1,0 +1,515 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualCutRepairHitting
+
+/-!
+Cycle 97 evidence for `G-aat-quality-surface-01`.
+
+This file transports the Cycle 96 repair-hitting necessity theorem across
+finite carrier/schema changes.  A residual cut repair transport map carries
+old source-side hit bookkeeping predicates and preserves edge, residual-present,
+and residual-free data away from those hit loci.  Therefore an old residual cut
+that is unhit at edge/source/target maps to a new residual cut.  If the new
+canonical residual cut class vanishes, every old residual cut must be hit.
+
+The result remains a necessary condition.  It does not assert hit sufficiency,
+repair synthesis, global minimality, vanishing-to-closure, arbitrary atlas
+category/functoriality, true Cech/H1/coboundary quotient, source extraction
+completeness, ArchMap correctness, runtime repair synthesis, tooling runtime
+extraction, UI correctness, or whole-codebase quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualMappedRepairHitting
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasMorphism
+open SemanticResidualAtlasMapLaws
+open SemanticResidualCutRepairHitting
+
+/-! ## Cross-carrier repair transport maps -/
+
+/--
+A cross-carrier residual cut repair transport map preserves the three pieces
+of residual cut data away from supplied source-side hit loci.
+-/
+structure ResidualCutRepairTransportMap
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    (old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom)
+    (new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom) where
+  mapIndex : LeftIndex -> RightIndex
+  edgeHit : LeftIndex × LeftIndex -> Prop
+  sourceHit : LeftIndex -> Prop
+  targetHit : LeftIndex -> Prop
+  edge_preserving_unhit :
+    forall source target,
+      old.edge source target ->
+        Not (edgeHit (source, target)) ->
+          new.edge (mapIndex source) (mapIndex target)
+  residual_present_preserving_unhit :
+    forall index,
+      IndexedResidualPresentAt old.projection old.cover index ->
+        Not (sourceHit index) ->
+          IndexedResidualPresentAt new.projection new.cover
+            (mapIndex index)
+  residual_free_preserving_unhit :
+    forall index,
+      IndexedResidualFreeAt old.projection old.cover index ->
+        Not (targetHit index) ->
+          IndexedResidualFreeAt new.projection new.cover
+            (mapIndex index)
+
+/-- An unhit old residual cut maps to a new residual cut. -/
+theorem unhit_oldResidualCut_maps_to_newCut
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (transportMap : ResidualCutRepairTransportMap old new)
+    {pair : LeftIndex × LeftIndex}
+    (hcut : IsResidualTransitionCutPair old pair)
+    (hedge : Not (transportMap.edgeHit pair))
+    (hsource : Not (transportMap.sourceHit pair.1))
+    (htarget : Not (transportMap.targetHit pair.2)) :
+    IsResidualTransitionCutPair new
+      (mapResidualPair transportMap.mapIndex pair) := by
+  exact
+    ⟨transportMap.edge_preserving_unhit pair.1 pair.2
+        hcut.1 hedge,
+      transportMap.residual_present_preserving_unhit pair.1
+        hcut.2.1 hsource,
+      transportMap.residual_free_preserving_unhit pair.2
+        hcut.2.2 htarget⟩
+
+/-- An unhit old residual cut gives a nonzero new canonical cut class. -/
+theorem unhit_oldResidualCut_maps_to_newCanonicalNonzero
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (transportMap : ResidualCutRepairTransportMap old new)
+    {pair : LeftIndex × LeftIndex}
+    (hcut : IsResidualTransitionCutPair old pair)
+    (hedge : Not (transportMap.edgeHit pair))
+    (hsource : Not (transportMap.sourceHit pair.1))
+    (htarget : Not (transportMap.targetHit pair.2)) :
+    (canonicalResidualCutCochain new).CutNonzero := by
+  have hnewCut :
+      IsResidualTransitionCutPair new
+        (mapResidualPair transportMap.mapIndex pair) :=
+    unhit_oldResidualCut_maps_to_newCut
+      transportMap hcut hedge hsource htarget
+  exact ⟨mapResidualPair transportMap.mapIndex pair, hnewCut, hnewCut⟩
+
+/--
+If the new canonical cut class vanishes, the old source cut must be hit before
+transport.
+-/
+theorem newCanonicalVanishes_forces_mappedOldResidualCutHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (transportMap : ResidualCutRepairTransportMap old new)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes)
+    {pair : LeftIndex × LeftIndex}
+    (hcut : IsResidualTransitionCutPair old pair) :
+    ResidualCutHit
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit
+      pair := by
+  intro hunhit
+  have hnewCut :
+      IsResidualTransitionCutPair new
+        (mapResidualPair transportMap.mapIndex pair) :=
+    unhit_oldResidualCut_maps_to_newCut
+      transportMap hcut hunhit.1 hunhit.2.1 hunhit.2.2
+  exact
+    hvanish
+      (mapResidualPair transportMap.mapIndex pair)
+      hnewCut
+      hnewCut
+
+/-- New canonical vanishing forces all old residual cuts to be hit. -/
+theorem newCanonicalVanishes_forces_allMappedOldResidualCutsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (transportMap : ResidualCutRepairTransportMap old new)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes) :
+    AllOldResidualCutsHit
+      old
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit := by
+  intro pair hcut
+  exact
+    newCanonicalVanishes_forces_mappedOldResidualCutHit
+      transportMap hvanish hcut
+
+/-- An unhit old residual cut obstructs new transition closure after transport. -/
+theorem unhit_oldResidualCut_maps_to_newTransitionClosureObstruction
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (transportMap : ResidualCutRepairTransportMap old new)
+    {pair : LeftIndex × LeftIndex}
+    (hcut : IsResidualTransitionCutPair old pair)
+    (hedge : Not (transportMap.edgeHit pair))
+    (hsource : Not (transportMap.sourceHit pair.1))
+    (htarget : Not (transportMap.targetHit pair.2))
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (AtlasResidualTransitionClosed new transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain new)
+      (unhit_oldResidualCut_maps_to_newCanonicalNonzero
+        transportMap hcut hedge hsource htarget)
+      transition
+
+/-- An unhit old residual cut rules out new transition-coherent data after transport. -/
+theorem unhit_oldResidualCut_maps_to_newTransitionCoherentDataObstruction
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (transportMap : ResidualCutRepairTransportMap old new)
+    {pair : LeftIndex × LeftIndex}
+    (hcut : IsResidualTransitionCutPair old pair)
+    (hedge : Not (transportMap.edgeHit pair))
+    (hsource : Not (transportMap.sourceHit pair.1))
+    (htarget : Not (transportMap.targetHit pair.2))
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (Nonempty (TransitionCoherentAtlasData new transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (canonicalResidualCutCochain new)
+      (unhit_oldResidualCut_maps_to_newCanonicalNonzero
+        transportMap hcut hedge hsource htarget)
+      transition
+
+/-! ## Cycle-95 map-law bridge -/
+
+/--
+A Cycle-95 cut-inducing atlas map is a repair transport map for any supplied
+source-side hit bookkeeping predicates.
+-/
+def residualCutInducingAtlasMap_to_repairTransportMap
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop) :
+    ResidualCutRepairTransportMap old new where
+  mapIndex := atlasMap.mapIndex
+  edgeHit := edgeHit
+  sourceHit := sourceHit
+  targetHit := targetHit
+  edge_preserving_unhit := by
+    intro source target hedge _hunhit
+    exact atlasMap.edge_preserving source target hedge
+  residual_present_preserving_unhit := by
+    intro index hpresent _hunhit
+    exact atlasMap.residual_present_preserving index hpresent
+  residual_free_preserving_unhit := by
+    intro index hfree _hunhit
+    exact atlasMap.residual_free_preserving index hfree
+
+/-- A Cycle-95 cut-inducing map transports any unhit old cut to a new cut. -/
+theorem residualCutInducingAtlasMap_unhit_oldCut_maps_to_newCut
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    {pair : LeftIndex × LeftIndex}
+    (hcut : IsResidualTransitionCutPair old pair)
+    (hedge : Not (edgeHit pair))
+    (hsource : Not (sourceHit pair.1))
+    (htarget : Not (targetHit pair.2)) :
+    IsResidualTransitionCutPair new
+      (mapResidualPair atlasMap.mapIndex pair) := by
+  exact
+    unhit_oldResidualCut_maps_to_newCut
+      (residualCutInducingAtlasMap_to_repairTransportMap
+        atlasMap edgeHit sourceHit targetHit)
+      hcut hedge hsource htarget
+
+/--
+Under a Cycle-95 cut-inducing map, new canonical vanishing forces every old
+residual cut to be hit by the supplied source-side hit predicates.
+-/
+theorem residualCutInducingAtlasMap_newVanishes_forces_oldCutsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes) :
+    AllOldResidualCutsHit old edgeHit sourceHit targetHit := by
+  exact
+    newCanonicalVanishes_forces_allMappedOldResidualCutsHit
+      (residualCutInducingAtlasMap_to_repairTransportMap
+        atlasMap edgeHit sourceHit targetHit)
+      hvanish
+
+/-! ## Selected source-to-extended target witness -/
+
+/-- The selected-to-extended no-hit transport map. -/
+def selectedToExtendedNoHitRepairTransportMap :
+    ResidualCutRepairTransportMap
+      selectedFrontierFlatAtlasSkeleton
+      selectedExtendedFrontierFlatAtlasSkeleton :=
+  residualCutInducingAtlasMap_to_repairTransportMap
+    selectedToExtendedResidualCutInducingMap
+    selectedNoEdgeHit
+    selectedNoSourceHit
+    selectedNoTargetHit
+
+/-- The unhit selected frontier-to-flat cut maps to an extended target cut. -/
+theorem selectedToExtendedNoHit_maps_frontierFlatCut :
+    IsResidualTransitionCutPair
+      selectedExtendedFrontierFlatAtlasSkeleton
+      (mapResidualPair
+        selectedToExtendedNoHitRepairTransportMap.mapIndex
+        selectedFrontierFlatResidualCutPair) := by
+  exact
+    unhit_oldResidualCut_maps_to_newCut
+      selectedToExtendedNoHitRepairTransportMap
+      selectedFrontierFlatResidualCutPair_isCut
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+
+/-- The no-hit selected source cut remains nonzero in the extended target. -/
+theorem selectedToExtendedNoHit_preserves_extendedCanonicalNonzero :
+    (canonicalResidualCutCochain
+      selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    unhit_oldResidualCut_maps_to_newCanonicalNonzero
+      selectedToExtendedNoHitRepairTransportMap
+      selectedFrontierFlatResidualCutPair_isCut
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+
+/--
+For any source-side hit predicates, vanishing of the extended target canonical
+class forces the selected frontier-to-flat source cut to be hit.
+-/
+theorem selectedToExtended_newVanishes_requires_frontierFlatCutHit
+    {edgeHit :
+      SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+    {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop}
+    (hvanish :
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton).CutVanishes) :
+    ResidualCutHit
+      edgeHit
+      sourceHit
+      targetHit
+      selectedFrontierFlatResidualCutPair := by
+  exact
+    newCanonicalVanishes_forces_mappedOldResidualCutHit
+      (residualCutInducingAtlasMap_to_repairTransportMap
+        selectedToExtendedResidualCutInducingMap
+        edgeHit
+        sourceHit
+        targetHit)
+      hvanish
+      selectedFrontierFlatResidualCutPair_isCut
+
+/-- The no-hit selected source cut obstructs extended target transition closure. -/
+theorem selectedToExtendedNoHit_obstructs_extendedTransitionClosure
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedExtendedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    unhit_oldResidualCut_maps_to_newTransitionClosureObstruction
+      selectedToExtendedNoHitRepairTransportMap
+      selectedFrontierFlatResidualCutPair_isCut
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+      transition
+
+/-- The no-hit selected source cut rules out extended target coherent data. -/
+theorem selectedToExtendedNoHit_obstructs_extendedTransitionCoherentData
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedExtendedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    unhit_oldResidualCut_maps_to_newTransitionCoherentDataObstruction
+      selectedToExtendedNoHitRepairTransportMap
+      selectedFrontierFlatResidualCutPair_isCut
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-97 theorem package: source-side repair-hit necessity transports across
+finite carrier/schema changes when unhit edge/present/free data are preserved.
+-/
+theorem semanticResidualMappedRepairHitting_package :
+    (forall {LeftIndex : Type w}
+      {LeftAtom : Type u}
+      {RightIndex : Type x}
+      {RightAtom : Type v}
+      {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+      {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+      forall transportMap : ResidualCutRepairTransportMap old new,
+      forall pair : LeftIndex × LeftIndex,
+        IsResidualTransitionCutPair old pair ->
+          Not (transportMap.edgeHit pair) ->
+            Not (transportMap.sourceHit pair.1) ->
+              Not (transportMap.targetHit pair.2) ->
+                IsResidualTransitionCutPair new
+                  (mapResidualPair transportMap.mapIndex pair)) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall transportMap : ResidualCutRepairTransportMap old new,
+        forall pair : LeftIndex × LeftIndex,
+          IsResidualTransitionCutPair old pair ->
+            Not (transportMap.edgeHit pair) ->
+              Not (transportMap.sourceHit pair.1) ->
+                Not (transportMap.targetHit pair.2) ->
+                  (canonicalResidualCutCochain new).CutNonzero) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall transportMap : ResidualCutRepairTransportMap old new,
+        (canonicalResidualCutCochain new).CutVanishes ->
+          AllOldResidualCutsHit
+            old
+            transportMap.edgeHit
+            transportMap.sourceHit
+            transportMap.targetHit) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom},
+        forall _atlasMap : ResidualCutInducingAtlasMap old new,
+        forall edgeHit : LeftIndex × LeftIndex -> Prop,
+        forall sourceHit targetHit : LeftIndex -> Prop,
+        (canonicalResidualCutCochain new).CutVanishes ->
+          AllOldResidualCutsHit old edgeHit sourceHit targetHit) /\
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (forall
+        {edgeHit :
+          SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+        {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop},
+        (canonicalResidualCutCochain
+          selectedExtendedFrontierFlatAtlasSkeleton).CutVanishes ->
+            ResidualCutHit
+              edgeHit
+              sourceHit
+              targetHit
+              selectedFrontierFlatResidualCutPair) /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedExtendedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedExtendedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} transportMap pair hcut hedge hsource htarget =>
+        unhit_oldResidualCut_maps_to_newCut
+          transportMap hcut hedge hsource htarget,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} transportMap pair hcut hedge hsource htarget =>
+        unhit_oldResidualCut_maps_to_newCanonicalNonzero
+          transportMap hcut hedge hsource htarget,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} transportMap hvanish =>
+        newCanonicalVanishes_forces_allMappedOldResidualCutsHit
+          transportMap hvanish,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} atlasMap edgeHit sourceHit targetHit hvanish =>
+        residualCutInducingAtlasMap_newVanishes_forces_oldCutsHit
+          atlasMap edgeHit sourceHit targetHit hvanish,
+      selectedToExtendedNoHit_preserves_extendedCanonicalNonzero,
+      fun {_edgeHit} {_sourceHit} {_targetHit} hvanish =>
+        selectedToExtended_newVanishes_requires_frontierFlatCutHit
+          hvanish,
+      selectedToExtendedNoHit_obstructs_extendedTransitionClosure,
+      selectedToExtendedNoHit_obstructs_extendedTransitionCoherentData⟩
+
+end SemanticResidualMappedRepairHitting
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-repair-hitting.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-repair-hitting.md
@@ -1,0 +1,145 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: cross-carrier repair necessity / mapped residual cut persistence / genius-support convergence
+candidate_type: cross-carrier residual repair-hitting theorem / obstruction-class-support / repair-necessity
+capability_category: semantic-obstruction / repair-necessity / cut-locus-transport / finite-atlas-transition / genius-support
+expected_base_score: 90
+expected_evidence_multiplier: 2.0
+expected_final_score: 180
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can remap diagnostics between schemas, but they do not prove that unhit edge/present/free preservation across a carrier map transports repair-hitting necessity for residual cut obstruction classes.
+origin: cycle-97
+tags: [quality-surface, semantic-repair, residual-cut, repair-hitting, carrier-change, obstruction-transport, genius-support]
+created: 2026-06-23
+cycle: 97
+lean: proved-in-research
+planned_report_section: "Cycle 97: Cross-carrier residual cut repair-hitting transport"
+---
+
+# Cross-Carrier Residual Cut Repair-Hitting Transport
+
+## 主張
+
+Cycle 96 の same-carrier repair-hitting necessity を、finite carrier / schema change をまたぐ形へ持ち上げる。
+`ResidualCutRepairTransportMap` は old atlas から new atlas への `mapIndex` と、source-side supplied bookkeeping predicates としての `edgeHit`、`sourceHit`、`targetHit` を持つ。
+この map は、hit されていない old active edge、residual-present source、residual-free target を new 側へ保存する。
+したがって unhit old residual cut は new residual cut へ写り、new canonical residual cut class を nonzero にする。
+
+その結果、new canonical residual cut class が vanishes するなら、old residual cut は source-side の edge/source/target hit predicate のどこかで hit されていなければならない。
+また、unhit old residual cut は new transition closure と new transition-coherent atlas data を阻む。
+
+Cycle 95 の `ResidualCutInducingAtlasMap` は、hit predicates に依存しない保存 law を持つため、任意の source-side hit bookkeeping predicates に対して `ResidualCutRepairTransportMap` を誘導する。
+この bridge は補助 corollary であり、主成果は generic `ResidualCutRepairTransportMap` の unhit preservation laws から repair-hit necessity を導く theorem である。
+selected witness では `selectedToExtendedResidualCutInducingMap` と `Option SelectedSemanticOverlapIndex` extended carrier を用い、selected frontier-to-flat cut が no-hit のまま extended target obstruction として残ることを示す。
+
+この主張は repair-hitting の必要条件である。
+hit sufficiency、actual repair synthesis、global minimal repair set、vanishing-to-closure、arbitrary atlas category/functoriality、true `H^1` / Cech quotient / coboundary quotient、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、UI correctness、whole-codebase quality は含まない。
+
+## 候補種別
+
+`cross-carrier residual repair-hitting theorem` / `obstruction-class-support` / `repair-necessity`
+
+## 依拠
+
+- Cycle 95: residual cut-locus transport induced by atlas map laws。
+- Cycle 96: same-carrier residual cut repair-hitting theorem。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+単に cross-carrier persistence を field として仮定するだけなら Cycle 96 の wrapper になる。
+この候補では、unhit edge preservation、unhit residual-present preservation、unhit residual-free preservation という三 law から mapped residual cut preservation を証明する。
+さらに Cycle 95 の unconditional preservation map が、この unhit repair transport map を任意の source-side hit predicates に対して誘導することを示す。
+
+## 数学的興味
+
+repair-hitting necessity が同一 carrier の artifact ではなく、finite carrier/schema change に沿って移送できることを示す。
+これは true functorial cohomology ではないが、future semantic repair-gluing obstruction theorem が diagnostic schema refinement / carrier extension をまたいでも repair hit obligations を保持するための中核補題になる。
+
+## GOAL への前進
+
+Cycle 96 で得た `obstruction vanishing -> old cut hit` を、Cycle 95 の map-law transport と結合した。
+これにより、repair necessity が presentation/carrier change に耐えることを Lean theorem として固定した。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は診断を別 schema へ表示し直せる。
+しかし、それらは unhit edge/present/free preservation laws から、new canonical vanishing が source-side old cut hit を必要とすることを証明しない。
+AAT 側では、schema change 後に residual obstruction が消えたと主張するためにも、source-side hit obligations を失わない条件を theorem として要求できる。
+
+## SCORE 見込み
+
+- `score_reason`: same-carrier repair-hitting necessity を cross-carrier map-law transport へ上げる。Cycle 95 と Cycle 96 の合成だが、unhit edge/present/free laws から mapped cut preservation を直接導き、selected extended witness まで持つため high support。
+- `dullness_risk`: direct persistence field だけなら wrapper。三 preservation law から cut preservation を導き、Cycle 95 bridge と selected witness を入れて回避する。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualMappedRepairHitting.lean` で transport map、mapped nonzero/no-go、target vanishing forces source hit、Cycle 95 bridge、selected Option witness、theorem package を証明する。
+
+## CS / SWE への帰結
+
+architecture repair の証拠が schema migration や diagnostic carrier extension をまたぐ場合でも、old residual cut が unhit のまま new schema へ保存されるなら obstruction は残る。
+new dashboard が green になるには、source-side の old cut hit bookkeeping を説明できなければならない。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualMappedRepairHitting.lean` に固定した。
+
+- `ResidualCutRepairTransportMap`
+- `unhit_oldResidualCut_maps_to_newCut`
+- `unhit_oldResidualCut_maps_to_newCanonicalNonzero`
+- `newCanonicalVanishes_forces_mappedOldResidualCutHit`
+- `newCanonicalVanishes_forces_allMappedOldResidualCutsHit`
+- `unhit_oldResidualCut_maps_to_newTransitionClosureObstruction`
+- `unhit_oldResidualCut_maps_to_newTransitionCoherentDataObstruction`
+- `residualCutInducingAtlasMap_to_repairTransportMap`
+- `residualCutInducingAtlasMap_unhit_oldCut_maps_to_newCut`
+- `residualCutInducingAtlasMap_newVanishes_forces_oldCutsHit`
+- `selectedToExtendedNoHitRepairTransportMap`
+- `selectedToExtendedNoHit_maps_frontierFlatCut`
+- `selectedToExtendedNoHit_preserves_extendedCanonicalNonzero`
+- `selectedToExtended_newVanishes_requires_frontierFlatCutHit`
+- `selectedToExtendedNoHit_obstructs_extendedTransitionClosure`
+- `selectedToExtendedNoHit_obstructs_extendedTransitionCoherentData`
+- `semanticResidualMappedRepairHitting_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualMappedRepairHitting.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualMappedRepairHitting`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic cross-carrier repair-hitting theorem 群と Cycle 95 bridge は axiom-free。selected witness と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、finite old/new atlas skeletons with possibly different carriers、source-side supplied bookkeeping hit predicates、unhit edge/present/free preservation laws、new canonical residual cut class nonzero / vanishing、target transition closure / coherent data no-go に限定する。
+unchecked: hit sufficiency、actual repair synthesis、global minimal repair set、vanishing-to-closure theorem、arbitrary atlas category/functoriality、true H1/Cech/coboundary quotient、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、whole-codebase quality。
+
+## 審判メモ
+
+- G1 A/B: cross-carrier repair-hitting transport を採択候補として推奨。direct persistence field だけでは弱いので、unhit edge/present/free preservation laws から mapped cut を導く shape に修正。
+- G2 A: accept / base 90 / final 180。direct law-derived transport、Cycle 95 bridge、selected witness があれば 90 を支持。
+- G2 B: accept / base 88、upper 180。wrapper risk を避けるには三 preservation law から cut preservation を導くことが必須。
+- G2 revise 解決: `ResidualCutRepairTransportMap` は mapped cut persistence を field にせず、unhit edge/present/free preservation fields から `unhit_oldResidualCut_maps_to_newCut` を証明した。
+
+## 追加 required fields
+
+- `mathematical_interest`: repair-hitting necessity を finite carrier/schema change に沿って transport する。
+- `goal_advancement`: same-carrier repair hit obligation を cross-carrier map-law obligation へ上げた。
+- `planned_theorem_names`: `newCanonicalVanishes_forces_allMappedOldResidualCutsHit`, `residualCutInducingAtlasMap_to_repairTransportMap`, `semanticResidualMappedRepairHitting_package`
+- `visible_projection`: source-side hit predicates、carrier/schema map、new canonical residual cut class。
+- `protected_structure`: residual transition cut locus、unhit edge/present/free preservation、target nonzero obstruction、source-side hit necessity。
+- `exactness_or_minimality_claim`: target vanishing forces source old cuts hit under unhit preservation。global minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: schema change that preserves unhit residual cut data cannot erase source repair-hit obligations。
+- `previous_cycle_delta`: Cycle 96 の same-carrier repair-hitting theorem を Cycle 95 map-law transport と結合した。
+- `rival_stress_test`: rival は diagnostics を remap できても、source-side hit obligations が target vanishing に必要であることを証明しない。
+- `genius_potential`: strong support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の cross-carrier repair-hitting lemma。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: repair hit obligation が finite carrier/schema change に耐えることを固定する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-cut-repair-hitting.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-map-laws.md`
+- planned report section: `Cycle 97: Cross-carrier residual cut repair-hitting transport`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 97 G1/G2 で cross-carrier residual cut repair-hitting transport を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualMappedRepairHitting.lean` に固定し、単体 `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 13342
+- total SCORE: 13522
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -101,8 +101,9 @@
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-invariance / genius-support: 176
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-induction / genius-support: 172
   - semantic-obstruction / repair-necessity / finite-atlas-transition / obstruction-class-support / genius-support: 176
+  - semantic-obstruction / repair-necessity / cut-locus-transport / finite-atlas-transition / genius-support: 180
 - evidence portfolio:
-  - proved-in-research: 96
+  - proved-in-research: 97
 
 ## Phase synthesis
 
@@ -118,7 +119,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-96 件の Lean-proved research artifacts は、次の paper seed を形成している。
+97 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -143,6 +144,7 @@ certificate の基本単位は
 - semantic residual cut-locus transport は、finite carrier が変わっても supplied cut-preserving / cut-surjective map の下で canonical obstruction class と target no-go reading が移送されることを示す。
 - semantic residual atlas map laws は、edge preservation、residual-present preservation、residual-free preservation、target cut-data lift から residual cut-locus transport と canonical obstruction transport を誘導できることを示す。
 - semantic residual cut repair hitting は、old/new atlas 間で unhit cuts が persistence law を満たすなら、new canonical residual cut class の vanishing が old residual cut の edge/source/target hit を必要とすることを示す。
+- semantic residual mapped repair hitting は、unhit edge/present/free preservation laws により、repair-hitting necessity が finite carrier/schema change をまたいで transport されることを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -199,8 +201,9 @@ Cycle 93 後の total SCORE は 12818 であり、tracking Issue active threshol
 Cycle 94 後の total SCORE は 12994 であり、tracking Issue active threshold 15000 までは残り 2006 SCORE である。
 Cycle 95 後の total SCORE は 13166 であり、tracking Issue active threshold 15000 までは残り 1834 SCORE である。
 Cycle 96 後の total SCORE は 13342 であり、tracking Issue active threshold 15000 までは残り 1658 SCORE である。
+Cycle 97 後の total SCORE は 13522 であり、tracking Issue active threshold 15000 までは残り 1478 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 96 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 97 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -229,7 +232,8 @@ semantic residual obstruction class modulo cut-noise theorem、
 semantic residual atlas gauge invariance theorem、
 semantic residual cut-locus transport theorem、
 semantic residual atlas map law induction theorem、
-semantic residual cut repair-hitting theorem を含む。
+semantic residual cut repair-hitting theorem、
+semantic residual mapped repair-hitting theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5105,4 +5109,82 @@ quality.
 
 Cycle 96 後の total SCORE は 13342 であり、tracking Issue active threshold 15000 までは残り 1658 SCORE である。
 次 cycle では、cross-carrier repair hitting via Cycle 95 map laws、local-pass/global-fail taxonomy after repair necessity、finite pre-H1 adapter、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 97: Cross-carrier residual cut repair-hitting transport
+
+```text
+candidate: Cross-carrier residual cut repair-hitting transport
+candidate_type: cross-carrier residual repair-hitting theorem / obstruction-class-support / repair-necessity
+evidence_stage: proved-in-research
+base_score: 90
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 180
+category: semantic-obstruction / repair-necessity / cut-locus-transport / finite-atlas-transition / genius-support
+goal_delta: Cycle 96 の same-carrier repair-hitting necessity を、Cycle 95 の map-law transport と結合し、finite carrier/schema change をまたぐ source-side hit obligation へ上げた。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、cross-carrier residual cut repair transport map、unhit edge/present/free preservation laws、mapped cut nonzero/no-go、target vanishing forces source hit、Cycle 95 inducing-map bridge、selected extended-carrier witness、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は diagnostics を remap できるが、unhit edge/present/free preservation laws から source-side repair hit obligations を target vanishing の必要条件として transport する Lean artifact は持たない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualMappedRepairHitting.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualMappedRepairHitting`, and `lake build FormalAGResearch` passed. Axiom probe reported generic cross-carrier repair-hitting theorem family and Cycle 95 bridge axiom-free; selected witness and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: local-pass/global-fail taxonomy after repair necessity; finite pre-H1 status-drop adapter; cross-carrier minimality; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualMappedRepairHitting.lean`
+transports Cycle 96 repair-hitting necessity across finite carrier/schema
+changes.  `ResidualCutRepairTransportMap` contains an old-to-new index map and
+source-side supplied hit predicates.  Its laws preserve active edges,
+residual-present sources, and residual-free targets whenever the corresponding
+old edge/source/target loci are unhit.
+
+From those three unhit preservation laws, Lean proves that an unhit old
+residual cut maps to a new residual cut.  Therefore the new canonical residual
+cut class is nonzero, and it obstructs new transition closure and
+transition-coherent atlas data.  Conversely, if the new canonical residual cut
+class vanishes, each old residual cut must be hit by the source-side
+bookkeeping predicates.
+
+Cycle 95's `ResidualCutInducingAtlasMap` induces a
+`ResidualCutRepairTransportMap` for arbitrary source-side hit predicates,
+because unconditional edge/present/free preservation is stronger than unhit
+preservation.  This bridge is a supporting corollary; the main result is the
+generic `ResidualCutRepairTransportMap` theorem from unhit preservation laws.
+The selected witness uses the selected-to-extended Option
+carrier map: the no-hit selected frontier-to-flat cut maps to an extended
+target residual cut, remains nonzero, and obstructs extended transition
+closure/data.
+
+Lean proves:
+
+- `ResidualCutRepairTransportMap`: cross-carrier repair transport map with unhit preservation laws.
+- `unhit_oldResidualCut_maps_to_newCut`: unhit old cut maps to a new cut.
+- `unhit_oldResidualCut_maps_to_newCanonicalNonzero`: unhit old cut makes target canonical class nonzero.
+- `newCanonicalVanishes_forces_mappedOldResidualCutHit`: target vanishing forces a source old cut hit.
+- `newCanonicalVanishes_forces_allMappedOldResidualCutsHit`: target vanishing forces all source old cuts hit.
+- `unhit_oldResidualCut_maps_to_newTransitionClosureObstruction`: unhit old cut obstructs target transition closure.
+- `unhit_oldResidualCut_maps_to_newTransitionCoherentDataObstruction`: unhit old cut rules out target coherent data.
+- `residualCutInducingAtlasMap_to_repairTransportMap`: Cycle 95 inducing map gives repair transport map.
+- `residualCutInducingAtlasMap_unhit_oldCut_maps_to_newCut`: inducing map transports unhit old cuts.
+- `residualCutInducingAtlasMap_newVanishes_forces_oldCutsHit`: target vanishing under inducing map forces source cuts hit.
+- `selectedToExtendedNoHitRepairTransportMap`: selected-to-extended no-hit transport map.
+- `selectedToExtendedNoHit_maps_frontierFlatCut`: selected no-hit cut maps to extended target cut.
+- `selectedToExtendedNoHit_preserves_extendedCanonicalNonzero`: selected no-hit cut remains nonzero in extended target.
+- `selectedToExtended_newVanishes_requires_frontierFlatCutHit`: extended target vanishing forces selected source cut hit.
+- `selectedToExtendedNoHit_obstructs_extendedTransitionClosure`: selected no-hit source cut obstructs extended target closure.
+- `selectedToExtendedNoHit_obstructs_extendedTransitionCoherentData`: selected no-hit source cut rules out extended target coherent data.
+- `semanticResidualMappedRepairHitting_package`: theorem package.
+
+This cycle is a strong support node, not a `genius unlock`.  It proves
+cross-carrier repair-hit necessity under explicit unhit preservation laws.  It
+does not prove hit sufficiency, repair synthesis, global minimality,
+vanishing-to-closure, arbitrary atlas category/functoriality, true `H^1` /
+Cech / coboundary quotient, source extraction completeness, ArchMap
+correctness, runtime repair synthesis, tooling runtime extraction, UI
+correctness, or whole-codebase quality.
+
+### Next Frontier
+
+Cycle 97 後の total SCORE は 13522 であり、tracking Issue active threshold 15000 までは残り 1478 SCORE である。
+次 cycle では、local-pass/global-fail taxonomy after repair necessity、finite pre-H1 status-drop adapter、cross-carrier minimality、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 97 として、different-carrier old/new atlas skeleton 上の cross-carrier residual cut repair-hitting transport theorem を追加します。source-side supplied hit predicates と unhit edge/present/free preservation laws から、unhit old residual cut が target cut へ写り、target canonical vanishing が source old cut hit を必要とすることを証明します。tracking Issue は threshold 15000 継続のため close しません。

score ledger: +180、total 13342 -> 13522、remaining 1478。G3 formalization audit: pass。G3.5 ledger audit: pass。G4 score audit: confirm +180 / strong genius-support node。

## 証明した定理

- `ResidualCutRepairTransportMap`
- `unhit_oldResidualCut_maps_to_newCut`
- `unhit_oldResidualCut_maps_to_newCanonicalNonzero`
- `newCanonicalVanishes_forces_mappedOldResidualCutHit`
- `newCanonicalVanishes_forces_allMappedOldResidualCutsHit`
- `unhit_oldResidualCut_maps_to_newTransitionClosureObstruction`
- `unhit_oldResidualCut_maps_to_newTransitionCoherentDataObstruction`
- `residualCutInducingAtlasMap_to_repairTransportMap`
- `residualCutInducingAtlasMap_unhit_oldCut_maps_to_newCut`
- `residualCutInducingAtlasMap_newVanishes_forces_oldCutsHit`
- `selectedToExtendedNoHitRepairTransportMap`
- `selectedToExtendedNoHit_maps_frontierFlatCut`
- `selectedToExtendedNoHit_preserves_extendedCanonicalNonzero`
- `selectedToExtended_newVanishes_requires_frontierFlatCutHit`
- `selectedToExtendedNoHit_obstructs_extendedTransitionClosure`
- `selectedToExtendedNoHit_obstructs_extendedTransitionCoherentData`
- `semanticResidualMappedRepairHitting_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-repair-hitting.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualMappedRepairHitting.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualMappedRepairHitting`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check` / `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] Lean forbidden-token scan
- [x] `#print axioms` probe: generic cross-carrier repair-hitting theorem family and Cycle 95 bridge は axiom-free。selected witness と package は標準 `propext` / `Quot.sound` のみ。

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

## Claim boundary

finite old/new atlas skeletons with possibly different carriers、source-side supplied bookkeeping hit predicates、unhit edge/present/free preservation laws、target canonical residual cut class nonzero / vanishing、target transition closure / coherent data no-go に限定します。hit sufficiency、actual repair synthesis、global minimal repair set、vanishing-to-closure theorem、arbitrary atlas category/functoriality、true H1/Cech/coboundary quotient、source extraction completeness、ArchMap correctness、runtime repair synthesis、tooling runtime extraction、whole-codebase quality は主張しません。