### PR TITLE
研究ループCycle98: status drop adapterを追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -94,3 +94,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMorphism
 import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMapLaws
 import Formal.AG.Research.QualitySurface.SemanticResidualCutRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualMappedRepairHitting
+import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropAdapter

--- a/Formal/AG/Research/QualitySurface/SemanticResidualStatusDropAdapter.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualStatusDropAdapter.lean
@@ -1,0 +1,443 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualMappedRepairHitting
+
+/-!
+Cycle 98 evidence for `G-aat-quality-surface-01`.
+
+This file builds a finite residual status-drop adapter.  A supplied exact
+boolean residual status reading records residual-present indices as `true` and
+residual-free indices as `false`.  Under such a reading, residual transition
+cuts are exactly active edges whose status drops from `true` to `false`.
+
+The adapter is deliberately finite and status-based.  It is not a true H1
+class, does not construct a Cech or coboundary quotient, does not prove
+vanishing-to-closure, and does not assert source extraction completeness,
+repair synthesis, ArchMap correctness, runtime/tooling/UI correctness, or
+whole-codebase quality.
+-/
+
+universe u w
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualStatusDropAdapter
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasGauge
+open SemanticResidualCutRepairHitting
+open SemanticResidualMappedRepairHitting
+
+/-! ## Exact boolean residual status readings -/
+
+/-- Residual-present and residual-free are mutually exclusive at an index. -/
+theorem indexedResidualPresent_not_free
+    {Index : Type w}
+    {Atom : Type u}
+    {projection : Index -> Atom -> BridgeComponent}
+    {cover : Index -> HandoffCechCover}
+    {index : Index}
+    (hpresent : IndexedResidualPresentAt projection cover index) :
+    Not (IndexedResidualFreeAt projection cover index) := by
+  intro hfree
+  rcases hpresent with ⟨residual, hresidual⟩
+  exact hfree residual hresidual
+
+/--
+A supplied exact boolean residual status reading for a finite atlas.
+`true` means residual-present; `false` means residual-free.
+-/
+structure ResidualBooleanStatusReading
+    {Index : Type w}
+    {Atom : Type u}
+    (atlas : FiniteSemanticRepairAtlasSkeleton Index Atom) where
+  status : Index -> Bool
+  present_iff_true :
+    forall index,
+      IndexedResidualPresentAt atlas.projection atlas.cover index <->
+        status index = true
+  free_iff_false :
+    forall index,
+      IndexedResidualFreeAt atlas.projection atlas.cover index <->
+        status index = false
+
+/-- An active edge whose supplied residual status drops from true to false. -/
+def ResidualStatusDropPair
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas)
+    (pair : Index × Index) : Prop :=
+  atlas.edge pair.1 pair.2 /\
+    reading.status pair.1 = true /\
+      reading.status pair.2 = false
+
+/-- A cochain supported on status-drop active edges. -/
+def residualStatusDropCochain
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas) :
+    ResidualCutCochain atlas where
+  support := ResidualStatusDropPair reading
+
+/-- Exact status-drop pairs are exactly residual transition cut pairs. -/
+theorem residualStatusDropPair_iff_residualCutPair
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas)
+    (pair : Index × Index) :
+    ResidualStatusDropPair reading pair <->
+      IsResidualTransitionCutPair atlas pair := by
+  constructor
+  · intro hdrop
+    exact
+      ⟨hdrop.1,
+        (reading.present_iff_true pair.1).mpr hdrop.2.1,
+        (reading.free_iff_false pair.2).mpr hdrop.2.2⟩
+  · intro hcut
+    exact
+      ⟨hcut.1,
+        (reading.present_iff_true pair.1).mp hcut.2.1,
+        (reading.free_iff_false pair.2).mp hcut.2.2⟩
+
+/-- The status-drop cochain is cut-noise equivalent to the canonical cochain. -/
+theorem canonicalResidualCutCochain_cutNoiseEquivalent_statusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas) :
+    CutNoiseEquivalent
+      (canonicalResidualCutCochain atlas)
+      (residualStatusDropCochain reading) := by
+  intro pair hcut
+  constructor
+  · intro _hsupport
+    exact
+      (residualStatusDropPair_iff_residualCutPair
+        reading pair).mpr hcut
+  · intro _hdrop
+    exact hcut
+
+/-! ## Vanishing and nonzero status-drop criteria -/
+
+/-- No active edge has a true-to-false residual status drop. -/
+def NoResidualStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas) : Prop :=
+  forall pair : Index × Index,
+    atlas.edge pair.1 pair.2 ->
+      Not
+        (reading.status pair.1 = true /\
+          reading.status pair.2 = false)
+
+/-- Some active edge has a true-to-false residual status drop. -/
+def ExistsResidualStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas) : Prop :=
+  exists pair : Index × Index,
+    atlas.edge pair.1 pair.2 /\
+      reading.status pair.1 = true /\
+        reading.status pair.2 = false
+
+/-- Status-drop cochain vanishing is exactly absence of active true-to-false drops. -/
+theorem residualStatusDropCochain_vanishes_iff_noStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas) :
+    (residualStatusDropCochain reading).CutVanishes <->
+      NoResidualStatusDrop reading := by
+  constructor
+  · intro hvanish pair hedge hdrop
+    have hsupport : (residualStatusDropCochain reading).support pair :=
+      ⟨hedge, hdrop⟩
+    have hcut :
+        IsResidualTransitionCutPair atlas pair :=
+      (residualStatusDropPair_iff_residualCutPair
+        reading pair).mp hsupport
+    exact hvanish pair hcut hsupport
+  · intro hno pair _hcut hsupport
+    exact hno pair hsupport.1 hsupport.2
+
+/-- Status-drop cochain nonzero is exactly existence of an active true-to-false drop. -/
+theorem residualStatusDropCochain_nonzero_iff_existsStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas) :
+    (residualStatusDropCochain reading).CutNonzero <->
+      ExistsResidualStatusDrop reading := by
+  constructor
+  · intro hnonzero
+    rcases hnonzero with ⟨pair, _hcut, hsupport⟩
+    exact ⟨pair, hsupport.1, hsupport.2.1, hsupport.2.2⟩
+  · intro hdrop
+    rcases hdrop with ⟨pair, hedge, hsource, htarget⟩
+    have hsupport : (residualStatusDropCochain reading).support pair :=
+      ⟨hedge, hsource, htarget⟩
+    have hcut :
+        IsResidualTransitionCutPair atlas pair :=
+      (residualStatusDropPair_iff_residualCutPair
+        reading pair).mp hsupport
+    exact ⟨pair, hcut, hsupport⟩
+
+/-- Canonical residual cut-class vanishing is no true-to-false status drop. -/
+theorem canonicalResidualCutClass_vanishes_iff_noStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas) :
+    (canonicalResidualCutCochain atlas).CutVanishes <->
+      NoResidualStatusDrop reading := by
+  exact
+    (cutNoiseEquivalent_preserves_cutVanishes
+      (canonicalResidualCutCochain_cutNoiseEquivalent_statusDrop reading)).trans
+      (residualStatusDropCochain_vanishes_iff_noStatusDrop reading)
+
+/-- Canonical residual cut-class nonzero is existence of a true-to-false status drop. -/
+theorem canonicalResidualCutClass_nonzero_iff_existsStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas) :
+    (canonicalResidualCutCochain atlas).CutNonzero <->
+      ExistsResidualStatusDrop reading := by
+  exact
+    (cutNoiseEquivalent_preserves_cutNonzero
+      (canonicalResidualCutCochain_cutNoiseEquivalent_statusDrop reading)).trans
+      (residualStatusDropCochain_nonzero_iff_existsStatusDrop reading)
+
+/-- A status drop obstructs residual transition closure. -/
+theorem existsStatusDrop_obstructs_atlasTransitionClosure
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas)
+    (hdrop : ExistsResidualStatusDrop reading)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (AtlasResidualTransitionClosed atlas transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain atlas)
+      ((canonicalResidualCutClass_nonzero_iff_existsStatusDrop
+        reading).mpr hdrop)
+      transition
+
+/-- A status drop rules out transition-coherent atlas data. -/
+theorem existsStatusDrop_obstructs_transitionCoherentData
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas)
+    (hdrop : ExistsResidualStatusDrop reading)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (Nonempty (TransitionCoherentAtlasData atlas transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (canonicalResidualCutCochain atlas)
+      ((canonicalResidualCutClass_nonzero_iff_existsStatusDrop
+        reading).mpr hdrop)
+      transition
+
+/-! ## Selected status-drop witness -/
+
+/-- The selected residual status reads repair-frontier as present and flat as free. -/
+def selectedFrontierFlatResidualStatus :
+    SelectedSemanticOverlapIndex -> Bool
+  | SelectedSemanticOverlapIndex.flat => false
+  | SelectedSemanticOverlapIndex.repairFrontier => true
+
+/-- The selected frontier-to-flat atlas has an exact boolean status reading. -/
+def selectedFrontierFlatResidualStatusReading :
+    ResidualBooleanStatusReading selectedFrontierFlatAtlasSkeleton where
+  status := selectedFrontierFlatResidualStatus
+  present_iff_true := by
+    intro index
+    cases index with
+    | flat =>
+        constructor
+        · intro hpresent
+          exact False.elim
+            (selected_flatIndexedResidualNotPresent hpresent)
+        · intro htrue
+          cases htrue
+    | repairFrontier =>
+        constructor
+        · intro _hpresent
+          rfl
+        · intro _htrue
+          exact selected_repairFrontierResidualPresent
+  free_iff_false := by
+    intro index
+    cases index with
+    | flat =>
+        constructor
+        · intro _hfree
+          rfl
+        · intro _hfalse
+          exact selected_flatIndexedResidualFree
+    | repairFrontier =>
+        constructor
+        · intro hfree
+          exact False.elim
+            ((indexedResidualPresent_not_free
+              selected_repairFrontierResidualPresent) hfree)
+        · intro hfalse
+          cases hfalse
+
+/-- The selected frontier-to-flat edge is a true-to-false status drop. -/
+theorem selectedFrontierFlat_existsStatusDrop :
+    ExistsResidualStatusDrop selectedFrontierFlatResidualStatusReading := by
+  exact
+    ⟨selectedFrontierFlatResidualCutPair,
+      selected_frontierToFlatEdge,
+      rfl,
+      rfl⟩
+
+/-- The selected status drop gives nonzero canonical residual cut class. -/
+theorem selectedFrontierFlat_statusDrop_canonicalNonzero :
+    (canonicalResidualCutCochain
+      selectedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    (canonicalResidualCutClass_nonzero_iff_existsStatusDrop
+      selectedFrontierFlatResidualStatusReading).mpr
+      selectedFrontierFlat_existsStatusDrop
+
+/-- The selected status drop obstructs transition closure. -/
+theorem selectedFrontierFlat_statusDrop_obstructs_transitionClosure
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    existsStatusDrop_obstructs_atlasTransitionClosure
+      selectedFrontierFlatResidualStatusReading
+      selectedFrontierFlat_existsStatusDrop
+      transition
+
+/-- The selected status drop rules out transition-coherent atlas data. -/
+theorem selectedFrontierFlat_statusDrop_obstructs_transitionCoherentData
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    existsStatusDrop_obstructs_transitionCoherentData
+      selectedFrontierFlatResidualStatusReading
+      selectedFrontierFlat_existsStatusDrop
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-98 theorem package: exact finite residual boolean status readings turn
+canonical residual cut classes into active true-to-false status-drop classes.
+-/
+theorem semanticResidualStatusDropAdapter_package :
+    (forall {Index : Type w}
+      {Atom : Type u}
+      {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+      forall reading : ResidualBooleanStatusReading atlas,
+      forall pair : Index × Index,
+        ResidualStatusDropPair reading pair <->
+          IsResidualTransitionCutPair atlas pair) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall reading : ResidualBooleanStatusReading atlas,
+        CutNoiseEquivalent
+          (canonicalResidualCutCochain atlas)
+          (residualStatusDropCochain reading)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall reading : ResidualBooleanStatusReading atlas,
+        (canonicalResidualCutCochain atlas).CutVanishes <->
+          NoResidualStatusDrop reading) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall reading : ResidualBooleanStatusReading atlas,
+        (canonicalResidualCutCochain atlas).CutNonzero <->
+          ExistsResidualStatusDrop reading) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall reading : ResidualBooleanStatusReading atlas,
+        ExistsResidualStatusDrop reading ->
+          forall transition : Index -> Index -> Atom -> Atom,
+            Not (AtlasResidualTransitionClosed atlas transition)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom},
+        forall reading : ResidualBooleanStatusReading atlas,
+        ExistsResidualStatusDrop reading ->
+          forall transition : Index -> Index -> Atom -> Atom,
+            Not
+              (Nonempty
+                (TransitionCoherentAtlasData atlas transition))) /\
+      ExistsResidualStatusDrop selectedFrontierFlatResidualStatusReading /\
+      (canonicalResidualCutCochain
+        selectedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_Index} {_Atom} {_atlas} reading pair =>
+        residualStatusDropPair_iff_residualCutPair reading pair,
+      fun {_Index} {_Atom} {_atlas} reading =>
+        canonicalResidualCutCochain_cutNoiseEquivalent_statusDrop reading,
+      fun {_Index} {_Atom} {_atlas} reading =>
+        canonicalResidualCutClass_vanishes_iff_noStatusDrop reading,
+      fun {_Index} {_Atom} {_atlas} reading =>
+        canonicalResidualCutClass_nonzero_iff_existsStatusDrop reading,
+      fun {_Index} {_Atom} {_atlas} reading hdrop transition =>
+        existsStatusDrop_obstructs_atlasTransitionClosure
+          reading hdrop transition,
+      fun {_Index} {_Atom} {_atlas} reading hdrop transition =>
+        existsStatusDrop_obstructs_transitionCoherentData
+          reading hdrop transition,
+      selectedFrontierFlat_existsStatusDrop,
+      selectedFrontierFlat_statusDrop_canonicalNonzero,
+      selectedFrontierFlat_statusDrop_obstructs_transitionClosure,
+      selectedFrontierFlat_statusDrop_obstructs_transitionCoherentData⟩
+
+end SemanticResidualStatusDropAdapter
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-adapter.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-adapter.md
@@ -1,0 +1,141 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: finite status-drop adapter / pre-H1-facing obstruction reading / genius-support convergence
+candidate_type: finite residual status-drop adapter / obstruction-class-support / pre-H1-facing
+capability_category: semantic-obstruction / status-drop-adapter / finite-atlas-transition / obstruction-class-support / genius-support
+expected_base_score: 88
+expected_evidence_multiplier: 2.0
+expected_final_score: 176
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can color nodes by status, but they do not prove that an exact supplied boolean residual status reading makes canonical residual cut classes precisely active true-to-false status-drop classes.
+origin: cycle-98
+tags: [quality-surface, semantic-repair, residual-cut, status-drop, obstruction-class, pre-h1-facing, genius-support]
+created: 2026-06-23
+cycle: 98
+lean: proved-in-research
+planned_report_section: "Cycle 98: Finite residual status-drop obstruction adapter"
+---
+
+# Finite Residual Status-Drop Obstruction Adapter
+
+## 主張
+
+finite atlas に supplied exact boolean residual status reading `status : Index -> Bool` を置く。
+`ResidualBooleanStatusReading` は、residual-present な index がちょうど `true`、residual-free な index がちょうど `false` であることを保証する。
+この exact reading の下で、residual transition cut pair は active edge 上の `true -> false` status drop pair と同値になる。
+
+したがって `residualStatusDropCochain` は canonical residual cut cochain と cut-noise equivalent であり、canonical residual cut class の vanishing / nonzero は、それぞれ true-to-false status drop の absence / existence と同値になる。
+status drop が存在するなら、transition closure と transition-coherent atlas data は存在できない。
+
+この adapter は finite status-drop adapter であり、true `H^1`、Cech quotient、coboundary quotient、cohomology class、vanishing-to-closure theorem ではない。
+`status` は supplied exact reading であり、source extraction、ArchMap/tooling/runtime extraction、repair synthesis、UI correctness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`finite residual status-drop adapter` / `obstruction-class-support` / `pre-H1-facing`
+
+## 依拠
+
+- Cycle 92: residual obstruction class modulo cut-noise。
+- Cycle 97: mapped repair-hitting transport。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+単なる status dashboard ではない。
+exact status reading の仮定を Lean structure として置き、active `true -> false` drop と residual cut pair の iff、status-drop cochain と canonical cochain の cut-noise equivalence、canonical vanishing/nonzero と status-drop absence/existence の iff、status-drop nonzero no-go をすべて theorem として固定する。
+
+## 数学的興味
+
+residual cut obstruction class が、finite exact boolean residual status reading の下では active directed status drop として読めることを示す。
+これは true cohomology ではないが、degree-one / pre-H1-facing な obstruction intuition を安全に導入する adapter になる。
+
+## GOAL への前進
+
+semantic repair-gluing obstruction target に向けて、cut-locus class の意味を `present -> free` status drop として明確化した。
+後続の local-pass/global-fail taxonomy や pre-H1 adapter の語彙を、過剰な H1 claim なしに準備する。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は node status を色分けできる。
+しかし、それらは exact status reading の下で active `true -> false` drop が canonical residual obstruction class と cut-noise equivalent であり、nonzero drop が closure/data no-go を持つことを証明しない。
+
+## SCORE 見込み
+
+- `score_reason`: residual obstruction class を finite boolean status-drop adapter として exact に読む。pre-H1-facing support node として有用だが、true H1 ではない。
+- `dullness_risk`: Cycle 92 の言い換えに見える危険がある。status reading structure、drop/cut iff、cut-noise equivalence、canonical vanish/nonzero iff、selected witness/no-go を揃えて回避する。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualStatusDropAdapter.lean` で generic adapter と selected frontier-to-flat witness を証明する。
+
+## CS / SWE への帰結
+
+品質 surface 上の red/green status が意味を持つには、status reading が residual-present/free を exact に反映している必要がある。
+そのとき active `true -> false` transition は単なる色の変化ではなく、canonical residual obstruction class として transition closure を阻む。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualStatusDropAdapter.lean` に固定した。
+
+- `indexedResidualPresent_not_free`
+- `ResidualBooleanStatusReading`
+- `ResidualStatusDropPair`
+- `residualStatusDropCochain`
+- `residualStatusDropPair_iff_residualCutPair`
+- `canonicalResidualCutCochain_cutNoiseEquivalent_statusDrop`
+- `NoResidualStatusDrop`
+- `ExistsResidualStatusDrop`
+- `residualStatusDropCochain_vanishes_iff_noStatusDrop`
+- `residualStatusDropCochain_nonzero_iff_existsStatusDrop`
+- `canonicalResidualCutClass_vanishes_iff_noStatusDrop`
+- `canonicalResidualCutClass_nonzero_iff_existsStatusDrop`
+- `existsStatusDrop_obstructs_atlasTransitionClosure`
+- `existsStatusDrop_obstructs_transitionCoherentData`
+- `selectedFrontierFlatResidualStatus`
+- `selectedFrontierFlatResidualStatusReading`
+- `selectedFrontierFlat_existsStatusDrop`
+- `selectedFrontierFlat_statusDrop_canonicalNonzero`
+- `selectedFrontierFlat_statusDrop_obstructs_transitionClosure`
+- `selectedFrontierFlat_statusDrop_obstructs_transitionCoherentData`
+- `semanticResidualStatusDropAdapter_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualStatusDropAdapter.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualStatusDropAdapter`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic status-drop adapter theorem 群は axiom-free。selected witness と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、supplied exact boolean residual status reading、finite status-drop pair/cochain、canonical cut-noise equivalence、canonical vanishing/nonzero iff status-drop absence/existence、nonzero status-drop closure/data no-go に限定する。
+unchecked: true H1/cohomology、Cech quotient、coboundary quotient、vanishing-to-closure theorem、status extraction completeness、source extraction completeness、ArchMap correctness、repair synthesis、runtime repair synthesis、tooling runtime extraction、UI correctness、whole-codebase quality。
+
+## 審判メモ
+
+- G1/G2 A: accept / base 86-90。selected witness と no-go package まで揃えば base 88 前後が妥当。genius unlock ではなく pre-H1-facing support。
+- G1/G2 B: accept / base 82-86。Cycle 92 の言い換えに見えないよう exact status-drop absence/existence と canonical class の同値を必須にすること。
+- G2 revise 解決: `status` を supplied exact reading と明記し、true H1/Cech/coboundary ではなく finite status-drop adapter に限定した。
+
+## 追加 required fields
+
+- `mathematical_interest`: canonical residual cut class を exact boolean status drop として読む。
+- `goal_advancement`: residual obstruction class の pre-H1-facing interpretation を安全な finite adapter として固定した。
+- `planned_theorem_names`: `residualStatusDropPair_iff_residualCutPair`, `canonicalResidualCutClass_nonzero_iff_existsStatusDrop`, `semanticResidualStatusDropAdapter_package`
+- `visible_projection`: exact residual status reading、active true-to-false edge、canonical cut class。
+- `protected_structure`: residual-present/free exactness、cut-noise equivalence、vanishing/nonzero iff、closure/data obstruction。
+- `exactness_or_minimality_claim`: exact supplied status reading underlies drop/cut iff。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: status dashboard without exact residual reading does not certify obstruction class semantics。
+- `previous_cycle_delta`: Cycle 97 の repair-hit transport 後に、cut class を status-drop adapter として再解釈した。
+- `rival_stress_test`: rival は statuses を表示できても、status drop を canonical obstruction class として証明しない。
+- `genius_potential`: support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の pre-H1-facing adapter。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: obstruction class を active residual status drop として読む interface を固定する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-repair-hitting.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-obstruction-class.md`
+- planned report section: `Cycle 98: Finite residual status-drop obstruction adapter`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 98 G1/G2 で finite residual status-drop obstruction adapter を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualStatusDropAdapter.lean` に固定し、単体 `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 13522
+- total SCORE: 13698
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -102,8 +102,9 @@
   - semantic-obstruction / finite-atlas-transition / obstruction-class-support / transport-induction / genius-support: 172
   - semantic-obstruction / repair-necessity / finite-atlas-transition / obstruction-class-support / genius-support: 176
   - semantic-obstruction / repair-necessity / cut-locus-transport / finite-atlas-transition / genius-support: 180
+  - semantic-obstruction / status-drop-adapter / finite-atlas-transition / obstruction-class-support / genius-support: 176
 - evidence portfolio:
-  - proved-in-research: 97
+  - proved-in-research: 98
 
 ## Phase synthesis
 
@@ -119,7 +120,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-97 件の Lean-proved research artifacts は、次の paper seed を形成している。
+98 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -145,6 +146,7 @@ certificate の基本単位は
 - semantic residual atlas map laws は、edge preservation、residual-present preservation、residual-free preservation、target cut-data lift から residual cut-locus transport と canonical obstruction transport を誘導できることを示す。
 - semantic residual cut repair hitting は、old/new atlas 間で unhit cuts が persistence law を満たすなら、new canonical residual cut class の vanishing が old residual cut の edge/source/target hit を必要とすることを示す。
 - semantic residual mapped repair hitting は、unhit edge/present/free preservation laws により、repair-hitting necessity が finite carrier/schema change をまたいで transport されることを示す。
+- semantic residual status-drop adapter は、supplied exact boolean residual status reading の下で canonical residual cut class が active true-to-false status-drop class と一致することを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -202,8 +204,9 @@ Cycle 94 後の total SCORE は 12994 であり、tracking Issue active threshol
 Cycle 95 後の total SCORE は 13166 であり、tracking Issue active threshold 15000 までは残り 1834 SCORE である。
 Cycle 96 後の total SCORE は 13342 であり、tracking Issue active threshold 15000 までは残り 1658 SCORE である。
 Cycle 97 後の total SCORE は 13522 であり、tracking Issue active threshold 15000 までは残り 1478 SCORE である。
+Cycle 98 後の total SCORE は 13698 であり、tracking Issue active threshold 15000 までは残り 1302 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 97 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 98 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -233,7 +236,8 @@ semantic residual atlas gauge invariance theorem、
 semantic residual cut-locus transport theorem、
 semantic residual atlas map law induction theorem、
 semantic residual cut repair-hitting theorem、
-semantic residual mapped repair-hitting theorem を含む。
+semantic residual mapped repair-hitting theorem、
+semantic residual status-drop adapter theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5187,4 +5191,78 @@ correctness, or whole-codebase quality.
 
 Cycle 97 後の total SCORE は 13522 であり、tracking Issue active threshold 15000 までは残り 1478 SCORE である。
 次 cycle では、local-pass/global-fail taxonomy after repair necessity、finite pre-H1 status-drop adapter、cross-carrier minimality、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 98: Finite residual status-drop obstruction adapter
+
+```text
+candidate: Finite residual status-drop obstruction adapter
+candidate_type: finite residual status-drop adapter / obstruction-class-support / pre-H1-facing
+evidence_stage: proved-in-research
+base_score: 88
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 176
+category: semantic-obstruction / status-drop-adapter / finite-atlas-transition / obstruction-class-support / genius-support
+goal_delta: Cycle 92-97 の residual cut class tower を、supplied exact boolean residual status reading 上の active true-to-false drop class として読める adapter へ接続した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、exact residual boolean status reading、status-drop pair/cochain、drop/cut iff、canonical cut-noise equivalence、canonical vanish/nonzero iff status-drop absence/existence、selected status witness、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は node status を色分けできるが、exact status reading の下で true-to-false drop が canonical residual obstruction class と一致し、nonzero drop が closure/data no-go を持つことを Lean theorem として示さない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualStatusDropAdapter.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualStatusDropAdapter`, and `lake build FormalAGResearch` passed. Axiom probe reported generic status-drop adapter theorem family axiom-free; selected witness and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: local-pass/global-fail taxonomy after status adapter; finite pre-H1 support without cohomology overclaim; cross-carrier minimality; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualStatusDropAdapter.lean`
+builds a finite residual status-drop adapter.  A supplied exact boolean status
+reading records residual-present indices as `true` and residual-free indices
+as `false`.  Under such a reading, an active `true -> false` edge is exactly a
+residual transition cut pair.
+
+The status-drop cochain is cut-noise equivalent to the canonical residual cut
+cochain.  Consequently, canonical residual cut-class vanishing is equivalent
+to absence of active true-to-false drops, and canonical nonzero is equivalent
+to existence of such a drop.  A nonzero status drop obstructs residual
+transition closure and rules out transition-coherent atlas data.
+
+The selected witness gives the frontier-to-flat atlas an exact status reading:
+`repairFrontier` is `true`, `flat` is `false`, and the selected active edge is
+a status drop.  This selected status drop recovers the selected canonical
+nonzero obstruction and no-go theorems.
+
+Lean proves:
+
+- `indexedResidualPresent_not_free`: residual-present and residual-free are mutually exclusive.
+- `ResidualBooleanStatusReading`: exact supplied boolean residual status reading.
+- `ResidualStatusDropPair`: active true-to-false status drop.
+- `residualStatusDropCochain`: cochain supported on status drops.
+- `residualStatusDropPair_iff_residualCutPair`: exact status drops are residual cuts.
+- `canonicalResidualCutCochain_cutNoiseEquivalent_statusDrop`: status-drop cochain equals canonical class on the cut locus.
+- `NoResidualStatusDrop`: absence of active true-to-false drops.
+- `ExistsResidualStatusDrop`: existence of an active true-to-false drop.
+- `residualStatusDropCochain_vanishes_iff_noStatusDrop`: status-drop cochain vanishing criterion.
+- `residualStatusDropCochain_nonzero_iff_existsStatusDrop`: status-drop cochain nonzero criterion.
+- `canonicalResidualCutClass_vanishes_iff_noStatusDrop`: canonical vanishing iff no status drop.
+- `canonicalResidualCutClass_nonzero_iff_existsStatusDrop`: canonical nonzero iff status drop exists.
+- `existsStatusDrop_obstructs_atlasTransitionClosure`: status drop obstructs transition closure.
+- `existsStatusDrop_obstructs_transitionCoherentData`: status drop rules out coherent data.
+- `selectedFrontierFlatResidualStatus`: selected boolean residual status.
+- `selectedFrontierFlatResidualStatusReading`: exact selected status reading.
+- `selectedFrontierFlat_existsStatusDrop`: selected frontier-to-flat drop exists.
+- `selectedFrontierFlat_statusDrop_canonicalNonzero`: selected status drop gives canonical nonzero.
+- `selectedFrontierFlat_statusDrop_obstructs_transitionClosure`: selected status drop obstructs closure.
+- `selectedFrontierFlat_statusDrop_obstructs_transitionCoherentData`: selected status drop rules out coherent data.
+- `semanticResidualStatusDropAdapter_package`: theorem package.
+
+This cycle is a support node, not a `genius unlock`.  It is a finite
+status-drop adapter, not a true `H^1` class, Cech quotient, coboundary quotient,
+or cohomology theorem.  It does not prove vanishing-to-closure, status
+extraction completeness, source extraction completeness, ArchMap correctness,
+repair synthesis, runtime repair synthesis, tooling runtime extraction, UI
+correctness, or whole-codebase quality.
+
+### Next Frontier
+
+Cycle 98 後の total SCORE は 13698 であり、tracking Issue active threshold 15000 までは残り 1302 SCORE である。
+次 cycle では、local-pass/global-fail taxonomy after status adapter、finite pre-H1 support without cohomology overclaim、cross-carrier minimality、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 98 として、finite residual status-drop obstruction adapter を追加します。supplied exact boolean residual status reading の下で、active true-to-false status drop pair が residual transition cut pair と同値であり、status-drop cochain が canonical residual cut cochain と cut-noise equivalent であることを証明します。tracking Issue は threshold 15000 継続のため close しません。

score ledger: +176、total 13522 -> 13698、remaining 1302。G3 formalization audit: pass。G3.5 ledger audit: pass。G4 score audit: confirm +176 / support cycle。

## 証明した定理

- `indexedResidualPresent_not_free`
- `ResidualBooleanStatusReading`
- `ResidualStatusDropPair`
- `residualStatusDropCochain`
- `residualStatusDropPair_iff_residualCutPair`
- `canonicalResidualCutCochain_cutNoiseEquivalent_statusDrop`
- `NoResidualStatusDrop`
- `ExistsResidualStatusDrop`
- `residualStatusDropCochain_vanishes_iff_noStatusDrop`
- `residualStatusDropCochain_nonzero_iff_existsStatusDrop`
- `canonicalResidualCutClass_vanishes_iff_noStatusDrop`
- `canonicalResidualCutClass_nonzero_iff_existsStatusDrop`
- `existsStatusDrop_obstructs_atlasTransitionClosure`
- `existsStatusDrop_obstructs_transitionCoherentData`
- `selectedFrontierFlatResidualStatus`
- `selectedFrontierFlatResidualStatusReading`
- `selectedFrontierFlat_existsStatusDrop`
- `selectedFrontierFlat_statusDrop_canonicalNonzero`
- `selectedFrontierFlat_statusDrop_obstructs_transitionClosure`
- `selectedFrontierFlat_statusDrop_obstructs_transitionCoherentData`
- `semanticResidualStatusDropAdapter_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-adapter.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualStatusDropAdapter.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualStatusDropAdapter`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check` / `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] Lean forbidden-token scan
- [x] `#print axioms` probe: generic status-drop adapter theorem family は axiom-free。selected witness と package は標準 `propext` / `Quot.sound` のみ。

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

## Claim boundary

supplied exact boolean residual status reading、finite status-drop pair/cochain、canonical cut-noise equivalence、canonical vanish/nonzero iff status-drop absence/existence、nonzero status-drop closure/data no-go に限定します。true H1/cohomology、Cech quotient、coboundary quotient、vanishing-to-closure theorem、status extraction completeness、source extraction completeness、ArchMap correctness、repair synthesis、runtime repair synthesis、tooling runtime extraction、UI correctness、whole-codebase quality は主張しません。