### PR TITLE
Cycle 100 mapped status-drop repair hitting を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -96,3 +96,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualCutRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualMappedRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropAdapter
 import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropRepairHitting
+import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropRepairHitting

--- a/Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropRepairHitting.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropRepairHitting.lean
@@ -1,0 +1,729 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropRepairHitting
+
+/-!
+Cycle 100 evidence for `G-aat-quality-surface-01`.
+
+This file transports status-drop repair-hitting necessity across finite
+carrier/schema changes.  For old/new exact boolean residual status readings,
+a mapped status-drop repair transport carries source-side hit predicates and
+preserves old active edges, old source `true` status, and old target `false`
+status after mapping whenever the corresponding old loci are unhit.  Hence an
+unhit old true-to-false status drop maps to a new true-to-false status drop.
+So absence of new status drops, or vanishing of the new canonical residual cut
+class, forces the old status drop to be hit.
+
+This is a necessary condition only.  It does not assert hit sufficiency,
+repair synthesis, global minimality, vanishing-to-closure, true H1/Cech/
+coboundary structure, status extraction, ArchMap correctness, tooling/runtime/
+UI correctness, or whole-codebase quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualMappedStatusDropRepairHitting
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasMorphism
+open SemanticResidualAtlasMapLaws
+open SemanticResidualCutRepairHitting
+open SemanticResidualMappedRepairHitting
+open SemanticResidualStatusDropAdapter
+open SemanticResidualStatusDropRepairHitting
+
+/-! ## Cross-carrier status-drop repair transport maps -/
+
+/--
+A cross-carrier status-drop repair transport map preserves old active edges,
+source `true` status, and target `false` status after mapping, away from
+supplied source-side hit loci.
+-/
+structure ResidualStatusDropRepairTransportMap
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (newReading : ResidualBooleanStatusReading new) where
+  mapIndex : LeftIndex -> RightIndex
+  edgeHit : LeftIndex × LeftIndex -> Prop
+  sourceHit : LeftIndex -> Prop
+  targetHit : LeftIndex -> Prop
+  edge_preserving_unhit :
+    forall source target,
+      old.edge source target ->
+        Not (edgeHit (source, target)) ->
+          new.edge (mapIndex source) (mapIndex target)
+  source_true_preserving_unhit :
+    forall index,
+      oldReading.status index = true ->
+        Not (sourceHit index) ->
+          newReading.status (mapIndex index) = true
+  target_false_preserving_unhit :
+    forall index,
+      oldReading.status index = false ->
+        Not (targetHit index) ->
+          newReading.status (mapIndex index) = false
+
+/-- Every old mapped status-drop hit obligation is satisfied. -/
+def AllMappedOldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop) : Prop :=
+  forall pair,
+    ResidualStatusDropPair oldReading pair ->
+      ResidualCutHit edgeHit sourceHit targetHit pair
+
+/-! ## Mapped persistence and repair necessity -/
+
+/-- An unhit old status drop maps to a new status drop. -/
+theorem unhit_oldStatusDrop_maps_to_newStatusDrop
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transportMap.edgeHit pair))
+    (hsource : Not (transportMap.sourceHit pair.1))
+    (htarget : Not (transportMap.targetHit pair.2)) :
+    ResidualStatusDropPair newReading
+      (mapResidualPair transportMap.mapIndex pair) := by
+  exact
+    ⟨transportMap.edge_preserving_unhit pair.1 pair.2 hdrop.1 hedge,
+      transportMap.source_true_preserving_unhit pair.1 hdrop.2.1 hsource,
+      transportMap.target_false_preserving_unhit pair.2 hdrop.2.2 htarget⟩
+
+/-- An unhit old status drop gives an existing mapped new status drop. -/
+theorem unhit_oldStatusDrop_maps_to_newExistsStatusDrop
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transportMap.edgeHit pair))
+    (hsource : Not (transportMap.sourceHit pair.1))
+    (htarget : Not (transportMap.targetHit pair.2)) :
+    ExistsResidualStatusDrop newReading := by
+  have hnewDrop :
+      ResidualStatusDropPair newReading
+        (mapResidualPair transportMap.mapIndex pair) :=
+    unhit_oldStatusDrop_maps_to_newStatusDrop
+      transportMap hdrop hedge hsource htarget
+  exact
+    ⟨mapResidualPair transportMap.mapIndex pair,
+      hnewDrop.1,
+      hnewDrop.2.1,
+      hnewDrop.2.2⟩
+
+/-- An unhit old status drop gives a nonzero mapped new canonical class. -/
+theorem unhit_oldStatusDrop_maps_to_newCanonicalNonzero
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transportMap.edgeHit pair))
+    (hsource : Not (transportMap.sourceHit pair.1))
+    (htarget : Not (transportMap.targetHit pair.2)) :
+    (canonicalResidualCutCochain new).CutNonzero := by
+  exact
+    (canonicalResidualCutClass_nonzero_iff_existsStatusDrop
+      newReading).mpr
+      (unhit_oldStatusDrop_maps_to_newExistsStatusDrop
+        transportMap hdrop hedge hsource htarget)
+
+/--
+If the new status surface has no active drops, an old source status drop must
+be hit before transport.
+-/
+theorem newNoStatusDrop_forces_mappedOldStatusDropHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    (hno : NoResidualStatusDrop newReading)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair) :
+    ResidualCutHit
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit
+      pair := by
+  intro hunhit
+  have hnewDrop :
+      ResidualStatusDropPair newReading
+        (mapResidualPair transportMap.mapIndex pair) :=
+    unhit_oldStatusDrop_maps_to_newStatusDrop
+      transportMap hdrop hunhit.1 hunhit.2.1 hunhit.2.2
+  exact
+    hno
+      (mapResidualPair transportMap.mapIndex pair)
+      hnewDrop.1
+      hnewDrop.2
+
+/-- New no-drop status forces every old status drop to be hit. -/
+theorem newNoStatusDrop_forces_allMappedOldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    (hno : NoResidualStatusDrop newReading) :
+    AllMappedOldStatusDropsHit
+      oldReading
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit := by
+  intro pair hdrop
+  exact
+    newNoStatusDrop_forces_mappedOldStatusDropHit
+      transportMap hno hdrop
+
+/-- New canonical vanishing forces a given old status drop to be hit. -/
+theorem newCanonicalVanishes_forces_mappedOldStatusDropHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair) :
+    ResidualCutHit
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit
+      pair := by
+  have hno :
+      NoResidualStatusDrop newReading :=
+    (canonicalResidualCutClass_vanishes_iff_noStatusDrop
+      newReading).mp hvanish
+  exact newNoStatusDrop_forces_mappedOldStatusDropHit
+    transportMap hno hdrop
+
+/-- New canonical vanishing forces every old status drop to be hit. -/
+theorem newCanonicalVanishes_forces_allMappedOldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes) :
+    AllMappedOldStatusDropsHit
+      oldReading
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit := by
+  intro pair hdrop
+  exact newCanonicalVanishes_forces_mappedOldStatusDropHit
+    transportMap hvanish hdrop
+
+/-- An unhit old status drop obstructs new transition closure after mapping. -/
+theorem unhit_oldStatusDrop_maps_to_newTransitionClosureObstruction
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transportMap.edgeHit pair))
+    (hsource : Not (transportMap.sourceHit pair.1))
+    (htarget : Not (transportMap.targetHit pair.2))
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (AtlasResidualTransitionClosed new transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain new)
+      (unhit_oldStatusDrop_maps_to_newCanonicalNonzero
+        transportMap hdrop hedge hsource htarget)
+      transition
+
+/-- An unhit old status drop rules out mapped new transition-coherent data. -/
+theorem unhit_oldStatusDrop_maps_to_newTransitionCoherentDataObstruction
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair)
+    (hedge : Not (transportMap.edgeHit pair))
+    (hsource : Not (transportMap.sourceHit pair.1))
+    (htarget : Not (transportMap.targetHit pair.2))
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (Nonempty (TransitionCoherentAtlasData new transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (canonicalResidualCutCochain new)
+      (unhit_oldStatusDrop_maps_to_newCanonicalNonzero
+        transportMap hdrop hedge hsource htarget)
+      transition
+
+/-! ## Cycle-95 inducing-map bridge -/
+
+/--
+A residual-cut inducing atlas map induces a mapped status-drop repair transport
+between exact status readings for any source-side hit predicates.
+-/
+def residualCutInducingAtlasMap_to_statusDropRepairTransportMap
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop) :
+    ResidualStatusDropRepairTransportMap oldReading newReading where
+  mapIndex := atlasMap.mapIndex
+  edgeHit := edgeHit
+  sourceHit := sourceHit
+  targetHit := targetHit
+  edge_preserving_unhit := by
+    intro source target hedge _hunhit
+    exact atlasMap.edge_preserving source target hedge
+  source_true_preserving_unhit := by
+    intro index htrue _hunhit
+    exact
+      (newReading.present_iff_true (atlasMap.mapIndex index)).mp
+        (atlasMap.residual_present_preserving index
+          ((oldReading.present_iff_true index).mpr htrue))
+  target_false_preserving_unhit := by
+    intro index hfalse _hunhit
+    exact
+      (newReading.free_iff_false (atlasMap.mapIndex index)).mp
+        (atlasMap.residual_free_preserving index
+          ((oldReading.free_iff_false index).mpr hfalse))
+
+/-- Under an inducing map, new no-drop status forces all old status drops hit. -/
+theorem residualCutInducingAtlasMap_newNoStatusDrop_forces_oldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    (hno : NoResidualStatusDrop newReading) :
+    AllMappedOldStatusDropsHit oldReading edgeHit sourceHit targetHit := by
+  exact
+    newNoStatusDrop_forces_allMappedOldStatusDropsHit
+      (residualCutInducingAtlasMap_to_statusDropRepairTransportMap
+        (oldReading := oldReading)
+        (newReading := newReading)
+        atlasMap edgeHit sourceHit targetHit)
+      hno
+
+/-- Under an inducing map, new canonical vanishing forces all old status drops hit. -/
+theorem residualCutInducingAtlasMap_newCanonicalVanishes_forces_oldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    (hvanish : (canonicalResidualCutCochain new).CutVanishes) :
+    AllMappedOldStatusDropsHit oldReading edgeHit sourceHit targetHit := by
+  exact
+    newCanonicalVanishes_forces_allMappedOldStatusDropsHit
+      (residualCutInducingAtlasMap_to_statusDropRepairTransportMap
+        (oldReading := oldReading)
+        (newReading := newReading)
+        atlasMap edgeHit sourceHit targetHit)
+      hvanish
+
+/-! ## Selected source-to-extended status witness -/
+
+/-- Exact status reading on the selected extended carrier. -/
+def selectedExtendedFrontierFlatResidualStatus
+    (index : SelectedExtendedOverlapIndex) : Bool :=
+  selectedFrontierFlatResidualStatus
+    (selectedExtendedToSelectedIndex index)
+
+/-- The selected extended atlas has an exact boolean status reading. -/
+def selectedExtendedFrontierFlatResidualStatusReading :
+    ResidualBooleanStatusReading selectedExtendedFrontierFlatAtlasSkeleton where
+  status := selectedExtendedFrontierFlatResidualStatus
+  present_iff_true := by
+    intro index
+    simpa [selectedExtendedFrontierFlatAtlasSkeleton,
+      selectedExtendedFrontierFlatResidualStatus]
+      using
+        (selectedFrontierFlatResidualStatusReading.present_iff_true
+          (selectedExtendedToSelectedIndex index))
+  free_iff_false := by
+    intro index
+    simpa [selectedExtendedFrontierFlatAtlasSkeleton,
+      selectedExtendedFrontierFlatResidualStatus]
+      using
+        (selectedFrontierFlatResidualStatusReading.free_iff_false
+          (selectedExtendedToSelectedIndex index))
+
+/-- The selected-to-extended no-hit status transport map. -/
+def selectedToExtendedNoHitStatusDropRepairTransportMap :
+    ResidualStatusDropRepairTransportMap
+      selectedFrontierFlatResidualStatusReading
+      selectedExtendedFrontierFlatResidualStatusReading :=
+  residualCutInducingAtlasMap_to_statusDropRepairTransportMap
+    selectedToExtendedResidualCutInducingMap
+    selectedNoEdgeHit
+    selectedNoSourceHit
+    selectedNoTargetHit
+
+/-- The selected frontier-to-flat source status drop. -/
+theorem selectedFrontierFlat_statusDropPair :
+    ResidualStatusDropPair
+      selectedFrontierFlatResidualStatusReading
+      selectedFrontierFlatResidualCutPair := by
+  exact ⟨selected_frontierToFlatEdge, rfl, rfl⟩
+
+/-- The unhit selected status drop maps to an extended status drop. -/
+theorem selectedToExtendedNoHit_maps_frontierFlatStatusDrop :
+    ResidualStatusDropPair
+      selectedExtendedFrontierFlatResidualStatusReading
+      (mapResidualPair
+        selectedToExtendedNoHitStatusDropRepairTransportMap.mapIndex
+        selectedFrontierFlatResidualCutPair) := by
+  exact
+    unhit_oldStatusDrop_maps_to_newStatusDrop
+      selectedToExtendedNoHitStatusDropRepairTransportMap
+      selectedFrontierFlat_statusDropPair
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+
+/-- The no-hit selected source status drop remains nonzero after extension. -/
+theorem selectedToExtendedNoHit_preserves_extendedStatusCanonicalNonzero :
+    (canonicalResidualCutCochain
+      selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    unhit_oldStatusDrop_maps_to_newCanonicalNonzero
+      selectedToExtendedNoHitStatusDropRepairTransportMap
+      selectedFrontierFlat_statusDropPair
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+
+/--
+For any source-side hit predicates, no status drops in the extended target
+force the selected source status drop to be hit.
+-/
+theorem selectedToExtended_newNoStatusDrop_requires_frontierFlatStatusHit
+    {edgeHit :
+      SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+    {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop}
+    (hno : NoResidualStatusDrop
+      selectedExtendedFrontierFlatResidualStatusReading) :
+    ResidualCutHit
+      edgeHit
+      sourceHit
+      targetHit
+      selectedFrontierFlatResidualCutPair := by
+  exact
+    newNoStatusDrop_forces_mappedOldStatusDropHit
+      (residualCutInducingAtlasMap_to_statusDropRepairTransportMap
+        selectedToExtendedResidualCutInducingMap
+        edgeHit
+        sourceHit
+        targetHit)
+      hno
+      selectedFrontierFlat_statusDropPair
+
+/--
+For any source-side hit predicates, vanishing of the extended target canonical
+class forces the selected source status drop to be hit.
+-/
+theorem selectedToExtended_newCanonicalVanishes_requires_frontierFlatStatusHit
+    {edgeHit :
+      SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+    {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop}
+    (hvanish :
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton).CutVanishes) :
+    ResidualCutHit
+      edgeHit
+      sourceHit
+      targetHit
+      selectedFrontierFlatResidualCutPair := by
+  have hall :
+      AllMappedOldStatusDropsHit
+        selectedFrontierFlatResidualStatusReading
+        edgeHit
+        sourceHit
+        targetHit :=
+    residualCutInducingAtlasMap_newCanonicalVanishes_forces_oldStatusDropsHit
+      (oldReading := selectedFrontierFlatResidualStatusReading)
+      (newReading := selectedExtendedFrontierFlatResidualStatusReading)
+      selectedToExtendedResidualCutInducingMap
+      edgeHit
+      sourceHit
+      targetHit
+      hvanish
+  exact hall
+      selectedFrontierFlatResidualCutPair
+      selectedFrontierFlat_statusDropPair
+
+/-- The no-hit selected source status drop obstructs extended transition closure. -/
+theorem selectedToExtendedNoHit_obstructs_extendedStatusTransitionClosure
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedExtendedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    unhit_oldStatusDrop_maps_to_newTransitionClosureObstruction
+      selectedToExtendedNoHitStatusDropRepairTransportMap
+      selectedFrontierFlat_statusDropPair
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+      transition
+
+/-- The no-hit selected source status drop rules out extended coherent data. -/
+theorem selectedToExtendedNoHit_obstructs_extendedStatusTransitionCoherentData
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedExtendedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    unhit_oldStatusDrop_maps_to_newTransitionCoherentDataObstruction
+      selectedToExtendedNoHitStatusDropRepairTransportMap
+      selectedFrontierFlat_statusDropPair
+      (by intro h; cases h)
+      (by intro h; cases h)
+      (by intro h; cases h)
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-100 theorem package: status-drop repair-hit necessity transports across
+finite carrier/schema changes under unhit edge/source-true/target-false laws.
+-/
+theorem semanticResidualMappedStatusDropRepairHitting_package :
+    (forall {LeftIndex : Type w}
+      {LeftAtom : Type u}
+      {RightIndex : Type x}
+      {RightAtom : Type v}
+      {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+      {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+      {oldReading : ResidualBooleanStatusReading old}
+      {newReading : ResidualBooleanStatusReading new},
+      forall transportMap :
+        ResidualStatusDropRepairTransportMap oldReading newReading,
+      forall pair : LeftIndex × LeftIndex,
+        ResidualStatusDropPair oldReading pair ->
+          Not (transportMap.edgeHit pair) ->
+            Not (transportMap.sourceHit pair.1) ->
+              Not (transportMap.targetHit pair.2) ->
+                ResidualStatusDropPair newReading
+                  (mapResidualPair transportMap.mapIndex pair)) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new},
+        forall transportMap :
+          ResidualStatusDropRepairTransportMap oldReading newReading,
+        NoResidualStatusDrop newReading ->
+          AllMappedOldStatusDropsHit
+            oldReading
+            transportMap.edgeHit
+            transportMap.sourceHit
+            transportMap.targetHit) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new},
+        forall transportMap :
+          ResidualStatusDropRepairTransportMap oldReading newReading,
+        (canonicalResidualCutCochain new).CutVanishes ->
+          AllMappedOldStatusDropsHit
+            oldReading
+            transportMap.edgeHit
+            transportMap.sourceHit
+            transportMap.targetHit) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {_newReading : ResidualBooleanStatusReading new},
+        forall _atlasMap : ResidualCutInducingAtlasMap old new,
+        forall edgeHit : LeftIndex × LeftIndex -> Prop,
+        forall sourceHit targetHit : LeftIndex -> Prop,
+        (canonicalResidualCutCochain new).CutVanishes ->
+          AllMappedOldStatusDropsHit oldReading edgeHit sourceHit targetHit) /\
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (forall
+        {edgeHit :
+          SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+        {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop},
+        NoResidualStatusDrop
+          selectedExtendedFrontierFlatResidualStatusReading ->
+          ResidualCutHit
+            edgeHit
+            sourceHit
+            targetHit
+            selectedFrontierFlatResidualCutPair) /\
+      (forall
+        {edgeHit :
+          SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+        {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop},
+        (canonicalResidualCutCochain
+          selectedExtendedFrontierFlatAtlasSkeleton).CutVanishes ->
+          ResidualCutHit
+            edgeHit
+            sourceHit
+            targetHit
+            selectedFrontierFlatResidualCutPair) /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedExtendedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedExtendedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading}
+        transportMap pair hdrop hedge hsource htarget =>
+        unhit_oldStatusDrop_maps_to_newStatusDrop
+          transportMap hdrop hedge hsource htarget,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading}
+        transportMap hno =>
+        newNoStatusDrop_forces_allMappedOldStatusDropsHit
+          transportMap hno,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading}
+        transportMap hvanish =>
+        newCanonicalVanishes_forces_allMappedOldStatusDropsHit
+          transportMap hvanish,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading}
+        atlasMap edgeHit sourceHit targetHit hvanish =>
+        residualCutInducingAtlasMap_newCanonicalVanishes_forces_oldStatusDropsHit
+          (oldReading := _oldReading)
+          (newReading := _newReading)
+          atlasMap edgeHit sourceHit targetHit hvanish,
+      selectedToExtendedNoHit_preserves_extendedStatusCanonicalNonzero,
+      fun {_edgeHit} {_sourceHit} {_targetHit} hno =>
+        selectedToExtended_newNoStatusDrop_requires_frontierFlatStatusHit hno,
+      fun {_edgeHit} {_sourceHit} {_targetHit} hvanish =>
+        selectedToExtended_newCanonicalVanishes_requires_frontierFlatStatusHit
+          hvanish,
+      selectedToExtendedNoHit_obstructs_extendedStatusTransitionClosure,
+      selectedToExtendedNoHit_obstructs_extendedStatusTransitionCoherentData⟩
+
+end SemanticResidualMappedStatusDropRepairHitting
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-repair-hitting.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-repair-hitting.md
@@ -1,0 +1,170 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: cross-carrier status-drop repair-hitting theorem / mapped repair necessity / genius-support convergence
+candidate_type: cross-carrier residual status-drop repair-hitting theorem / status-drop transport / obstruction-class-support
+capability_category: semantic-obstruction / status-drop-adapter / repair-necessity / cross-carrier-transport / genius-support
+expected_base_score: 90
+expected_evidence_multiplier: 2.0
+expected_final_score: 180
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can remap status surfaces, but they do not prove that target no-drop or canonical vanishing forces source-side hits for old true-to-false status drops across a finite carrier/schema map.
+origin: cycle-100
+tags: [quality-surface, semantic-repair, residual-cut, status-drop, repair-hitting, transport, obstruction-class, genius-support]
+created: 2026-06-23
+cycle: 100
+lean: proved-in-research
+planned_report_section: "Cycle 100: Cross-carrier residual status-drop repair-hitting transport"
+---
+
+# Cross-Carrier Residual Status-Drop Repair-Hitting Transport
+
+## 主張
+
+old/new finite atlas と supplied exact boolean residual status readings を置く。
+`ResidualStatusDropRepairTransportMap` は `mapIndex` と source-side hit predicates
+`edgeHit`、`sourceHit`、`targetHit` を持ち、unhit な old active edge、source `true`
+status、target `false` status を mapped new 側へ保存する三つの law を持つ。
+
+この三 law から、unhit old true-to-false status drop は mapped new true-to-false status drop
+へ移る。したがって target no-drop status または target canonical residual cut-class vanishing は、
+source-side old status drop が edge/source/target のどこかで hit されることを必要条件として要求する。
+
+Cycle 95 の `ResidualCutInducingAtlasMap` は、old/new の exact status readings が与えられたとき、
+residual-present/free preservation を true/false status preservation に変換して、
+`ResidualStatusDropRepairTransportMap` を誘導する。
+
+これは必要条件であり、hit sufficiency、repair synthesis、global minimality、vanishing-to-closure、
+true `H^1` / Cech / coboundary quotient、status extraction、ArchMap/tooling correctness、
+runtime/UI correctness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`cross-carrier residual status-drop repair-hitting theorem` / `status-drop transport` / `obstruction-class-support`
+
+## 依拠
+
+- Cycle 95: residual atlas map laws。
+- Cycle 98: finite residual status-drop adapter。
+- Cycle 99: same-carrier residual status-drop repair-hitting necessity。
+- open genius target: `Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases`。
+
+## 非自明性
+
+単なる same-carrier theorem の再掲ではない。
+`mapIndex`、source-side hit predicates、exact status readings、Cycle 95 inducing map bridge を使い、
+old status `true/false` を residual-present/free に戻してから new mapped status `true/false` へ進める。
+selected-to-extended Option carrier witness では、target 側にも exact status reading を構成し、
+frontier-to-flat drop が extended target drop として残ることを証明する。
+
+## 数学的興味
+
+finite pre-H1-facing status-drop obstruction reading が、carrier/schema change をまたいでも
+repair-hit obligation として transport されることを示す。
+これは semantic repair-gluing obstruction target に向けた transport-invariant repair frontier layer である。
+
+## GOAL への前進
+
+status-drop adapter、repair-hit necessity、carrier transport を一つの Lean theorem surface に接続した。
+genius unlock ではないが、future finite semantic repair-gluing obstruction theorem に必要な
+cross-carrier support node として強い。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は status view を remap できる。
+しかし、exact readings と residual-cut inducing map の下で target no-drop / target vanishing が
+source old status-drop hit を必要とすることは証明しない。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 99 の status-drop repair-hitting necessity を cross-carrier mapIndex 付きへ上げ、
+  Cycle 95 inducing-map bridge と selected Option-carrier exact status witness を固定した。
+- `dullness_risk`: Cycle 97 と Cycle 99 の単純合成に見える危険がある。exact reading bridge と
+  selected extended status reading / no-hit no-go package により回避した。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropRepairHitting.lean`
+  で generic transport theorem、inducing-map bridge、selected-to-extended witness を証明する。
+
+## CS / SWE への帰結
+
+schema migration や carrier remap 後に status drop が消えたと主張するには、old source-side drop loci が
+hit されたことを説明する必要がある。
+この theorem は、mapped quality surface の green 化を source repair-frontier obligation に戻す。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropRepairHitting.lean` に固定した。
+
+- `ResidualStatusDropRepairTransportMap`
+- `AllMappedOldStatusDropsHit`
+- `unhit_oldStatusDrop_maps_to_newStatusDrop`
+- `unhit_oldStatusDrop_maps_to_newExistsStatusDrop`
+- `unhit_oldStatusDrop_maps_to_newCanonicalNonzero`
+- `newNoStatusDrop_forces_mappedOldStatusDropHit`
+- `newNoStatusDrop_forces_allMappedOldStatusDropsHit`
+- `newCanonicalVanishes_forces_mappedOldStatusDropHit`
+- `newCanonicalVanishes_forces_allMappedOldStatusDropsHit`
+- `unhit_oldStatusDrop_maps_to_newTransitionClosureObstruction`
+- `unhit_oldStatusDrop_maps_to_newTransitionCoherentDataObstruction`
+- `residualCutInducingAtlasMap_to_statusDropRepairTransportMap`
+- `residualCutInducingAtlasMap_newNoStatusDrop_forces_oldStatusDropsHit`
+- `residualCutInducingAtlasMap_newCanonicalVanishes_forces_oldStatusDropsHit`
+- `selectedExtendedFrontierFlatResidualStatus`
+- `selectedExtendedFrontierFlatResidualStatusReading`
+- `selectedToExtendedNoHitStatusDropRepairTransportMap`
+- `selectedFrontierFlat_statusDropPair`
+- `selectedToExtendedNoHit_maps_frontierFlatStatusDrop`
+- `selectedToExtendedNoHit_preserves_extendedStatusCanonicalNonzero`
+- `selectedToExtended_newNoStatusDrop_requires_frontierFlatStatusHit`
+- `selectedToExtended_newCanonicalVanishes_requires_frontierFlatStatusHit`
+- `selectedToExtendedNoHit_obstructs_extendedStatusTransitionClosure`
+- `selectedToExtendedNoHit_obstructs_extendedStatusTransitionCoherentData`
+- `semanticResidualMappedStatusDropRepairHitting_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropRepairHitting.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropRepairHitting`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic theorem 群と inducing-map bridge は axiom-free。selected witness と package は標準
+  `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、supplied exact status readings、finite old/new atlas skeletons、source-side hit predicates、
+mapIndex 付き unhit preservation laws、target no-drop / canonical vanishing から source hit necessity への
+接続に限定する。
+unchecked: hit sufficiency、repair synthesis、global minimality、vanishing-to-closure、true H1/cohomology、
+Cech quotient、coboundary quotient、status extraction、ArchMap correctness、runtime/UI correctness、
+whole-codebase quality、arbitrary atlas category/functoriality。
+
+## 審判メモ
+
+- G1: accept。必須条件は direct persistence field ではなく `mapIndex` 付き three-law transport から mapped drop persistence を証明すること。初期見込みは base 88 / final +176、bridge と selected witness が強ければ base 90 / final +180。
+- G2: accept with required shape。exact status readings を使って Cycle 95 inducing map から true/false preservation を導出し、selected-to-extended Option carrier witness まで揃えば +180 推奨。genius unlock ではなく strong genius-support。
+- G2 revise 解決: `ResidualCutInducingAtlasMap` bridge、selected extended exact status reading、mapped drop persistence、target no-drop/canonical vanishing hit necessity、selected no-hit no-go package を追加した。
+
+## 追加 required fields
+
+- `mathematical_interest`: status-drop repair-hitting necessity を carrier/schema transport invariant にする。
+- `goal_advancement`: semantic repair-gluing obstruction target の cross-carrier repair frontier layer を強化した。
+- `planned_theorem_names`: `unhit_oldStatusDrop_maps_to_newStatusDrop`, `residualCutInducingAtlasMap_to_statusDropRepairTransportMap`, `semanticResidualMappedStatusDropRepairHitting_package`
+- `visible_projection`: exact residual status reading、mapIndex、source-side hit loci、target no-drop / vanishing。
+- `protected_structure`: unhit edge/source-true/target-false preservation、mapped status-drop persistence、target hit necessity。
+- `exactness_or_minimality_claim`: supplied exact status readings と inducing-map preservation に相対化した exact transport。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: no-hit source status drop が mapped target drop として残るなら target no-drop / vanishing claim は失敗する。
+- `previous_cycle_delta`: Cycle 99 の same-carrier status-drop repair hitting を cross-carrier mapIndex 付きへ上げた。
+- `rival_stress_test`: rival は status surface を remap できても、target status-drop elimination の source hit necessity を theorem として出さない。
+- `genius_potential`: strong support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の cross-carrier repair-hit layer。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: exact status-drop adapter、repair-hitting necessity、carrier transport を接続する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-repair-hitting.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-repair-hitting.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-atlas-map-laws.md`
+- planned report section: `Cycle 100: Cross-carrier residual status-drop repair-hitting transport`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 100 G1/G2 で cross-carrier residual status-drop repair-hitting transport を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualMappedStatusDropRepairHitting.lean` に固定し、単体
+  `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 13874
+- total SCORE: 14054
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -104,8 +104,9 @@
   - semantic-obstruction / repair-necessity / cut-locus-transport / finite-atlas-transition / genius-support: 180
   - semantic-obstruction / status-drop-adapter / finite-atlas-transition / obstruction-class-support / genius-support: 176
   - semantic-obstruction / status-drop-adapter / repair-necessity / finite-atlas-transition / genius-support: 176
+  - semantic-obstruction / status-drop-adapter / repair-necessity / cross-carrier-transport / genius-support: 180
 - evidence portfolio:
-  - proved-in-research: 99
+  - proved-in-research: 100
 
 ## Phase synthesis
 
@@ -121,7 +122,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-99 件の Lean-proved research artifacts は、次の paper seed を形成している。
+100 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -149,6 +150,7 @@ certificate の基本単位は
 - semantic residual mapped repair hitting は、unhit edge/present/free preservation laws により、repair-hitting necessity が finite carrier/schema change をまたいで transport されることを示す。
 - semantic residual status-drop adapter は、supplied exact boolean residual status reading の下で canonical residual cut class が active true-to-false status-drop class と一致することを示す。
 - semantic residual status-drop repair hitting は、unhit edge/status preservation laws により、new status-drop absence または canonical vanishing が old true-to-false status drop の edge/source/target hit を必要とすることを示す。
+- semantic residual mapped status-drop repair hitting は、exact status readings と mapIndex 付き unhit preservation laws により、status-drop repair-hitting necessity が finite carrier/schema change をまたいで transport されることを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -208,8 +210,9 @@ Cycle 96 後の total SCORE は 13342 であり、tracking Issue active threshol
 Cycle 97 後の total SCORE は 13522 であり、tracking Issue active threshold 15000 までは残り 1478 SCORE である。
 Cycle 98 後の total SCORE は 13698 であり、tracking Issue active threshold 15000 までは残り 1302 SCORE である。
 Cycle 99 後の total SCORE は 13874 であり、tracking Issue active threshold 15000 までは残り 1126 SCORE である。
+Cycle 100 後の total SCORE は 14054 であり、tracking Issue active threshold 15000 までは残り 946 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 99 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 100 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -241,7 +244,8 @@ semantic residual atlas map law induction theorem、
 semantic residual cut repair-hitting theorem、
 semantic residual mapped repair-hitting theorem、
 semantic residual status-drop adapter theorem、
-semantic residual status-drop repair-hitting theorem を含む。
+semantic residual status-drop repair-hitting theorem、
+semantic residual mapped status-drop repair-hitting theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5345,4 +5349,91 @@ correctness, or whole-codebase quality.
 
 Cycle 99 後の total SCORE は 13874 であり、tracking Issue active threshold 15000 までは残り 1126 SCORE である。
 次 cycle では、local-pass/global-fail taxonomy after status-drop repair necessity、cross-carrier status-drop repair hitting、finite pre-H1 support without cohomology overclaim、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 100: Cross-carrier residual status-drop repair-hitting transport
+
+```text
+candidate: Cross-carrier residual status-drop repair-hitting transport
+candidate_type: cross-carrier residual status-drop repair-hitting theorem / status-drop transport / obstruction-class-support
+evidence_stage: proved-in-research
+base_score: 90
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 180
+category: semantic-obstruction / status-drop-adapter / repair-necessity / cross-carrier-transport / genius-support
+goal_delta: Cycle 99 の same-carrier status-drop repair-hitting necessity を、Cycle 95 の map law と exact status readings を通じて finite carrier/schema change をまたぐ source-side hit obligation へ上げた。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、mapped status-drop repair transport、mapped drop persistence、target no-drop/canonical vanishing forces source hit、Cycle 95 inducing-map bridge、selected-to-extended exact status witness、no-hit no-go package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は status surface を remap できるが、target no-drop または target canonical vanishing が source old status-drop loci の hit を必要とすることを Lean theorem として要求できない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropRepairHitting.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropRepairHitting`, and `lake build FormalAGResearch` passed. Axiom probe reported the generic mapped status-drop repair-hitting theorem family and inducing-map bridge axiom-free; selected witness and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: local-pass/global-fail taxonomy after cross-carrier status-drop repair necessity; finite pre-H1 support without cohomology overclaim; cross-carrier status-drop minimality; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropRepairHitting.lean`
+transports Cycle 99 status-drop repair-hitting necessity across finite
+carrier/schema changes.  `ResidualStatusDropRepairTransportMap` contains a
+map `mapIndex` from old indices to new indices, source-side hit predicates,
+and three unhit preservation laws: old active edges, old source `true` status,
+and old target `false` status must be preserved after mapping when the
+corresponding source loci are unhit.
+
+From these three laws, Lean proves that an unhit old true-to-false status drop
+maps to a new true-to-false status drop.  Therefore target no-drop status, or
+target canonical residual cut-class vanishing, forces every old status drop to
+be hit at the source edge, source index, or target index locus.
+
+Cycle 95's `ResidualCutInducingAtlasMap` induces a mapped status-drop repair
+transport whenever old/new exact status readings are supplied.  The proof
+converts old status `true` / `false` through exact residual-present/free
+readings, applies the inducing map's present/free preservation, and converts
+back to new status `true` / `false`.
+
+The selected witness builds an exact status reading on the selected extended
+Option carrier.  The no-hit selected frontier-to-flat source drop maps to an
+extended target drop, remains a nonzero canonical obstruction, and obstructs
+extended transition closure and transition-coherent data.  Target no-drop or
+canonical vanishing would require a source-side frontier-to-flat hit.
+
+Lean proves:
+
+- `ResidualStatusDropRepairTransportMap`: cross-carrier status-drop repair transport map.
+- `AllMappedOldStatusDropsHit`: all old status drops are hit by source-side hit predicates.
+- `unhit_oldStatusDrop_maps_to_newStatusDrop`: an unhit old status drop maps to a new status drop.
+- `unhit_oldStatusDrop_maps_to_newExistsStatusDrop`: an unhit old status drop gives an existing target status drop.
+- `unhit_oldStatusDrop_maps_to_newCanonicalNonzero`: an unhit old status drop keeps the target canonical class nonzero.
+- `newNoStatusDrop_forces_mappedOldStatusDropHit`: target no-drop status forces a given old status drop to be hit.
+- `newNoStatusDrop_forces_allMappedOldStatusDropsHit`: target no-drop status forces all old status drops to be hit.
+- `newCanonicalVanishes_forces_mappedOldStatusDropHit`: target canonical vanishing forces a given old status drop to be hit.
+- `newCanonicalVanishes_forces_allMappedOldStatusDropsHit`: target canonical vanishing forces all old status drops to be hit.
+- `unhit_oldStatusDrop_maps_to_newTransitionClosureObstruction`: an unhit old status drop obstructs target transition closure.
+- `unhit_oldStatusDrop_maps_to_newTransitionCoherentDataObstruction`: an unhit old status drop rules out target coherent data.
+- `residualCutInducingAtlasMap_to_statusDropRepairTransportMap`: Cycle 95 inducing map gives mapped status-drop repair transport.
+- `residualCutInducingAtlasMap_newNoStatusDrop_forces_oldStatusDropsHit`: target no-drop under inducing map forces source hits.
+- `residualCutInducingAtlasMap_newCanonicalVanishes_forces_oldStatusDropsHit`: target vanishing under inducing map forces source hits.
+- `selectedExtendedFrontierFlatResidualStatus`: selected extended status function.
+- `selectedExtendedFrontierFlatResidualStatusReading`: exact selected extended status reading.
+- `selectedToExtendedNoHitStatusDropRepairTransportMap`: selected-to-extended no-hit status transport map.
+- `selectedFrontierFlat_statusDropPair`: selected source status-drop pair.
+- `selectedToExtendedNoHit_maps_frontierFlatStatusDrop`: selected source drop maps to an extended target drop.
+- `selectedToExtendedNoHit_preserves_extendedStatusCanonicalNonzero`: selected no-hit drop remains nonzero in the extended target.
+- `selectedToExtended_newNoStatusDrop_requires_frontierFlatStatusHit`: target no-drop requires selected source hit.
+- `selectedToExtended_newCanonicalVanishes_requires_frontierFlatStatusHit`: target vanishing requires selected source hit.
+- `selectedToExtendedNoHit_obstructs_extendedStatusTransitionClosure`: selected no-hit source drop obstructs extended transition closure.
+- `selectedToExtendedNoHit_obstructs_extendedStatusTransitionCoherentData`: selected no-hit source drop rules out extended coherent data.
+- `semanticResidualMappedStatusDropRepairHitting_package`: theorem package.
+
+This cycle is a strong support node, not a `genius unlock`.  It proves
+cross-carrier status-drop repair-hit necessity under supplied exact status
+readings and explicit unhit preservation laws.  It does not prove hit
+sufficiency, repair synthesis, global minimality, vanishing-to-closure, true
+`H^1` / Cech / coboundary quotient, status extraction, source extraction,
+ArchMap correctness, runtime repair synthesis, tooling runtime extraction, UI
+correctness, whole-codebase quality, or arbitrary atlas category/functoriality.
+
+### Next Frontier
+
+Cycle 100 後の total SCORE は 14054 であり、tracking Issue active threshold 15000 までは残り 946 SCORE である。
+次 cycle では、local-pass/global-fail taxonomy after cross-carrier status-drop repair necessity、finite pre-H1 support without cohomology overclaim、cross-carrier status-drop minimality、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 100 として、cross-carrier residual status-drop repair-hitting transport を Lean research layer に追加しました。
Cycle 99 の same-carrier status-drop repair-hitting necessity を `mapIndex` 付きの finite carrier/schema transport へ拡張し、Cycle 95 の `ResidualCutInducingAtlasMap` と exact status readings から mapped status-drop repair transport を誘導します。

SCORE は +180 とし、`G-aat-quality-surface-01` の total を 13874 から 14054 に更新しました。genius unlock ではなく strong `genius-support` として扱います。

## 証明した定理

- `ResidualStatusDropRepairTransportMap`
- `AllMappedOldStatusDropsHit`
- `unhit_oldStatusDrop_maps_to_newStatusDrop`
- `unhit_oldStatusDrop_maps_to_newExistsStatusDrop`
- `unhit_oldStatusDrop_maps_to_newCanonicalNonzero`
- `newNoStatusDrop_forces_mappedOldStatusDropHit`
- `newNoStatusDrop_forces_allMappedOldStatusDropsHit`
- `newCanonicalVanishes_forces_mappedOldStatusDropHit`
- `newCanonicalVanishes_forces_allMappedOldStatusDropsHit`
- `unhit_oldStatusDrop_maps_to_newTransitionClosureObstruction`
- `unhit_oldStatusDrop_maps_to_newTransitionCoherentDataObstruction`
- `residualCutInducingAtlasMap_to_statusDropRepairTransportMap`
- `residualCutInducingAtlasMap_newNoStatusDrop_forces_oldStatusDropsHit`
- `residualCutInducingAtlasMap_newCanonicalVanishes_forces_oldStatusDropsHit`
- `selectedExtendedFrontierFlatResidualStatusReading`
- `selectedToExtendedNoHit_maps_frontierFlatStatusDrop`
- `selectedToExtendedNoHit_preserves_extendedStatusCanonicalNonzero`
- `selectedToExtended_newNoStatusDrop_requires_frontierFlatStatusHit`
- `selectedToExtended_newCanonicalVanishes_requires_frontierFlatStatusHit`
- `selectedToExtendedNoHit_obstructs_extendedStatusTransitionClosure`
- `selectedToExtendedNoHit_obstructs_extendedStatusTransitionCoherentData`
- `semanticResidualMappedStatusDropRepairHitting_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-repair-hitting.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropRepairHitting.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropRepairHitting`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

補足: `lake build` は成功しました。既存 unrelated warning として `Formal/Arch/Extension/FeatureExtensionExamples.lean` の unnecessary sequence focus linter warning が 2 件出ています。

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: proved-in-research。

`Closes #N` チェックは意図的に未チェックです。#2348 は active threshold 15000 まで継続する tracking Issue であり、この PR では close しません。
