### PR TITLE
Cycle 101 status-drop scanner を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -97,3 +97,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualMappedRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropAdapter
 import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropRepairHitting
+import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropScanner

--- a/Formal/AG/Research/QualitySurface/SemanticResidualStatusDropScanner.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualStatusDropScanner.lean
@@ -1,0 +1,539 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropRepairHitting
+
+/-!
+Cycle 101 evidence for `G-aat-quality-surface-01`.
+
+This file makes the finite status-drop surface computable by a supplied edge
+order.  A status-drop scanner returns the first active true-to-false residual
+status drop in that order.  When the edge order covers all active edges,
+scanner `none` is exact for `NoResidualStatusDrop`, and hence for canonical
+residual cut-class vanishing under an exact status reading.
+
+The scanner exactness is also connected back to repair-hitting necessity:
+target scanner `none` forces old status drops to be hit under same-carrier and
+mapped status-drop repair transports.
+
+This is an edge-order-relative finite scanner theorem.  It does not assert a
+canonical global edge order, hit sufficiency, repair synthesis, global
+minimality, vanishing-to-closure, true H1/Cech/coboundary structure, status
+extraction, ArchMap correctness, tooling/runtime/UI correctness, or
+whole-codebase quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualStatusDropScanner
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualCutRepairHitting
+open SemanticResidualMappedRepairHitting
+open SemanticResidualStatusDropAdapter
+open SemanticResidualStatusDropRepairHitting
+open SemanticResidualMappedStatusDropRepairHitting
+
+/-! ## Finite status-drop scanner -/
+
+/-- No listed edge pair is an active true-to-false status drop. -/
+def ListedResidualStatusDropsClear
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas)
+    (edgeOrder : List (Index × Index)) : Prop :=
+  forall pair,
+    pair ∈ edgeOrder ->
+      Not (ResidualStatusDropPair reading pair)
+
+/-- The first active true-to-false residual status drop in a supplied edge order. -/
+def firstResidualStatusDrop?
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas)
+    [DecidablePred (ResidualStatusDropPair reading)] :
+    List (Index × Index) -> Option (Index × Index)
+  | [] => none
+  | pair :: rest =>
+      if ResidualStatusDropPair reading pair then
+        some pair
+      else
+        firstResidualStatusDrop? reading rest
+
+/-- A returned status-drop pair is in the supplied edge order. -/
+theorem firstResidualStatusDrop?_some_mem
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas)
+    [DecidablePred (ResidualStatusDropPair reading)] :
+    forall {edgeOrder : List (Index × Index)} {pair : Index × Index},
+      firstResidualStatusDrop? reading edgeOrder = some pair ->
+        pair ∈ edgeOrder
+  | [], _pair, hsome => by
+      cases hsome
+  | head :: rest, pair, hsome => by
+      by_cases hdrop : ResidualStatusDropPair reading head
+      · have hpair : pair = head := by
+          simpa [firstResidualStatusDrop?, hdrop] using hsome.symm
+        subst pair
+        simp
+      · have htail :
+          firstResidualStatusDrop? reading rest = some pair := by
+          simpa [firstResidualStatusDrop?, hdrop] using hsome
+        exact List.mem_cons_of_mem head
+          (firstResidualStatusDrop?_some_mem reading htail)
+
+/-- A returned status-drop pair is an actual active true-to-false status drop. -/
+theorem firstResidualStatusDrop?_some_pairDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas)
+    [DecidablePred (ResidualStatusDropPair reading)] :
+    forall {edgeOrder : List (Index × Index)} {pair : Index × Index},
+      firstResidualStatusDrop? reading edgeOrder = some pair ->
+        ResidualStatusDropPair reading pair
+  | [], _pair, hsome => by
+      cases hsome
+  | head :: rest, pair, hsome => by
+      by_cases hdrop : ResidualStatusDropPair reading head
+      · have hpair : pair = head := by
+          simpa [firstResidualStatusDrop?, hdrop] using hsome.symm
+        subst pair
+        exact hdrop
+      · have htail :
+          firstResidualStatusDrop? reading rest = some pair := by
+          simpa [firstResidualStatusDrop?, hdrop] using hsome
+        exact firstResidualStatusDrop?_some_pairDrop reading htail
+
+/-- A returned status-drop pair gives an existence witness. -/
+theorem firstResidualStatusDrop?_some_existsStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {reading : ResidualBooleanStatusReading atlas}
+    [DecidablePred (ResidualStatusDropPair reading)]
+    {edgeOrder : List (Index × Index)}
+    {pair : Index × Index}
+    (hscan : firstResidualStatusDrop? reading edgeOrder = some pair) :
+    ExistsResidualStatusDrop reading := by
+  have hdrop :
+      ResidualStatusDropPair reading pair :=
+    firstResidualStatusDrop?_some_pairDrop reading hscan
+  exact ⟨pair, hdrop.1, hdrop.2.1, hdrop.2.2⟩
+
+/-- A returned scanner status drop makes the canonical residual class nonzero. -/
+theorem firstResidualStatusDrop?_some_canonicalNonzero
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {reading : ResidualBooleanStatusReading atlas}
+    [DecidablePred (ResidualStatusDropPair reading)]
+    {edgeOrder : List (Index × Index)}
+    {pair : Index × Index}
+    (hscan : firstResidualStatusDrop? reading edgeOrder = some pair) :
+    (canonicalResidualCutCochain atlas).CutNonzero := by
+  exact
+    (canonicalResidualCutClass_nonzero_iff_existsStatusDrop
+      reading).mpr
+      (firstResidualStatusDrop?_some_existsStatusDrop hscan)
+
+/-- A returned scanner status drop obstructs atlas-wide transition closure. -/
+theorem firstResidualStatusDrop?_some_obstructs_transitionClosure
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {reading : ResidualBooleanStatusReading atlas}
+    [DecidablePred (ResidualStatusDropPair reading)]
+    {edgeOrder : List (Index × Index)}
+    {pair : Index × Index}
+    (hscan : firstResidualStatusDrop? reading edgeOrder = some pair)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (AtlasResidualTransitionClosed atlas transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain atlas)
+      (firstResidualStatusDrop?_some_canonicalNonzero hscan)
+      transition
+
+/-- A returned scanner status drop rules out transition-coherent atlas data. -/
+theorem firstResidualStatusDrop?_some_obstructs_transitionCoherentData
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {reading : ResidualBooleanStatusReading atlas}
+    [DecidablePred (ResidualStatusDropPair reading)]
+    {edgeOrder : List (Index × Index)}
+    {pair : Index × Index}
+    (hscan : firstResidualStatusDrop? reading edgeOrder = some pair)
+    (transition : Index -> Index -> Atom -> Atom) :
+    Not (Nonempty (TransitionCoherentAtlasData atlas transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (canonicalResidualCutCochain atlas)
+      (firstResidualStatusDrop?_some_canonicalNonzero hscan)
+      transition
+
+/--
+The status-drop scanner returns `none` exactly when the supplied edge order is
+clear of active true-to-false status drops.
+-/
+theorem firstResidualStatusDrop?_none_iff_listedStatusDropsClear
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    (reading : ResidualBooleanStatusReading atlas)
+    [DecidablePred (ResidualStatusDropPair reading)] :
+    forall edgeOrder,
+      firstResidualStatusDrop? reading edgeOrder = none <->
+        ListedResidualStatusDropsClear reading edgeOrder
+  | [] => by
+      constructor
+      · intro _ pair hmem _hpair
+        cases hmem
+      · intro _
+        rfl
+  | head :: rest => by
+      constructor
+      · intro hnone pair hmem hpair
+        by_cases hdrop : ResidualStatusDropPair reading head
+        · have hsome :
+            firstResidualStatusDrop? reading (head :: rest) =
+              some head := by
+            simp [firstResidualStatusDrop?, hdrop]
+          rw [hsome] at hnone
+          cases hnone
+        · have htail :
+            firstResidualStatusDrop? reading rest = none := by
+            simpa [firstResidualStatusDrop?, hdrop] using hnone
+          cases hmem with
+          | head =>
+              exact hdrop hpair
+          | tail _ hlisted =>
+              exact
+                ((firstResidualStatusDrop?_none_iff_listedStatusDropsClear
+                  reading rest).mp htail) pair hlisted hpair
+      · intro hclear
+        by_cases hdrop : ResidualStatusDropPair reading head
+        · have hnot :
+            Not (ResidualStatusDropPair reading head) :=
+            hclear head (by simp)
+          exact False.elim (hnot hdrop)
+        · have hrestClear :
+            ListedResidualStatusDropsClear reading rest := by
+            intro pair hmem hpair
+            exact hclear pair (by simp [hmem]) hpair
+          have htailNone :
+            firstResidualStatusDrop? reading rest = none :=
+            (firstResidualStatusDrop?_none_iff_listedStatusDropsClear
+              reading rest).mpr hrestClear
+          simp [firstResidualStatusDrop?, hdrop, htailNone]
+
+/--
+For a complete supplied edge order, scanner `none` is exact for absence of
+active true-to-false status drops.
+-/
+theorem firstResidualStatusDrop?_none_iff_noStatusDrop
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {reading : ResidualBooleanStatusReading atlas}
+    [DecidablePred (ResidualStatusDropPair reading)]
+    {edgeOrder : List (Index × Index)}
+    (hcomplete : ListedAtlasEdgesComplete atlas edgeOrder) :
+    firstResidualStatusDrop? reading edgeOrder = none <->
+      NoResidualStatusDrop reading := by
+  constructor
+  · intro hnone pair hedge hstatus
+    have hclear :
+        ListedResidualStatusDropsClear reading edgeOrder :=
+      (firstResidualStatusDrop?_none_iff_listedStatusDropsClear
+        reading edgeOrder).mp hnone
+    exact hclear pair (hcomplete pair.1 pair.2 hedge) ⟨hedge, hstatus⟩
+  · intro hno
+    apply
+      (firstResidualStatusDrop?_none_iff_listedStatusDropsClear
+        reading edgeOrder).mpr
+    intro pair _hmem hdrop
+    exact hno pair hdrop.1 hdrop.2
+
+/-- For a complete edge order, scanner `none` is exact for canonical vanishing. -/
+theorem firstResidualStatusDrop?_none_iff_canonicalVanishes
+    {Index : Type w}
+    {Atom : Type u}
+    {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {reading : ResidualBooleanStatusReading atlas}
+    [DecidablePred (ResidualStatusDropPair reading)]
+    {edgeOrder : List (Index × Index)}
+    (hcomplete : ListedAtlasEdgesComplete atlas edgeOrder) :
+    firstResidualStatusDrop? reading edgeOrder = none <->
+      (canonicalResidualCutCochain atlas).CutVanishes := by
+  exact
+    (firstResidualStatusDrop?_none_iff_noStatusDrop
+      hcomplete).trans
+      (canonicalResidualCutClass_vanishes_iff_noStatusDrop reading).symm
+
+/-! ## Scanner-driven repair-hit necessity -/
+
+/-- Target status scanner `none` forces same-carrier old status drops hit. -/
+theorem targetStatusScannerNone_forces_allOldStatusDropsHit
+    {Index : Type w}
+    {Atom : Type u}
+    {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (transport : ResidualStatusDropRepairTransport oldReading newReading)
+    {targetEdgeOrder : List (Index × Index)}
+    (hcomplete : ListedAtlasEdgesComplete new targetEdgeOrder)
+    (hscan : firstResidualStatusDrop? newReading targetEdgeOrder = none) :
+    AllOldStatusDropsHit
+      oldReading
+      transport.edgeHit
+      transport.sourceHit
+      transport.targetHit := by
+  have hno :
+      NoResidualStatusDrop newReading :=
+    (firstResidualStatusDrop?_none_iff_noStatusDrop
+      hcomplete).mp hscan
+  exact newNoStatusDrop_forces_allOldStatusDropsHit transport hno
+
+/-- Target status scanner `none` forces mapped old status drops hit. -/
+theorem targetStatusScannerNone_forces_allMappedOldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    {targetEdgeOrder : List (RightIndex × RightIndex)}
+    (hcomplete : ListedAtlasEdgesComplete new targetEdgeOrder)
+    (hscan : firstResidualStatusDrop? newReading targetEdgeOrder = none) :
+    AllMappedOldStatusDropsHit
+      oldReading
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit := by
+  have hno :
+      NoResidualStatusDrop newReading :=
+    (firstResidualStatusDrop?_none_iff_noStatusDrop
+      hcomplete).mp hscan
+  exact newNoStatusDrop_forces_allMappedOldStatusDropsHit
+    transportMap hno
+
+/-! ## Selected status scanner witnesses -/
+
+/-- The selected status-drop predicate is decidable without classical choice. -/
+instance selectedFrontierFlatStatusDropPairDecidable :
+    DecidablePred
+      (ResidualStatusDropPair selectedFrontierFlatResidualStatusReading) := by
+  intro pair
+  cases pair with
+  | mk source target =>
+      cases source <;> cases target <;>
+        simp [ResidualStatusDropPair,
+          selectedFrontierFlatResidualStatusReading,
+          selectedFrontierFlatResidualStatus,
+          selectedFrontierFlatAtlasSkeleton,
+          selectedFrontierToFlatEdge] <;>
+          infer_instance
+
+/-- The selected status scanner returns the frontier-to-flat status drop. -/
+theorem selected_firstResidualStatusDrop :
+    firstResidualStatusDrop?
+      selectedFrontierFlatResidualStatusReading
+      selectedFrontierFlatScanOrder =
+        some selectedFrontierFlatResidualCutPair := by
+  simp [selectedFrontierFlatScanOrder, firstResidualStatusDrop?,
+    ResidualStatusDropPair,
+    selectedFrontierFlatResidualStatusReading,
+    selectedFrontierFlatResidualStatus,
+    selectedFrontierFlatAtlasSkeleton,
+    selectedFrontierToFlatEdge,
+    selectedFrontierFlatResidualCutPair]
+
+/-- The selected status scanner hit makes the canonical class nonzero. -/
+theorem selected_firstResidualStatusDrop_canonicalNonzero :
+    (canonicalResidualCutCochain
+      selectedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    firstResidualStatusDrop?_some_canonicalNonzero
+      selected_firstResidualStatusDrop
+
+/-- The selected status scanner hit obstructs transition closure. -/
+theorem selected_firstResidualStatusDrop_obstructs_transitionClosure
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    firstResidualStatusDrop?_some_obstructs_transitionClosure
+      selected_firstResidualStatusDrop
+      transition
+
+/-- The selected status scanner hit rules out transition-coherent data. -/
+theorem selected_firstResidualStatusDrop_obstructs_transitionCoherentData
+    (transition :
+      SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    firstResidualStatusDrop?_some_obstructs_transitionCoherentData
+      selected_firstResidualStatusDrop
+      transition
+
+/-! ## Theorem package -/
+
+/--
+Cycle-101 theorem package: finite status-drop scanner exactness and
+scanner-driven repair-hit necessity.
+-/
+theorem semanticResidualStatusDropScanner_package :
+    (forall {Index : Type w}
+      {Atom : Type u}
+      {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+      {reading : ResidualBooleanStatusReading atlas}
+      {_inst : DecidablePred (ResidualStatusDropPair reading)}
+      {edgeOrder : List (Index × Index)}
+      {pair : Index × Index},
+      firstResidualStatusDrop? reading edgeOrder = some pair ->
+        ExistsResidualStatusDrop reading) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {reading : ResidualBooleanStatusReading atlas}
+        {_inst : DecidablePred (ResidualStatusDropPair reading)}
+        {edgeOrder : List (Index × Index)}
+        {pair : Index × Index},
+        firstResidualStatusDrop? reading edgeOrder = some pair ->
+          (canonicalResidualCutCochain atlas).CutNonzero) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {reading : ResidualBooleanStatusReading atlas}
+        {_inst : DecidablePred (ResidualStatusDropPair reading)}
+        {edgeOrder : List (Index × Index)},
+        ListedAtlasEdgesComplete atlas edgeOrder ->
+          (firstResidualStatusDrop? reading edgeOrder = none <->
+            NoResidualStatusDrop reading)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {atlas : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {reading : ResidualBooleanStatusReading atlas}
+        {_inst : DecidablePred (ResidualStatusDropPair reading)}
+        {edgeOrder : List (Index × Index)},
+        ListedAtlasEdgesComplete atlas edgeOrder ->
+          (firstResidualStatusDrop? reading edgeOrder = none <->
+            (canonicalResidualCutCochain atlas).CutVanishes)) /\
+      (forall {Index : Type w}
+        {Atom : Type u}
+        {old new : FiniteSemanticRepairAtlasSkeleton Index Atom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new}
+        {_inst : DecidablePred (ResidualStatusDropPair newReading)},
+        forall transport : ResidualStatusDropRepairTransport oldReading newReading,
+        forall targetEdgeOrder : List (Index × Index),
+          ListedAtlasEdgesComplete new targetEdgeOrder ->
+            firstResidualStatusDrop? newReading targetEdgeOrder = none ->
+              AllOldStatusDropsHit
+                oldReading
+                transport.edgeHit
+                transport.sourceHit
+                transport.targetHit) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new}
+        {_inst : DecidablePred (ResidualStatusDropPair newReading)},
+        forall transportMap :
+          ResidualStatusDropRepairTransportMap oldReading newReading,
+        forall targetEdgeOrder : List (RightIndex × RightIndex),
+          ListedAtlasEdgesComplete new targetEdgeOrder ->
+            firstResidualStatusDrop? newReading targetEdgeOrder = none ->
+              AllMappedOldStatusDropsHit
+                oldReading
+                transportMap.edgeHit
+                transportMap.sourceHit
+                transportMap.targetHit) /\
+      firstResidualStatusDrop?
+        selectedFrontierFlatResidualStatusReading
+        selectedFrontierFlatScanOrder =
+          some selectedFrontierFlatResidualCutPair /\
+      (canonicalResidualCutCochain
+        selectedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedSemanticOverlapIndex -> SelectedSemanticOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_Index} {_Atom} {_atlas} {_reading} {_inst} {_edgeOrder} {_pair}
+        hscan =>
+        firstResidualStatusDrop?_some_existsStatusDrop hscan,
+      fun {_Index} {_Atom} {_atlas} {_reading} {_inst} {_edgeOrder} {_pair}
+        hscan =>
+        firstResidualStatusDrop?_some_canonicalNonzero hscan,
+      fun {_Index} {_Atom} {_atlas} {_reading} {_inst} {_edgeOrder}
+        hcomplete =>
+        firstResidualStatusDrop?_none_iff_noStatusDrop hcomplete,
+      fun {_Index} {_Atom} {_atlas} {_reading} {_inst} {_edgeOrder}
+        hcomplete =>
+        firstResidualStatusDrop?_none_iff_canonicalVanishes hcomplete,
+      fun {_Index} {_Atom} {_old} {_new} {_oldReading} {_newReading}
+        {_inst} transport targetEdgeOrder hcomplete hscan =>
+        targetStatusScannerNone_forces_allOldStatusDropsHit
+          transport hcomplete hscan,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading} {_inst}
+        transportMap targetEdgeOrder hcomplete hscan =>
+        targetStatusScannerNone_forces_allMappedOldStatusDropsHit
+          transportMap hcomplete hscan,
+      selected_firstResidualStatusDrop,
+      selected_firstResidualStatusDrop_canonicalNonzero,
+      selected_firstResidualStatusDrop_obstructs_transitionClosure,
+      selected_firstResidualStatusDrop_obstructs_transitionCoherentData⟩
+
+end SemanticResidualStatusDropScanner
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-scanner.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-scanner.md
@@ -1,0 +1,160 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: finite status-drop scanner exactness / computable repair-hit necessity / genius-support convergence
+candidate_type: finite residual status-drop scanner exactness / scanner-driven repair-hit necessity / computability-support
+capability_category: semantic-obstruction / status-drop-scanner / computability / repair-necessity / genius-support
+expected_base_score: 88
+expected_evidence_multiplier: 2.0
+expected_final_score: 176
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can list status transitions, but they do not prove scanner none/existence exactness and then use target scanner none to force old or mapped old repair-hit obligations.
+origin: cycle-101
+tags: [quality-surface, semantic-repair, residual-cut, status-drop, scanner, repair-hitting, computability, genius-support]
+created: 2026-06-23
+cycle: 101
+lean: proved-in-research
+planned_report_section: "Cycle 101: Finite residual status-drop scanner exactness"
+---
+
+# Finite Residual Status-Drop Scanner Exactness
+
+## 主張
+
+supplied exact boolean residual status reading と supplied finite edge order に対し、
+`firstResidualStatusDrop?` は最初の active true-to-false status drop を返す。
+返った `some pair` は実際の `ResidualStatusDropPair` であり、`ExistsResidualStatusDrop`、
+canonical residual cut-class nonzero、transition closure / coherent data no-go を与える。
+
+edge order が active edges を complete に cover するなら、scanner `none` は
+`NoResidualStatusDrop` と同値であり、exact reading の下で canonical residual cut-class vanishing とも同値である。
+さらに target scanner `none` は、same-carrier transport と mapped transport のそれぞれで、old status drops が
+hit されることを必要条件として強制する。
+
+これは complete supplied edge order に相対化された finite scanner theorem であり、canonical global order、
+hit sufficiency、repair synthesis、global minimality、vanishing-to-closure、true `H^1` / Cech /
+coboundary quotient、status extraction、ArchMap/tooling correctness、runtime/UI correctness、
+whole-codebase quality は主張しない。
+
+## 候補種別
+
+`finite residual status-drop scanner exactness` / `scanner-driven repair-hit necessity` / `computability-support`
+
+## 依拠
+
+- Cycle 90: residual transition cut scanner exactness。
+- Cycle 98: finite residual status-drop adapter。
+- Cycle 99: same-carrier status-drop repair-hitting necessity。
+- Cycle 100: mapped status-drop repair-hitting transport。
+
+## 非自明性
+
+単なる status list ではない。
+`some` 側では proof-carrying status drop から canonical nonzero/no-go へ進み、`none` 側では complete
+edge order の下で no-drop/canonical vanishing と同値になる。
+さらに target scanner `none` を repair-hit necessity に接続し、検出結果から old/mapped old hit obligation を読める。
+
+## 数学的興味
+
+status-drop obstruction class を finite computable detector として読み、detector の `none` を
+repair-frontier obligation へ戻す。
+これは semantic repair-gluing obstruction target に向けた computability layer である。
+
+## GOAL への前進
+
+status-drop adapter、repair-hit theorem、mapped transport を finite scanner exactness に接続した。
+genius unlock ではないが、future finite semantic repair-gluing obstruction theorem に必要な
+測定可能性と repair obligation の接続を強める。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は status transition を列挙できる。
+しかし、complete supplied order 下の scanner `none` が exact no-drop/canonical vanishing であり、
+target scanner `none` が old/mapped old hit necessity を強制することは証明しない。
+
+## SCORE 見込み
+
+- `score_reason`: status-drop obstruction と repair-hit transport を finite scanner exactness へ落とし、
+  computable detector layer と repair obligation を接続した。
+- `dullness_risk`: Cycle 90 scanner pattern と Cycle 98-100 tower の合成に見える危険がある。
+  `targetStatusScannerNone_forces_allOldStatusDropsHit` と
+  `targetStatusScannerNone_forces_allMappedOldStatusDropsHit` を theorem として加えて回避する。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualStatusDropScanner.lean`
+  で scanner soundness/exactness、repair-hit necessity、selected witness を証明する。
+
+## CS / SWE への帰結
+
+品質 surface 上の status-drop scan が `none` を返すとき、それは complete supplied edge order と exact
+status reading に相対化された no-drop / canonical vanishing claim である。
+その target scan result は、repair transport law の下で old or mapped old status drops の hit obligation を要求する。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualStatusDropScanner.lean` に固定した。
+
+- `ListedResidualStatusDropsClear`
+- `firstResidualStatusDrop?`
+- `firstResidualStatusDrop?_some_mem`
+- `firstResidualStatusDrop?_some_pairDrop`
+- `firstResidualStatusDrop?_some_existsStatusDrop`
+- `firstResidualStatusDrop?_some_canonicalNonzero`
+- `firstResidualStatusDrop?_some_obstructs_transitionClosure`
+- `firstResidualStatusDrop?_some_obstructs_transitionCoherentData`
+- `firstResidualStatusDrop?_none_iff_listedStatusDropsClear`
+- `firstResidualStatusDrop?_none_iff_noStatusDrop`
+- `firstResidualStatusDrop?_none_iff_canonicalVanishes`
+- `targetStatusScannerNone_forces_allOldStatusDropsHit`
+- `targetStatusScannerNone_forces_allMappedOldStatusDropsHit`
+- `selectedFrontierFlatStatusDropPairDecidable`
+- `selected_firstResidualStatusDrop`
+- `selected_firstResidualStatusDrop_canonicalNonzero`
+- `selected_firstResidualStatusDrop_obstructs_transitionClosure`
+- `selected_firstResidualStatusDrop_obstructs_transitionCoherentData`
+- `semanticResidualStatusDropScanner_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualStatusDropScanner.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualStatusDropScanner`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic scanner theorem 群は標準 `propext` のみ。selected witness と package は標準
+  `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、supplied exact status reading、complete supplied edge order、finite scanner soundness/exactness、
+target scanner `none` から repair-hit necessity への接続に限定する。
+unchecked: canonical global edge order、hit sufficiency、repair synthesis、global minimality、vanishing-to-closure、
+true H1/cohomology、Cech quotient、coboundary quotient、status extraction、ArchMap correctness、
+runtime/UI correctness、whole-codebase quality。
+
+## 審判メモ
+
+- G1: accept。保守 base 86 / final +172。`scanner none -> mapped old drops hit` が theorem level で十分強く、card/report が wrapper でないことを示せば G4 で +176 まで許容。
+- G2: accept。base 86-88、final +172 から +176。Cycle 90 scanner exactness より強く、Cycle 98-100 の repair-hit 系列へ接続しているため +176 推奨。genius unlock ではなく genius-support。
+
+## 追加 required fields
+
+- `mathematical_interest`: status-drop obstruction を finite scanner exactness と repair-hit necessity に接続する。
+- `goal_advancement`: semantic repair-gluing obstruction target の computable detector layer を強化した。
+- `planned_theorem_names`: `firstResidualStatusDrop?_none_iff_noStatusDrop`, `targetStatusScannerNone_forces_allMappedOldStatusDropsHit`, `semanticResidualStatusDropScanner_package`
+- `visible_projection`: supplied edge order、first status drop、scanner none、target scan result。
+- `protected_structure`: exact status reading、complete edge order、canonical vanishing equivalence、repair-hit necessity。
+- `exactness_or_minimality_claim`: complete supplied edge order に相対化した scanner exactness。global minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: incomplete order の `none` は no-drop/canonical vanishing を証明しない。
+- `previous_cycle_delta`: Cycle 100 の mapped repair-hit theorem を finite target scanner result に接続した。
+- `rival_stress_test`: rival は status を list できても、scanner exactness と repair-hit necessity を theorem として出さない。
+- `genius_potential`: support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の computability layer。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: status-drop repair-hit theorem を finite scanner result で測定可能にする。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-repair-hitting.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-repair-hitting.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-adapter.md`
+- planned report section: `Cycle 101: Finite residual status-drop scanner exactness`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 101 G1/G2 で finite residual status-drop scanner exactness を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualStatusDropScanner.lean` に固定し、単体
+  `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 14054
+- total SCORE: 14230
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -105,8 +105,9 @@
   - semantic-obstruction / status-drop-adapter / finite-atlas-transition / obstruction-class-support / genius-support: 176
   - semantic-obstruction / status-drop-adapter / repair-necessity / finite-atlas-transition / genius-support: 176
   - semantic-obstruction / status-drop-adapter / repair-necessity / cross-carrier-transport / genius-support: 180
+  - semantic-obstruction / status-drop-scanner / computability / repair-necessity / genius-support: 176
 - evidence portfolio:
-  - proved-in-research: 100
+  - proved-in-research: 101
 
 ## Phase synthesis
 
@@ -122,7 +123,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-100 件の Lean-proved research artifacts は、次の paper seed を形成している。
+101 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -151,6 +152,7 @@ certificate の基本単位は
 - semantic residual status-drop adapter は、supplied exact boolean residual status reading の下で canonical residual cut class が active true-to-false status-drop class と一致することを示す。
 - semantic residual status-drop repair hitting は、unhit edge/status preservation laws により、new status-drop absence または canonical vanishing が old true-to-false status drop の edge/source/target hit を必要とすることを示す。
 - semantic residual mapped status-drop repair hitting は、exact status readings と mapIndex 付き unhit preservation laws により、status-drop repair-hitting necessity が finite carrier/schema change をまたいで transport されることを示す。
+- semantic residual status-drop scanner は、complete supplied edge order 上の finite scanner `none` が no-drop/canonical vanishing と同値であり、target scanner `none` が old/mapped old status-drop hit necessity を強制することを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -211,8 +213,9 @@ Cycle 97 後の total SCORE は 13522 であり、tracking Issue active threshol
 Cycle 98 後の total SCORE は 13698 であり、tracking Issue active threshold 15000 までは残り 1302 SCORE である。
 Cycle 99 後の total SCORE は 13874 であり、tracking Issue active threshold 15000 までは残り 1126 SCORE である。
 Cycle 100 後の total SCORE は 14054 であり、tracking Issue active threshold 15000 までは残り 946 SCORE である。
+Cycle 101 後の total SCORE は 14230 であり、tracking Issue active threshold 15000 までは残り 770 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 100 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 101 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -245,7 +248,8 @@ semantic residual cut repair-hitting theorem、
 semantic residual mapped repair-hitting theorem、
 semantic residual status-drop adapter theorem、
 semantic residual status-drop repair-hitting theorem、
-semantic residual mapped status-drop repair-hitting theorem を含む。
+semantic residual mapped status-drop repair-hitting theorem、
+semantic residual status-drop scanner theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5436,4 +5440,85 @@ correctness, whole-codebase quality, or arbitrary atlas category/functoriality.
 
 Cycle 100 後の total SCORE は 14054 であり、tracking Issue active threshold 15000 までは残り 946 SCORE である。
 次 cycle では、local-pass/global-fail taxonomy after cross-carrier status-drop repair necessity、finite pre-H1 support without cohomology overclaim、cross-carrier status-drop minimality、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 101: Finite residual status-drop scanner exactness
+
+```text
+candidate: Finite residual status-drop scanner exactness
+candidate_type: finite residual status-drop scanner exactness / scanner-driven repair-hit necessity / computability-support
+evidence_stage: proved-in-research
+base_score: 88
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 176
+category: semantic-obstruction / status-drop-scanner / computability / repair-necessity / genius-support
+goal_delta: Cycle 98-100 の status-drop / repair-hit tower を、complete supplied edge order 上の finite scanner exactness と target scanner none からの repair-hit necessity に接続した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、status-drop scanner、some soundness、none iff no-drop/canonical vanishing、same-carrier/mapped target scanner none forces old hit、selected scanner witness、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は status transitions を列挙できるが、scanner `none` の exactness と repair-hit necessity への接続を Lean theorem として保証できない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualStatusDropScanner.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualStatusDropScanner`, and `lake build FormalAGResearch` passed. Axiom probe reported generic scanner theorem family uses standard `propext` only; selected witness and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: finite pre-H1 support without cohomology overclaim; cross-carrier status-drop minimality; scanner completeness under mapped edge orders; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualStatusDropScanner.lean`
+adds a finite status-drop scanner for supplied exact boolean residual status
+readings.  Given a supplied finite edge order, `firstResidualStatusDrop?`
+returns the first active true-to-false residual status drop.  A `some` result
+is sound: the returned pair is listed, is a `ResidualStatusDropPair`, gives
+`ExistsResidualStatusDrop`, makes the canonical residual cut class nonzero,
+and obstructs transition closure and transition-coherent atlas data.
+
+For a complete supplied edge order, scanner `none` is exact for
+`NoResidualStatusDrop`.  Through the Cycle 98 status-drop adapter, the same
+`none` result is also equivalent to canonical residual cut-class vanishing.
+This is complete-order-relative exactness; no canonical global edge order is
+claimed.
+
+The scanner exactness is connected back to repair-hit necessity.  If the
+target status scanner returns `none` on a complete target edge order, then
+Cycle 99 same-carrier status-drop repair transport forces all old status drops
+to be hit.  Under Cycle 100 mapped status-drop repair transport, target
+scanner `none` likewise forces all mapped old status drops to be hit by the
+source-side hit predicates.
+
+The selected witness shows the selected frontier-to-flat scan returns the
+frontier-to-flat status drop, recovers canonical nonzero, and gives
+transition closure / coherent-data no-go.
+
+Lean proves:
+
+- `ListedResidualStatusDropsClear`: no listed edge pair is a status drop.
+- `firstResidualStatusDrop?`: first active true-to-false status-drop scanner.
+- `firstResidualStatusDrop?_some_mem`: returned pair is listed.
+- `firstResidualStatusDrop?_some_pairDrop`: returned pair is a status drop.
+- `firstResidualStatusDrop?_some_existsStatusDrop`: returned pair gives status-drop existence.
+- `firstResidualStatusDrop?_some_canonicalNonzero`: scanner hit gives canonical nonzero.
+- `firstResidualStatusDrop?_some_obstructs_transitionClosure`: scanner hit obstructs transition closure.
+- `firstResidualStatusDrop?_some_obstructs_transitionCoherentData`: scanner hit rules out coherent data.
+- `firstResidualStatusDrop?_none_iff_listedStatusDropsClear`: scanner none iff listed status drops are clear.
+- `firstResidualStatusDrop?_none_iff_noStatusDrop`: complete-order scanner none iff no status drop.
+- `firstResidualStatusDrop?_none_iff_canonicalVanishes`: complete-order scanner none iff canonical vanishing.
+- `targetStatusScannerNone_forces_allOldStatusDropsHit`: target scanner none forces same-carrier old drops hit.
+- `targetStatusScannerNone_forces_allMappedOldStatusDropsHit`: target scanner none forces mapped old drops hit.
+- `selectedFrontierFlatStatusDropPairDecidable`: selected predicate is decidable without classical choice.
+- `selected_firstResidualStatusDrop`: selected scanner returns the frontier-to-flat drop.
+- `selected_firstResidualStatusDrop_canonicalNonzero`: selected scanner hit gives canonical nonzero.
+- `selected_firstResidualStatusDrop_obstructs_transitionClosure`: selected scanner hit obstructs closure.
+- `selected_firstResidualStatusDrop_obstructs_transitionCoherentData`: selected scanner hit rules out coherent data.
+- `semanticResidualStatusDropScanner_package`: theorem package.
+
+This cycle is a support node, not a `genius unlock`.  It proves finite
+complete-order scanner exactness and scanner-driven repair-hit necessity.  It
+does not prove a canonical global edge order, hit sufficiency, repair
+synthesis, global minimality, vanishing-to-closure, true `H^1` / Cech /
+coboundary quotient, status extraction, ArchMap correctness, runtime repair
+synthesis, tooling runtime extraction, UI correctness, or whole-codebase
+quality.
+
+### Next Frontier
+
+Cycle 101 後の total SCORE は 14230 であり、tracking Issue active threshold 15000 までは残り 770 SCORE である。
+次 cycle では、finite pre-H1 support without cohomology overclaim、cross-carrier status-drop minimality、scanner completeness under mapped edge orders、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 101 として、finite residual status-drop scanner exactness と scanner-driven repair-hit necessity を Lean research layer に追加しました。
`firstResidualStatusDrop?` の `some` soundness、complete supplied edge order 下の `none` exactness、target scanner `none` から same-carrier / mapped old status drops hit への接続を証明します。

SCORE は +176 とし、`G-aat-quality-surface-01` の total を 14054 から 14230 に更新しました。genius unlock ではなく `genius-support` として扱います。

## 証明した定理

- `ListedResidualStatusDropsClear`
- `firstResidualStatusDrop?`
- `firstResidualStatusDrop?_some_mem`
- `firstResidualStatusDrop?_some_pairDrop`
- `firstResidualStatusDrop?_some_existsStatusDrop`
- `firstResidualStatusDrop?_some_canonicalNonzero`
- `firstResidualStatusDrop?_some_obstructs_transitionClosure`
- `firstResidualStatusDrop?_some_obstructs_transitionCoherentData`
- `firstResidualStatusDrop?_none_iff_listedStatusDropsClear`
- `firstResidualStatusDrop?_none_iff_noStatusDrop`
- `firstResidualStatusDrop?_none_iff_canonicalVanishes`
- `targetStatusScannerNone_forces_allOldStatusDropsHit`
- `targetStatusScannerNone_forces_allMappedOldStatusDropsHit`
- `selectedFrontierFlatStatusDropPairDecidable`
- `selected_firstResidualStatusDrop`
- `selected_firstResidualStatusDrop_canonicalNonzero`
- `selected_firstResidualStatusDrop_obstructs_transitionClosure`
- `selected_firstResidualStatusDrop_obstructs_transitionCoherentData`
- `semanticResidualStatusDropScanner_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-scanner.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualStatusDropScanner.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualStatusDropScanner`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

補足: `lake build` は成功しました。既存 unrelated warning として `Formal/Arch/Extension/FeatureExtensionExamples.lean` の unnecessary sequence focus linter warning が 2 件出ています。

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: proved-in-research。

`Closes #N` チェックは意図的に未チェックです。#2348 は active threshold 15000 まで継続する tracking Issue であり、この PR では close しません。
