### PR TITLE
Cycle 99 status-drop repair hitting を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -95,3 +95,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualAtlasMapLaws
 import Formal.AG.Research.QualitySurface.SemanticResidualCutRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualMappedRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropAdapter
+import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropRepairHitting

--- a/Formal/AG/Research/QualitySurface/SemanticResidualStatusDropRepairHitting.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualStatusDropRepairHitting.lean
@@ -1,0 +1,515 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropAdapter
+
+/-!
+Cycle 99 evidence for `G-aat-quality-surface-01`.
+
+This file combines finite residual status-drop readings with repair-hitting
+necessity.  For same-carrier old/new exact boolean residual status readings,
+source-side hit predicates mark the edge/source/target loci touched by a
+repair.  If active edges, source `true` status, and target `false` status are
+preserved away from those hit loci, then an unhit old true-to-false status drop
+remains a new true-to-false status drop.  Thus absence of new status drops
+forces every old status drop to be hit.
+
+This is a necessary condition only.  It does not assert hit sufficiency,
+repair synthesis, status extraction, vanishing-to-closure, true H1/Cech/
+coboundary structure, ArchMap correctness, tooling/runtime/UI correctness, or
+whole-codebase quality.
+-/
+
+universe u w
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualStatusDropRepairHitting
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualCutRepairHitting
+open SemanticResidualStatusDropAdapter
+
+/-! ## Status-drop repair transport -/
+
+/--
+A same-carrier status-drop repair transport preserves old active edges, source
+`true` status, and target `false` status away from supplied hit loci.
+-/
+structure ResidualStatusDropRepairTransport
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (newReading : ResidualBooleanStatusReading new) where
+  edgeHit : Index × Index -> Prop
+  sourceHit : Index -> Prop
+  targetHit : Index -> Prop
+  edge_preserving_unhit :
+    forall pair,
+      old.edge pair.1 pair.2 ->
+        Not (edgeHit pair) ->
+          new.edge pair.1 pair.2
+  source_true_preserving_unhit :
+    forall index,
+      oldReading.status index = true ->
+        Not (sourceHit index) ->
+          newReading.status index = true
+  target_false_preserving_unhit :
+    forall index,
+      oldReading.status index = false ->
+        Not (targetHit index) ->
+          newReading.status index = false
+
+/-- Every old status drop hit obligation is satisfied. -/
+def AllOldStatusDropsHit
+    {Index : Type w}
+    {Atom : Type u}
+    {old : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (edgeHit : Index × Index -> Prop)
+    (sourceHit targetHit : Index -> Prop) : Prop :=
+  forall pair,
+    ResidualStatusDropPair oldReading pair ->
+      ResidualCutHit edgeHit sourceHit targetHit pair
+
+/-- An unhit old status drop persists as a new status drop. -/
+theorem unhit_oldStatusDrop_persists_newStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    {pair : Index × Index}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transport.edgeHit pair))
+    (hsource : Not (transport.sourceHit pair.1))
+    (htarget : Not (transport.targetHit pair.2)) :
+    ResidualStatusDropPair newReading pair := by
+  exact
+    ⟨transport.edge_preserving_unhit pair hdrop.1 hedge,
+      transport.source_true_preserving_unhit pair.1 hdrop.2.1 hsource,
+      transport.target_false_preserving_unhit pair.2 hdrop.2.2 htarget⟩
+
+/-- An unhit old status drop gives an existing new status drop. -/
+theorem unhit_oldStatusDrop_preserves_newExistsStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    {pair : Index × Index}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transport.edgeHit pair))
+    (hsource : Not (transport.sourceHit pair.1))
+    (htarget : Not (transport.targetHit pair.2)) :
+    ExistsResidualStatusDrop newReading := by
+  have hnewDrop :
+      ResidualStatusDropPair newReading pair :=
+    unhit_oldStatusDrop_persists_newStatusDrop
+      transport hdrop hedge hsource htarget
+  exact ⟨pair, hnewDrop.1, hnewDrop.2.1, hnewDrop.2.2⟩
+
+/-- An unhit old status drop gives a nonzero new canonical residual class. -/
+theorem unhit_oldStatusDrop_preserves_newCanonicalNonzero
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    {pair : Index × Index}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transport.edgeHit pair))
+    (hsource : Not (transport.sourceHit pair.1))
+    (htarget : Not (transport.targetHit pair.2)) :
+    (canonicalResidualCutCochain new).CutNonzero := by
+  have hnewDrop :
+      ExistsResidualStatusDrop newReading :=
+    unhit_oldStatusDrop_preserves_newExistsStatusDrop
+      transport hdrop hedge hsource htarget
+  exact
+    (canonicalResidualCutClass_nonzero_iff_existsStatusDrop
+      newReading).mpr hnewDrop
+
+/-- If new status drops are absent, every old status drop must be hit. -/
+theorem newNoStatusDrop_forces_oldStatusDropHit
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    (hno : NoResidualStatusDrop newReading)
+    {pair : Index × Index}
+    (hdrop : ResidualStatusDropPair oldReading pair) :
+    ResidualCutHit
+      transport.edgeHit
+      transport.sourceHit
+      transport.targetHit
+      pair := by
+  intro hunhit
+  have hnewDrop :
+      ResidualStatusDropPair newReading pair :=
+    unhit_oldStatusDrop_persists_newStatusDrop
+      transport hdrop hunhit.1 hunhit.2.1 hunhit.2.2
+  exact hno pair hnewDrop.1 hnewDrop.2
+
+/-- If new status drops are absent, all old status drops must be hit. -/
+theorem newNoStatusDrop_forces_allOldStatusDropsHit
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    (hno : NoResidualStatusDrop newReading) :
+    AllOldStatusDropsHit
+      oldReading
+      transport.edgeHit
+      transport.sourceHit
+      transport.targetHit := by
+  intro pair hdrop
+  exact newNoStatusDrop_forces_oldStatusDropHit
+    transport hno hdrop
+
+/-- If the new canonical class vanishes, each old status drop must be hit. -/
+theorem newCanonicalVanishes_forces_oldStatusDropHit
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes)
+    {pair : Index × Index}
+    (hdrop : ResidualStatusDropPair oldReading pair) :
+    ResidualCutHit
+      transport.edgeHit
+      transport.sourceHit
+      transport.targetHit
+      pair := by
+  have hno :
+      NoResidualStatusDrop newReading :=
+    (canonicalResidualCutClass_vanishes_iff_noStatusDrop
+      newReading).mp hvanish
+  exact newNoStatusDrop_forces_oldStatusDropHit
+    transport hno hdrop
+
+/-- If the new canonical class vanishes, all old status drops must be hit. -/
+theorem newCanonicalVanishes_forces_allOldStatusDropsHit
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes) :
+    AllOldStatusDropsHit
+      oldReading
+      transport.edgeHit
+      transport.sourceHit
+      transport.targetHit := by
+  intro pair hdrop
+  exact newCanonicalVanishes_forces_oldStatusDropHit
+    transport hvanish hdrop
+
+/-- An unhit old status drop obstructs new transition closure. -/
+theorem unhit_oldStatusDrop_obstructs_newTransitionClosure
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    {pair : Index × Index}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transport.edgeHit pair))
+    (hsource : Not (transport.sourceHit pair.1))
+    (htarget : Not (transport.targetHit pair.2))
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (AtlasResidualTransitionClosed new transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain new)
+      (unhit_oldStatusDrop_preserves_newCanonicalNonzero
+        transport hdrop hedge hsource htarget)
+      transition
+
+/-- An unhit old status drop rules out new transition-coherent atlas data. -/
+theorem unhit_oldStatusDrop_obstructs_newTransitionCoherentData
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    {pair : Index × Index}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transport.edgeHit pair))
+    (hsource : Not (transport.sourceHit pair.1))
+    (htarget : Not (transport.targetHit pair.2))
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (Nonempty (TransitionCoherentAtlasData new transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (canonicalResidualCutCochain new)
+      (unhit_oldStatusDrop_preserves_newCanonicalNonzero
+        transport hdrop hedge hsource htarget)
+      transition
+
+/-! ## Selected no-hit status-drop witness -/
+
+/-- No-hit transport on the selected exact status reading. -/
+def selectedNoHitStatusDropRepairTransport :
+    ResidualStatusDropRepairTransport
+      selectedFrontierFlatResidualStatusReading
+      selectedFrontierFlatResidualStatusReading where
+  edgeHit := selectedNoEdgeHit
+  sourceHit := selectedNoSourceHit
+  targetHit := selectedNoTargetHit
+  edge_preserving_unhit := by
+    intro pair hedge _hunhit
+    exact hedge
+  source_true_preserving_unhit := by
+    intro index htrue _hunhit
+    exact htrue
+  target_false_preserving_unhit := by
+    intro index hfalse _hunhit
+    exact hfalse
+
+/-- The selected no-hit status drop remains nonzero. -/
+theorem selectedNoHitStatusDrop_preserves_canonicalNonzero :
+    (canonicalResidualCutCochain
+      selectedFrontierFlatAtlasSkeleton).CutNonzero := by
+  have hdrop :
+      ResidualStatusDropPair
+        selectedFrontierFlatResidualStatusReading
+        selectedFrontierFlatResidualCutPair :=
+    ⟨selected_frontierToFlatEdge, rfl, rfl⟩
+  exact
+    unhit_oldStatusDrop_preserves_newCanonicalNonzero
+      selectedNoHitStatusDropRepairTransport
+      hdrop
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+
+/-- If selected new status drops are absent, the selected old drop must be hit. -/
+theorem selected_newNoStatusDrop_requires_frontierFlatHit
+    (hno : NoResidualStatusDrop selectedFrontierFlatResidualStatusReading) :
+    ResidualCutHit
+      selectedNoEdgeHit
+      selectedNoSourceHit
+      selectedNoTargetHit
+      selectedFrontierFlatResidualCutPair := by
+  have hdrop :
+      ResidualStatusDropPair
+        selectedFrontierFlatResidualStatusReading
+        selectedFrontierFlatResidualCutPair :=
+    ⟨selected_frontierToFlatEdge, rfl, rfl⟩
+  exact
+    newNoStatusDrop_forces_oldStatusDropHit
+      selectedNoHitStatusDropRepairTransport hno hdrop
+
+/-- If the selected canonical class vanished, the selected old drop would be hit. -/
+theorem selected_newCanonicalVanishes_requires_frontierFlatHit
+    (hvanish :
+      (canonicalResidualCutCochain
+        selectedFrontierFlatAtlasSkeleton).CutVanishes) :
+    ResidualCutHit
+      selectedNoEdgeHit
+      selectedNoSourceHit
+      selectedNoTargetHit
+      selectedFrontierFlatResidualCutPair := by
+  have hno :
+      NoResidualStatusDrop selectedFrontierFlatResidualStatusReading :=
+    (canonicalResidualCutClass_vanishes_iff_noStatusDrop
+      selectedFrontierFlatResidualStatusReading).mp hvanish
+  exact selected_newNoStatusDrop_requires_frontierFlatHit hno
+
+/-- The selected no-hit status drop obstructs transition closure. -/
+theorem selectedNoHitStatusDrop_obstructs_transitionClosure
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedFrontierFlatAtlasSkeleton
+        transition) := by
+  have hdrop :
+      ResidualStatusDropPair
+        selectedFrontierFlatResidualStatusReading
+        selectedFrontierFlatResidualCutPair :=
+    ⟨selected_frontierToFlatEdge, rfl, rfl⟩
+  exact
+    unhit_oldStatusDrop_obstructs_newTransitionClosure
+      selectedNoHitStatusDropRepairTransport
+      hdrop
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+      transition
+
+/-- The selected no-hit status drop rules out transition-coherent data. -/
+theorem selectedNoHitStatusDrop_obstructs_transitionCoherentData
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedFrontierFlatAtlasSkeleton
+          transition)) := by
+  have hdrop :
+      ResidualStatusDropPair
+        selectedFrontierFlatResidualStatusReading
+        selectedFrontierFlatResidualCutPair :=
+    ⟨selected_frontierToFlatEdge, rfl, rfl⟩
+  exact
+    unhit_oldStatusDrop_obstructs_newTransitionCoherentData
+      selectedNoHitStatusDropRepairTransport
+      hdrop
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-99 theorem package: under unhit preservation of edge/source-true/
+target-false status data, absence of new status drops forces old status drops
+to be hit.
+-/
+theorem semanticResidualStatusDropRepairHitting_package :
+    (forall {Index : Type w}
+      {Atom : Type u}
+      {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+      {oldReading : ResidualBooleanStatusReading old}
+      {newReading : ResidualBooleanStatusReading new},
+      forall transport : ResidualStatusDropRepairTransport oldReading newReading,
+      forall pair : Index × Index,
+        ResidualStatusDropPair oldReading pair ->
+          Not (transport.edgeHit pair) ->
+            Not (transport.sourceHit pair.1) ->
+              Not (transport.targetHit pair.2) ->
+                ResidualStatusDropPair newReading pair) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new},
+        forall transport : ResidualStatusDropRepairTransport oldReading newReading,
+        forall pair : Index × Index,
+          ResidualStatusDropPair oldReading pair ->
+            Not (transport.edgeHit pair) ->
+              Not (transport.sourceHit pair.1) ->
+                Not (transport.targetHit pair.2) ->
+                  ExistsResidualStatusDrop newReading) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new},
+        forall transport : ResidualStatusDropRepairTransport oldReading newReading,
+        NoResidualStatusDrop newReading ->
+          AllOldStatusDropsHit
+            oldReading
+            transport.edgeHit
+            transport.sourceHit
+            transport.targetHit) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new},
+        forall transport : ResidualStatusDropRepairTransport oldReading newReading,
+        (canonicalResidualCutCochain new).CutVanishes ->
+          AllOldStatusDropsHit
+            oldReading
+            transport.edgeHit
+            transport.sourceHit
+            transport.targetHit) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new},
+        forall transport : ResidualStatusDropRepairTransport oldReading newReading,
+        forall pair : Index × Index,
+          ResidualStatusDropPair oldReading pair ->
+            Not (transport.edgeHit pair) ->
+              Not (transport.sourceHit pair.1) ->
+                Not (transport.targetHit pair.2) ->
+                  (canonicalResidualCutCochain new).CutNonzero) /\
+      (canonicalResidualCutCochain
+        selectedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (NoResidualStatusDrop selectedFrontierFlatResidualStatusReading ->
+        ResidualCutHit
+          selectedNoEdgeHit
+          selectedNoSourceHit
+          selectedNoTargetHit
+          selectedFrontierFlatResidualCutPair) /\
+      ((canonicalResidualCutCochain
+        selectedFrontierFlatAtlasSkeleton).CutVanishes ->
+        ResidualCutHit
+          selectedNoEdgeHit
+          selectedNoSourceHit
+          selectedNoTargetHit
+          selectedFrontierFlatResidualCutPair) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_Index} {_Atom} {_old} {_new} {_oldReading} {_newReading}
+        transport pair hdrop hedge hsource htarget =>
+        unhit_oldStatusDrop_persists_newStatusDrop
+          transport hdrop hedge hsource htarget,
+      fun {_Index} {_Atom} {_old} {_new} {_oldReading} {_newReading}
+        transport pair hdrop hedge hsource htarget =>
+        unhit_oldStatusDrop_preserves_newExistsStatusDrop
+          transport hdrop hedge hsource htarget,
+      fun {_Index} {_Atom} {_old} {_new} {_oldReading} {_newReading}
+        transport hno =>
+        newNoStatusDrop_forces_allOldStatusDropsHit transport hno,
+      fun {_Index} {_Atom} {_old} {_new} {_oldReading} {_newReading}
+        transport hvanish =>
+        newCanonicalVanishes_forces_allOldStatusDropsHit transport hvanish,
+      fun {_Index} {_Atom} {_old} {_new} {_oldReading} {_newReading}
+        transport pair hdrop hedge hsource htarget =>
+        unhit_oldStatusDrop_preserves_newCanonicalNonzero
+          transport hdrop hedge hsource htarget,
+      selectedNoHitStatusDrop_preserves_canonicalNonzero,
+      selected_newNoStatusDrop_requires_frontierFlatHit,
+      selected_newCanonicalVanishes_requires_frontierFlatHit,
+      selectedNoHitStatusDrop_obstructs_transitionClosure,
+      selectedNoHitStatusDrop_obstructs_transitionCoherentData⟩
+
+end SemanticResidualStatusDropRepairHitting
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-repair-hitting.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-repair-hitting.md
@@ -1,0 +1,159 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: finite status-drop repair-hitting theorem / pre-H1-facing repair necessity / genius-support convergence
+candidate_type: finite residual status-drop repair-hitting theorem / status-drop necessity / obstruction-class-support
+capability_category: semantic-obstruction / status-drop-adapter / repair-necessity / finite-atlas-transition / genius-support
+expected_base_score: 88
+expected_evidence_multiplier: 2.0
+expected_final_score: 176
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can show status transitions, but they do not prove that eliminating new true-to-false residual status drops requires hitting every old unhit status-drop locus.
+origin: cycle-99
+tags: [quality-surface, semantic-repair, residual-cut, status-drop, repair-hitting, obstruction-class, genius-support]
+created: 2026-06-23
+cycle: 99
+lean: proved-in-research
+planned_report_section: "Cycle 99: Residual status-drop repair-hitting necessity"
+---
+
+# Residual Status-Drop Repair-Hitting Necessity
+
+## 主張
+
+same-carrier old/new finite atlas に supplied exact boolean residual status reading を置く。
+`ResidualStatusDropRepairTransport` は、repair が触った edge/source/target loci を
+`edgeHit`、`sourceHit`、`targetHit` として記録し、unhit な active edge、source `true`
+status、target `false` status が old から new へ保存される三つの law を持つ。
+
+この三 law から、unhit な old true-to-false status drop は new true-to-false status drop
+として残る。したがって new 側に status drop が存在しない、または canonical residual cut
+class が vanishes するなら、old status drop は edge/source/target のどこかで hit されて
+いなければならない。
+
+これは必要条件であり、hit sufficiency、repair synthesis、global minimality、vanishing-to-closure、
+true `H^1` / Cech / coboundary quotient、status extraction、ArchMap/tooling correctness、
+runtime/UI correctness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`finite residual status-drop repair-hitting theorem` / `status-drop necessity` / `obstruction-class-support`
+
+## 依拠
+
+- Cycle 96: same-carrier residual cut repair-hitting necessity。
+- Cycle 98: finite residual status-drop obstruction adapter。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+status dashboard の言い換えではない。
+direct persistence を仮定するのではなく、edge preservation、source true preservation、target false
+preservation の三 law から drop persistence を証明し、その結果を status-drop absence と canonical
+vanishing の repair-hit 必要条件へ接続した。
+
+## 数学的興味
+
+finite pre-H1-facing obstruction reading を repair-hitting necessity と接続する。
+status drop を active true-to-false edge として読むだけでなく、その drop を消すためにどの loci
+を hit しなければならないかを theorem として固定する。
+
+## GOAL への前進
+
+semantic repair-gluing obstruction target に向けて、residual status surface 上の local pass / global fail
+候補を repair frontier obligation に戻す支持補題を得た。
+genius unlock ではないが、future semantic repair-gluing obstruction theorem の支柱になる。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は status transition や red/green node を表示できる。
+しかし、new status-drop absence / canonical vanishing が old status-drop loci の hit obligation を
+必要条件として要求することは証明しない。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 98 の exact status-drop adapter と Cycle 96 の repair-hitting necessity を、
+ 三つの unhit preservation law から導く status-level theorem として接続した。
+- `dullness_risk`: 単なる合成に見える危険がある。`ExistsResidualStatusDrop` bridge、canonical
+  vanishing bridge、selected witness/no-go package を揃えて回避する。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualStatusDropRepairHitting.lean`
+  で generic theorem と selected frontier-to-flat witness を証明する。
+
+## CS / SWE への帰結
+
+品質 surface 上で status drop が消えたと主張するには、old drop の edge/source/target locus に
+repair hit が入ったことを説明しなければならない。
+この theorem は、status green 化を単なる表示ではなく repair frontier obligation へ戻す。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualStatusDropRepairHitting.lean` に固定した。
+
+- `ResidualStatusDropRepairTransport`
+- `AllOldStatusDropsHit`
+- `unhit_oldStatusDrop_persists_newStatusDrop`
+- `unhit_oldStatusDrop_preserves_newExistsStatusDrop`
+- `unhit_oldStatusDrop_preserves_newCanonicalNonzero`
+- `newNoStatusDrop_forces_oldStatusDropHit`
+- `newNoStatusDrop_forces_allOldStatusDropsHit`
+- `newCanonicalVanishes_forces_oldStatusDropHit`
+- `newCanonicalVanishes_forces_allOldStatusDropsHit`
+- `unhit_oldStatusDrop_obstructs_newTransitionClosure`
+- `unhit_oldStatusDrop_obstructs_newTransitionCoherentData`
+- `selectedNoHitStatusDropRepairTransport`
+- `selectedNoHitStatusDrop_preserves_canonicalNonzero`
+- `selected_newNoStatusDrop_requires_frontierFlatHit`
+- `selected_newCanonicalVanishes_requires_frontierFlatHit`
+- `selectedNoHitStatusDrop_obstructs_transitionClosure`
+- `selectedNoHitStatusDrop_obstructs_transitionCoherentData`
+- `semanticResidualStatusDropRepairHitting_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualStatusDropRepairHitting.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualStatusDropRepairHitting`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic theorem 群は axiom-free。selected witness と package は標準
+  `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、supplied exact status readings、same-carrier unhit preservation laws、status-drop
+persistence、new no-drop / canonical vanishing から old status-drop hit necessity への接続に限定する。
+unchecked: hit sufficiency、repair synthesis、global minimality、vanishing-to-closure、true H1/cohomology、
+Cech quotient、coboundary quotient、status extraction、ArchMap correctness、runtime/UI correctness、
+whole-codebase quality。
+
+## 審判メモ
+
+- G1: accept with required decomposition。edge/source-true/target-false preservation laws から導くなら
+  base 82-86、final 164-172 以上が妥当。genius unlock ではなく `genius-support`。
+- G2: accept with revise。direct persistence field だけでなく三 law から drop persistence を証明し、
+  selected witness と theorem package を揃えれば base 86-88、final 172-176。
+- G2 revise 解決: persistence を law-derived にし、`ExistsResidualStatusDrop` bridge、canonical
+  vanishing bridge、selected witness/no-go package を追加した。
+
+## 追加 required fields
+
+- `mathematical_interest`: finite status-drop obstruction reading を repair-hitting necessity へ接続する。
+- `goal_advancement`: semantic repair-gluing obstruction target の repair frontier obligation layer を強化した。
+- `planned_theorem_names`: `unhit_oldStatusDrop_persists_newStatusDrop`, `newCanonicalVanishes_forces_allOldStatusDropsHit`, `semanticResidualStatusDropRepairHitting_package`
+- `visible_projection`: exact residual status reading、active true-to-false edge、hit loci。
+- `protected_structure`: unhit edge/source-true/target-false preservation、status-drop absence、canonical vanishing、hit necessity。
+- `exactness_or_minimality_claim`: supplied exact status reading と unhit preservation law に相対化した必要条件。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: no-hit old status drop が残るなら new no-drop / canonical vanishing claim は失敗する。
+- `previous_cycle_delta`: Cycle 98 の status-drop adapter を repair-hit obligation へ戻した。
+- `rival_stress_test`: rival は status 表示をできても、status-drop elimination の hit necessity を theorem として出さない。
+- `genius_potential`: support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の repair-hit layer。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: exact status-drop adapter を repair frontier obligation に接続する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-adapter.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-cut-repair-hitting.md`
+- planned report section: `Cycle 99: Residual status-drop repair-hitting necessity`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 99 G1/G2 で status-drop repair-hitting necessity を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualStatusDropRepairHitting.lean` に固定し、単体
+  `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 13698
+- total SCORE: 13874
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -103,8 +103,9 @@
   - semantic-obstruction / repair-necessity / finite-atlas-transition / obstruction-class-support / genius-support: 176
   - semantic-obstruction / repair-necessity / cut-locus-transport / finite-atlas-transition / genius-support: 180
   - semantic-obstruction / status-drop-adapter / finite-atlas-transition / obstruction-class-support / genius-support: 176
+  - semantic-obstruction / status-drop-adapter / repair-necessity / finite-atlas-transition / genius-support: 176
 - evidence portfolio:
-  - proved-in-research: 98
+  - proved-in-research: 99
 
 ## Phase synthesis
 
@@ -120,7 +121,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-98 件の Lean-proved research artifacts は、次の paper seed を形成している。
+99 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -147,6 +148,7 @@ certificate の基本単位は
 - semantic residual cut repair hitting は、old/new atlas 間で unhit cuts が persistence law を満たすなら、new canonical residual cut class の vanishing が old residual cut の edge/source/target hit を必要とすることを示す。
 - semantic residual mapped repair hitting は、unhit edge/present/free preservation laws により、repair-hitting necessity が finite carrier/schema change をまたいで transport されることを示す。
 - semantic residual status-drop adapter は、supplied exact boolean residual status reading の下で canonical residual cut class が active true-to-false status-drop class と一致することを示す。
+- semantic residual status-drop repair hitting は、unhit edge/status preservation laws により、new status-drop absence または canonical vanishing が old true-to-false status drop の edge/source/target hit を必要とすることを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -205,8 +207,9 @@ Cycle 95 後の total SCORE は 13166 であり、tracking Issue active threshol
 Cycle 96 後の total SCORE は 13342 であり、tracking Issue active threshold 15000 までは残り 1658 SCORE である。
 Cycle 97 後の total SCORE は 13522 であり、tracking Issue active threshold 15000 までは残り 1478 SCORE である。
 Cycle 98 後の total SCORE は 13698 であり、tracking Issue active threshold 15000 までは残り 1302 SCORE である。
+Cycle 99 後の total SCORE は 13874 であり、tracking Issue active threshold 15000 までは残り 1126 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 98 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 99 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -237,7 +240,8 @@ semantic residual cut-locus transport theorem、
 semantic residual atlas map law induction theorem、
 semantic residual cut repair-hitting theorem、
 semantic residual mapped repair-hitting theorem、
-semantic residual status-drop adapter theorem を含む。
+semantic residual status-drop adapter theorem、
+semantic residual status-drop repair-hitting theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5265,4 +5269,80 @@ correctness, or whole-codebase quality.
 
 Cycle 98 後の total SCORE は 13698 であり、tracking Issue active threshold 15000 までは残り 1302 SCORE である。
 次 cycle では、local-pass/global-fail taxonomy after status adapter、finite pre-H1 support without cohomology overclaim、cross-carrier minimality、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 99: Residual status-drop repair-hitting necessity
+
+```text
+candidate: Residual status-drop repair-hitting necessity
+candidate_type: finite residual status-drop repair-hitting theorem / status-drop necessity / obstruction-class-support
+evidence_stage: proved-in-research
+base_score: 88
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 176
+category: semantic-obstruction / status-drop-adapter / repair-necessity / finite-atlas-transition / genius-support
+goal_delta: Cycle 98 の exact status-drop adapter を Cycle 96 の repair-hitting necessity と接続し、status-drop elimination を old drop hit obligation へ戻した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、status-drop repair transport、unhit edge/source-true/target-false preservation laws、drop persistence、new no-drop/canonical vanishing forces old drop hit、selected frontier-to-flat no-hit witness、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は status transition や red/green surface を表示できるが、new status-drop absence または canonical vanishing が old true-to-false drop の edge/source/target hit を必要とすることを Lean theorem として要求できない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualStatusDropRepairHitting.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualStatusDropRepairHitting`, and `lake build FormalAGResearch` passed. Axiom probe reported the generic status-drop repair-hitting theorem family axiom-free; selected witness and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: local-pass/global-fail taxonomy after status-drop repair necessity; cross-carrier status-drop repair hitting; finite pre-H1 support without cohomology overclaim; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualStatusDropRepairHitting.lean`
+connects the finite status-drop adapter to repair-hitting necessity.  For
+same-carrier old/new finite semantic repair atlas skeletons, supplied exact
+boolean residual status readings record active residual status.  A
+`ResidualStatusDropRepairTransport` adds supplied hit predicates for edge,
+source-index, and target-index loci.  Its laws require old active edges,
+source `true` status, and target `false` status to be preserved whenever those
+loci are unhit.
+
+From those three unhit preservation laws, Lean proves that an unhit old
+true-to-false status drop persists as a new true-to-false status drop.  Thus
+the new atlas cannot have no status drops, nor can its canonical residual cut
+class vanish, unless every old status drop is hit at the edge, source, or
+target locus.
+
+The selected witness specializes this to the frontier-to-flat status drop with
+no hit predicates.  The selected old drop remains a canonical nonzero
+obstruction, and selected no-drop / canonical vanishing claims would require a
+frontier-to-flat hit.  The same selected no-hit witness also obstructs
+transition closure and transition-coherent atlas data.
+
+Lean proves:
+
+- `ResidualStatusDropRepairTransport`: same-carrier status-drop repair transport with unhit edge/source-true/target-false preservation laws.
+- `AllOldStatusDropsHit`: all old status drops are hit by supplied hit predicates.
+- `unhit_oldStatusDrop_persists_newStatusDrop`: an unhit old status drop persists as a new status drop.
+- `unhit_oldStatusDrop_preserves_newExistsStatusDrop`: an unhit old status drop gives an existing new status drop.
+- `unhit_oldStatusDrop_preserves_newCanonicalNonzero`: an unhit old status drop keeps the new canonical class nonzero.
+- `newNoStatusDrop_forces_oldStatusDropHit`: new absence of status drops forces a given old status drop to be hit.
+- `newNoStatusDrop_forces_allOldStatusDropsHit`: new absence of status drops forces all old status drops to be hit.
+- `newCanonicalVanishes_forces_oldStatusDropHit`: new canonical vanishing forces a given old status drop to be hit.
+- `newCanonicalVanishes_forces_allOldStatusDropsHit`: new canonical vanishing forces all old status drops to be hit.
+- `unhit_oldStatusDrop_obstructs_newTransitionClosure`: an unhit old status drop obstructs new transition closure.
+- `unhit_oldStatusDrop_obstructs_newTransitionCoherentData`: an unhit old status drop rules out new transition-coherent data.
+- `selectedNoHitStatusDropRepairTransport`: selected no-hit status-drop repair transport.
+- `selectedNoHitStatusDrop_preserves_canonicalNonzero`: selected no-hit status drop remains nonzero.
+- `selected_newNoStatusDrop_requires_frontierFlatHit`: selected no-drop claim requires frontier-to-flat hit.
+- `selected_newCanonicalVanishes_requires_frontierFlatHit`: selected canonical vanishing requires frontier-to-flat hit.
+- `selectedNoHitStatusDrop_obstructs_transitionClosure`: selected no-hit status drop obstructs transition closure.
+- `selectedNoHitStatusDrop_obstructs_transitionCoherentData`: selected no-hit status drop rules out coherent data.
+- `semanticResidualStatusDropRepairHitting_package`: theorem package.
+
+This cycle is a strong support node, not a `genius unlock`.  It proves a
+status-level repair-hitting necessary condition under supplied exact status
+readings and explicit unhit preservation laws.  It does not prove hit
+sufficiency, repair synthesis, global minimality, vanishing-to-closure, true
+`H^1` / Cech / coboundary quotient, status extraction, source extraction,
+ArchMap correctness, runtime repair synthesis, tooling runtime extraction, UI
+correctness, or whole-codebase quality.
+
+### Next Frontier
+
+Cycle 99 後の total SCORE は 13874 であり、tracking Issue active threshold 15000 までは残り 1126 SCORE である。
+次 cycle では、local-pass/global-fail taxonomy after status-drop repair necessity、cross-carrier status-drop repair hitting、finite pre-H1 support without cohomology overclaim、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 99 として、finite residual status-drop repair-hitting necessity を Lean research layer に追加しました。
Cycle 98 の exact status-drop adapter と Cycle 96 の repair-hitting necessity を接続し、same-carrier old/new exact status readings 上で、unhit edge/source-true/target-false preservation laws から old status drop persistence、new no-drop / canonical vanishing から old status-drop hit necessityを証明します。

SCORE は +176 とし、`G-aat-quality-surface-01` の total を 13698 から 13874 に更新しました。genius unlock ではなく `genius-support` として扱います。

## 証明した定理

- `ResidualStatusDropRepairTransport`
- `AllOldStatusDropsHit`
- `unhit_oldStatusDrop_persists_newStatusDrop`
- `unhit_oldStatusDrop_preserves_newExistsStatusDrop`
- `unhit_oldStatusDrop_preserves_newCanonicalNonzero`
- `newNoStatusDrop_forces_oldStatusDropHit`
- `newNoStatusDrop_forces_allOldStatusDropsHit`
- `newCanonicalVanishes_forces_oldStatusDropHit`
- `newCanonicalVanishes_forces_allOldStatusDropsHit`
- `unhit_oldStatusDrop_obstructs_newTransitionClosure`
- `unhit_oldStatusDrop_obstructs_newTransitionCoherentData`
- `selectedNoHitStatusDropRepairTransport`
- `selectedNoHitStatusDrop_preserves_canonicalNonzero`
- `selected_newNoStatusDrop_requires_frontierFlatHit`
- `selected_newCanonicalVanishes_requires_frontierFlatHit`
- `selectedNoHitStatusDrop_obstructs_transitionClosure`
- `selectedNoHitStatusDrop_obstructs_transitionCoherentData`
- `semanticResidualStatusDropRepairHitting_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-repair-hitting.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualStatusDropRepairHitting.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualStatusDropRepairHitting`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

補足: `lake build` は成功しました。既存 unrelated warning として `Formal/Arch/Extension/FeatureExtensionExamples.lean` の unnecessary sequence focus linter warning が 2 件出ています。

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: proved-in-research。

`Closes #N` チェックは意図的に未チェックです。#2348 は active threshold 15000 まで継続する tracking Issue であり、この PR では close しません。
