### PR TITLE
Cycle 102 induced status-drop scanner hitting を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -98,3 +98,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropAdapter
 import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropScanner
+import Formal.AG.Research.QualitySurface.SemanticResidualInducedStatusDropScannerHitting

--- a/Formal/AG/Research/QualitySurface/SemanticResidualInducedStatusDropScannerHitting.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualInducedStatusDropScannerHitting.lean
@@ -1,0 +1,366 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropScanner
+
+/-!
+Cycle 102 evidence for `G-aat-quality-surface-01`.
+
+This file specializes status-drop scanner exactness to residual-cut inducing
+atlas maps.  If a target complete edge-order scanner returns `none`, then an
+induced status-drop repair transport forces every old source status drop to be
+hit.  The selected-to-extended Option-carrier witness gives a concrete target
+scanner and shows that a target scanner `none` claim would require hitting the
+source frontier-to-flat status drop.
+
+The result is a finite, complete-edge-order-relative necessary condition.  It
+does not assert scanner-order canonicity, hit sufficiency, repair synthesis,
+global minimality, vanishing-to-closure, true H1/Cech/coboundary structure,
+status extraction, ArchMap correctness, tooling/runtime/UI correctness, or
+whole-codebase quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualInducedStatusDropScannerHitting
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasMorphism
+open SemanticResidualAtlasMapLaws
+open SemanticResidualCutRepairHitting
+open SemanticResidualMappedRepairHitting
+open SemanticResidualStatusDropAdapter
+open SemanticResidualStatusDropRepairHitting
+open SemanticResidualMappedStatusDropRepairHitting
+open SemanticResidualStatusDropScanner
+
+/-! ## Induced scanner-hit necessity -/
+
+/--
+Under a residual-cut inducing atlas map, target scanner `none` on a complete
+target edge order forces every old source status drop to be hit.
+-/
+theorem residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    {targetEdgeOrder : List (RightIndex × RightIndex)}
+    (hcomplete : ListedAtlasEdgesComplete new targetEdgeOrder)
+    (hscan : firstResidualStatusDrop? newReading targetEdgeOrder = none) :
+    AllMappedOldStatusDropsHit oldReading edgeHit sourceHit targetHit := by
+  exact
+    targetStatusScannerNone_forces_allMappedOldStatusDropsHit
+      (residualCutInducingAtlasMap_to_statusDropRepairTransportMap
+        (oldReading := oldReading)
+        (newReading := newReading)
+        atlasMap edgeHit sourceHit targetHit)
+      hcomplete
+      hscan
+
+/-- Under an inducing map, target scanner `none` forces a given old drop hit. -/
+theorem residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    {targetEdgeOrder : List (RightIndex × RightIndex)}
+    (hcomplete : ListedAtlasEdgesComplete new targetEdgeOrder)
+    (hscan : firstResidualStatusDrop? newReading targetEdgeOrder = none)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair) :
+    ResidualCutHit edgeHit sourceHit targetHit pair := by
+  exact
+    (residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropsHit
+      atlasMap edgeHit sourceHit targetHit hcomplete hscan)
+      pair
+      hdrop
+
+/-! ## Selected extended target scanner -/
+
+/-- A selected extended edge order whose second edge is the mapped status drop. -/
+def selectedExtendedFrontierFlatScanOrder :
+    List (SelectedExtendedOverlapIndex × SelectedExtendedOverlapIndex) :=
+  [(some SelectedSemanticOverlapIndex.flat,
+      some SelectedSemanticOverlapIndex.repairFrontier),
+    (some SelectedSemanticOverlapIndex.repairFrontier,
+      some SelectedSemanticOverlapIndex.flat)]
+
+/-- The selected extended scan order covers every active extended edge. -/
+theorem selectedExtendedFrontierFlatScanOrder_complete :
+    ListedAtlasEdgesComplete
+      selectedExtendedFrontierFlatAtlasSkeleton
+      selectedExtendedFrontierFlatScanOrder := by
+  intro source target hedge
+  cases source with
+  | none =>
+      exact False.elim
+        ((selectedExtended_none_no_outgoing_edge target) hedge)
+  | some sourceIndex =>
+      cases target with
+      | none =>
+          exact False.elim
+            ((selectedExtended_none_no_incoming_edge (some sourceIndex)) hedge)
+      | some targetIndex =>
+          cases sourceIndex <;> cases targetIndex <;>
+            simp [selectedExtendedFrontierFlatScanOrder,
+              selectedExtendedFrontierFlatAtlasSkeleton,
+              selectedExtendedFrontierFlatEdge,
+              selectedFrontierToFlatEdge] at hedge ⊢
+
+/-- The selected extended status-drop predicate is decidable without choice. -/
+instance selectedExtendedFrontierFlatStatusDropPairDecidable :
+    DecidablePred
+      (ResidualStatusDropPair
+        selectedExtendedFrontierFlatResidualStatusReading) := by
+  intro pair
+  cases pair with
+  | mk source target =>
+      cases source with
+      | none =>
+          cases target <;>
+            simp [ResidualStatusDropPair,
+              selectedExtendedFrontierFlatResidualStatusReading,
+              selectedExtendedFrontierFlatResidualStatus,
+              selectedExtendedFrontierFlatAtlasSkeleton,
+              selectedExtendedFrontierFlatEdge]
+            <;> infer_instance
+      | some sourceIndex =>
+          cases target with
+          | none =>
+              cases sourceIndex <;>
+                simp [ResidualStatusDropPair,
+                  selectedExtendedFrontierFlatResidualStatusReading,
+                  selectedExtendedFrontierFlatResidualStatus,
+                  selectedExtendedFrontierFlatAtlasSkeleton,
+                  selectedExtendedFrontierFlatEdge]
+                <;> infer_instance
+          | some targetIndex =>
+              cases sourceIndex <;> cases targetIndex <;>
+                simp [ResidualStatusDropPair,
+                  selectedExtendedFrontierFlatResidualStatusReading,
+                  selectedExtendedFrontierFlatResidualStatus,
+                  selectedExtendedFrontierFlatAtlasSkeleton,
+                  selectedExtendedFrontierFlatEdge,
+                  selectedFrontierToFlatEdge]
+                <;> infer_instance
+
+/-- The selected extended scanner returns the mapped frontier-to-flat drop. -/
+theorem selectedExtended_firstResidualStatusDrop :
+    firstResidualStatusDrop?
+      selectedExtendedFrontierFlatResidualStatusReading
+      selectedExtendedFrontierFlatScanOrder =
+        some
+          (mapResidualPair
+            selectedToExtendedIndex
+            selectedFrontierFlatResidualCutPair) := by
+  simp [selectedExtendedFrontierFlatScanOrder, firstResidualStatusDrop?,
+    mapResidualPair,
+    selectedToExtendedIndex,
+    selectedFrontierFlatResidualCutPair,
+    ResidualStatusDropPair,
+    selectedExtendedFrontierFlatResidualStatusReading,
+    selectedExtendedFrontierFlatResidualStatus,
+    selectedExtendedToSelectedIndex,
+    selectedFrontierFlatResidualStatus,
+    selectedExtendedFrontierFlatAtlasSkeleton,
+    selectedExtendedFrontierFlatEdge,
+    selectedFrontierToFlatEdge]
+
+/-- The selected extended scanner hit makes the target canonical class nonzero. -/
+theorem selectedExtended_firstResidualStatusDrop_canonicalNonzero :
+    (canonicalResidualCutCochain
+      selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    firstResidualStatusDrop?_some_canonicalNonzero
+      selectedExtended_firstResidualStatusDrop
+
+/-- The selected extended scanner hit obstructs transition closure. -/
+theorem selectedExtended_firstResidualStatusDrop_obstructs_transitionClosure
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedExtendedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    firstResidualStatusDrop?_some_obstructs_transitionClosure
+      selectedExtended_firstResidualStatusDrop
+      transition
+
+/-- The selected extended scanner hit rules out transition-coherent data. -/
+theorem selectedExtended_firstResidualStatusDrop_obstructs_transitionCoherentData
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedExtendedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    firstResidualStatusDrop?_some_obstructs_transitionCoherentData
+      selectedExtended_firstResidualStatusDrop
+      transition
+
+/--
+If the selected extended target scanner returned `none`, the selected source
+frontier-to-flat status drop would have to be hit.
+-/
+theorem selectedToExtended_targetScannerNone_requires_frontierFlatStatusHit
+    {edgeHit :
+      SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+    {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop}
+    (hscan :
+      firstResidualStatusDrop?
+        selectedExtendedFrontierFlatResidualStatusReading
+        selectedExtendedFrontierFlatScanOrder = none) :
+    ResidualCutHit
+      edgeHit
+      sourceHit
+      targetHit
+      selectedFrontierFlatResidualCutPair := by
+  exact
+    residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropHit
+      selectedToExtendedResidualCutInducingMap
+      edgeHit
+      sourceHit
+      targetHit
+      selectedExtendedFrontierFlatScanOrder_complete
+      hscan
+      selectedFrontierFlat_statusDropPair
+
+/-! ## Theorem package -/
+
+/--
+Cycle-102 theorem package: target scanner `none` under an inducing map forces
+source-side status-drop hit obligations.
+-/
+theorem semanticResidualInducedStatusDropScannerHitting_package :
+    (forall {LeftIndex : Type w}
+      {LeftAtom : Type u}
+      {RightIndex : Type x}
+      {RightAtom : Type v}
+      {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+      {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+      {oldReading : ResidualBooleanStatusReading old}
+      {newReading : ResidualBooleanStatusReading new}
+      {_inst : DecidablePred (ResidualStatusDropPair newReading)},
+      forall _atlasMap : ResidualCutInducingAtlasMap old new,
+      forall edgeHit : LeftIndex × LeftIndex -> Prop,
+      forall sourceHit targetHit : LeftIndex -> Prop,
+      forall targetEdgeOrder : List (RightIndex × RightIndex),
+        ListedAtlasEdgesComplete new targetEdgeOrder ->
+          firstResidualStatusDrop? newReading targetEdgeOrder = none ->
+            AllMappedOldStatusDropsHit oldReading edgeHit sourceHit targetHit) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new}
+        {_inst : DecidablePred (ResidualStatusDropPair newReading)},
+        forall _atlasMap : ResidualCutInducingAtlasMap old new,
+        forall edgeHit : LeftIndex × LeftIndex -> Prop,
+        forall sourceHit targetHit : LeftIndex -> Prop,
+        forall targetEdgeOrder : List (RightIndex × RightIndex),
+        forall pair : LeftIndex × LeftIndex,
+          ListedAtlasEdgesComplete new targetEdgeOrder ->
+            firstResidualStatusDrop? newReading targetEdgeOrder = none ->
+              ResidualStatusDropPair oldReading pair ->
+                ResidualCutHit edgeHit sourceHit targetHit pair) /\
+      ListedAtlasEdgesComplete
+        selectedExtendedFrontierFlatAtlasSkeleton
+        selectedExtendedFrontierFlatScanOrder /\
+      firstResidualStatusDrop?
+        selectedExtendedFrontierFlatResidualStatusReading
+        selectedExtendedFrontierFlatScanOrder =
+          some
+            (mapResidualPair
+              selectedToExtendedIndex
+              selectedFrontierFlatResidualCutPair) /\
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (forall
+        {edgeHit :
+          SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+        {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop},
+        firstResidualStatusDrop?
+          selectedExtendedFrontierFlatResidualStatusReading
+          selectedExtendedFrontierFlatScanOrder = none ->
+          ResidualCutHit
+            edgeHit
+            sourceHit
+            targetHit
+            selectedFrontierFlatResidualCutPair) /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedExtendedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedExtendedFrontierFlatAtlasSkeleton
+              transition))) := by
+  exact
+    ⟨fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading} {_inst}
+        atlasMap edgeHit sourceHit targetHit targetEdgeOrder
+        hcomplete hscan =>
+        residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropsHit
+          atlasMap edgeHit sourceHit targetHit hcomplete hscan,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading} {_inst}
+        atlasMap edgeHit sourceHit targetHit targetEdgeOrder pair
+        hcomplete hscan hdrop =>
+        residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropHit
+          atlasMap edgeHit sourceHit targetHit hcomplete hscan hdrop,
+      selectedExtendedFrontierFlatScanOrder_complete,
+      selectedExtended_firstResidualStatusDrop,
+      selectedExtended_firstResidualStatusDrop_canonicalNonzero,
+      fun {_edgeHit} {_sourceHit} {_targetHit} hscan =>
+        selectedToExtended_targetScannerNone_requires_frontierFlatStatusHit
+          hscan,
+      selectedExtended_firstResidualStatusDrop_obstructs_transitionClosure,
+      selectedExtended_firstResidualStatusDrop_obstructs_transitionCoherentData⟩
+
+end SemanticResidualInducedStatusDropScannerHitting
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-induced-status-drop-scanner-hitting.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-induced-status-drop-scanner-hitting.md
@@ -1,0 +1,141 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: induced target scanner repair-hit bridge / map-law computability support / genius-support convergence
+candidate_type: induced residual status-drop scanner hitting theorem / atlas-map scanner bridge / repair-necessity
+capability_category: semantic-obstruction / status-drop-scanner / atlas-map-induced / repair-necessity / genius-support
+expected_base_score: 86
+expected_evidence_multiplier: 2.0
+expected_final_score: 172
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can scan a target status surface, but they do not prove that target scanner none under an inducing atlas map forces source old status-drop hit obligations.
+origin: cycle-102
+tags: [quality-surface, semantic-repair, residual-cut, status-drop, scanner, atlas-map, repair-hitting, genius-support]
+created: 2026-06-23
+cycle: 102
+lean: proved-in-research
+planned_report_section: "Cycle 102: Induced target status-drop scanner hit obligations"
+---
+
+# Induced Target Status-Drop Scanner Hit Obligations
+
+## 主張
+
+`ResidualCutInducingAtlasMap`、old/new exact status readings、complete supplied target edge order を置く。
+target status-drop scanner が `none` を返すなら、Cycle 100 の induced status-drop repair transport と
+Cycle 101 の scanner exactness により、source 側の old status drops は `edgeHit` / `sourceHit` /
+`targetHit` のどこかで hit されなければならない。
+
+selected-to-extended Option carrier では、target scanner が concrete mapped frontier-to-flat drop を返す。
+もしその target scanner が `none` だと主張するなら、source の frontier-to-flat status drop hit が必要になる。
+
+これは complete supplied target edge order と supplied exact status readings に相対化された必要条件であり、
+canonical global order、hit sufficiency、repair synthesis、global minimality、vanishing-to-closure、
+true `H^1` / Cech / coboundary quotient、status extraction、ArchMap/tooling correctness、runtime/UI correctness、
+whole-codebase quality は主張しない。
+
+## 候補種別
+
+`induced residual status-drop scanner hitting theorem` / `atlas-map scanner bridge` / `repair-necessity`
+
+## 依拠
+
+- Cycle 95: residual atlas map laws。
+- Cycle 100: mapped status-drop repair-hitting transport。
+- Cycle 101: finite status-drop scanner exactness。
+
+## 非自明性
+
+単なる wrapper ではなく、`ResidualCutInducingAtlasMap` を前提にした target scanner result から、
+source-side old status-drop hit obligations を直接読む theorem surface を作る。
+selected witness では complete target scan order と concrete scanner hit を固定し、`none` claim が source hit を必要とすることを示す。
+
+## 数学的興味
+
+finite scanner exactness、carrier transport、repair-hit necessity を一つの induced map theorem に圧縮する。
+これは semantic repair-gluing obstruction target に向けた map-induced computability layer である。
+
+## GOAL への前進
+
+target quality surface を scan した結果から、source-side repair frontier obligation へ戻る直接 bridge を得た。
+genius unlock ではないが、future finite semantic repair-gluing obstruction theorem の operational reading を強める。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は target status surface を scan できる。
+しかし、inducing map と exact readings の下で target scanner `none` が source old status-drop hit を
+必要条件として要求することは証明しない。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 95/100/101 を direct bridge として圧縮し、target scanner result から source hit obligation へ戻した。
+- `dullness_risk`: Cycle 100/101 の合成に見える危険がある。selected complete target scan order と `none` requires source hit witness を加えて補強した。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualInducedStatusDropScannerHitting.lean` で induced scanner-hit theorem と selected witness を証明する。
+
+## CS / SWE への帰結
+
+target schema / carrier に移った後の status scan が `none` を返すなら、それは source 側の old status-drop
+loci が hit されたことを説明する obligation を生む。
+target-side green scan を source repair frontier の説明責務へ戻せる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualInducedStatusDropScannerHitting.lean` に固定した。
+
+- `residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropsHit`
+- `residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropHit`
+- `selectedExtendedFrontierFlatScanOrder`
+- `selectedExtendedFrontierFlatScanOrder_complete`
+- `selectedExtendedFrontierFlatStatusDropPairDecidable`
+- `selectedExtended_firstResidualStatusDrop`
+- `selectedExtended_firstResidualStatusDrop_canonicalNonzero`
+- `selectedExtended_firstResidualStatusDrop_obstructs_transitionClosure`
+- `selectedExtended_firstResidualStatusDrop_obstructs_transitionCoherentData`
+- `selectedToExtended_targetScannerNone_requires_frontierFlatStatusHit`
+- `semanticResidualInducedStatusDropScannerHitting_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualInducedStatusDropScannerHitting.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualInducedStatusDropScannerHitting`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic / complete-order theorem 群は標準 `propext` のみ。selected witness と package は標準
+  `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、ResidualCutInducingAtlasMap、supplied exact status readings、complete supplied target edge order、
+target scanner `none` から source hit necessity への bridge に限定する。
+unchecked: canonical global edge order、hit sufficiency、repair synthesis、global minimality、vanishing-to-closure、
+true H1/cohomology、Cech quotient、coboundary quotient、status extraction、ArchMap correctness、
+runtime/UI correctness、whole-codebase quality、arbitrary atlas category/functoriality。
+
+## 審判メモ
+
+- G1: accept。保守 base 86 / final +172。Cycle 95 inducing map laws + target scanner none から source-side old status-drop hit obligation を引き戻す support theorem。
+- G2: accept。base 84-86 / final +168 to +172。新 obstruction 本体ではなく direct bridge / support package として評価する。
+
+## 追加 required fields
+
+- `mathematical_interest`: target scanner exactness を inducing atlas map 経由の source hit necessity に変換する。
+- `goal_advancement`: semantic repair-gluing obstruction target の map-induced computability layer を強化した。
+- `planned_theorem_names`: `residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropsHit`, `selectedToExtended_targetScannerNone_requires_frontierFlatStatusHit`, `semanticResidualInducedStatusDropScannerHitting_package`
+- `visible_projection`: target scanner none、complete target edge order、inducing map、source hit loci。
+- `protected_structure`: exact readings、inducing map preservation、scanner exactness、source hit necessity。
+- `exactness_or_minimality_claim`: complete supplied target order に相対化した exactness。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: target scanner none without complete order or exact readings does not certify source hit obligation。
+- `previous_cycle_delta`: Cycle 101 の scanner exactness を ResidualCutInducingAtlasMap に直接接続した。
+- `rival_stress_test`: rival は target scan を表示できても source-side hit obligation を theorem として出さない。
+- `genius_potential`: support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の map-induced scanner bridge。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: target scanner result を source repair frontier obligation へ戻す。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-scanner.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-repair-hitting.md`
+- planned report section: `Cycle 102: Induced target status-drop scanner hit obligations`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 102 G1/G2 で induced target status-drop scanner hit obligations を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualInducedStatusDropScannerHitting.lean` に固定し、単体
+  `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 14230
+- total SCORE: 14402
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -106,8 +106,9 @@
   - semantic-obstruction / status-drop-adapter / repair-necessity / finite-atlas-transition / genius-support: 176
   - semantic-obstruction / status-drop-adapter / repair-necessity / cross-carrier-transport / genius-support: 180
   - semantic-obstruction / status-drop-scanner / computability / repair-necessity / genius-support: 176
+  - semantic-obstruction / status-drop-scanner / atlas-map-induced / repair-necessity / genius-support: 172
 - evidence portfolio:
-  - proved-in-research: 101
+  - proved-in-research: 102
 
 ## Phase synthesis
 
@@ -123,7 +124,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-101 件の Lean-proved research artifacts は、次の paper seed を形成している。
+102 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -153,6 +154,7 @@ certificate の基本単位は
 - semantic residual status-drop repair hitting は、unhit edge/status preservation laws により、new status-drop absence または canonical vanishing が old true-to-false status drop の edge/source/target hit を必要とすることを示す。
 - semantic residual mapped status-drop repair hitting は、exact status readings と mapIndex 付き unhit preservation laws により、status-drop repair-hitting necessity が finite carrier/schema change をまたいで transport されることを示す。
 - semantic residual status-drop scanner は、complete supplied edge order 上の finite scanner `none` が no-drop/canonical vanishing と同値であり、target scanner `none` が old/mapped old status-drop hit necessity を強制することを示す。
+- semantic residual induced status-drop scanner hitting は、ResidualCutInducingAtlasMap と complete target scanner `none` から source-side old status-drop hit obligation を直接読む bridge を与える。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -214,8 +216,9 @@ Cycle 98 後の total SCORE は 13698 であり、tracking Issue active threshol
 Cycle 99 後の total SCORE は 13874 であり、tracking Issue active threshold 15000 までは残り 1126 SCORE である。
 Cycle 100 後の total SCORE は 14054 であり、tracking Issue active threshold 15000 までは残り 946 SCORE である。
 Cycle 101 後の total SCORE は 14230 であり、tracking Issue active threshold 15000 までは残り 770 SCORE である。
+Cycle 102 後の total SCORE は 14402 であり、tracking Issue active threshold 15000 までは残り 598 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 101 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 102 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -249,7 +252,8 @@ semantic residual mapped repair-hitting theorem、
 semantic residual status-drop adapter theorem、
 semantic residual status-drop repair-hitting theorem、
 semantic residual mapped status-drop repair-hitting theorem、
-semantic residual status-drop scanner theorem を含む。
+semantic residual status-drop scanner theorem、
+semantic residual induced status-drop scanner hitting theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5521,4 +5525,79 @@ quality.
 
 Cycle 101 後の total SCORE は 14230 であり、tracking Issue active threshold 15000 までは残り 770 SCORE である。
 次 cycle では、finite pre-H1 support without cohomology overclaim、cross-carrier status-drop minimality、scanner completeness under mapped edge orders、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 102: Induced target status-drop scanner hit obligations
+
+```text
+candidate: Induced target status-drop scanner hit obligations
+candidate_type: induced residual status-drop scanner hitting theorem / atlas-map scanner bridge / repair-necessity
+evidence_stage: proved-in-research
+base_score: 86
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 172
+category: semantic-obstruction / status-drop-scanner / atlas-map-induced / repair-necessity / genius-support
+goal_delta: Cycle 95 の ResidualCutInducingAtlasMap と Cycle 101 の target scanner none exactness を接続し、target scanner none から source-side old status-drop hit obligation へ戻す bridge を固定した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、induced target scanner none theorem、selected extended target scan order、selected none-to-source-hit theorem、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は target status surface を scan できても、inducing map と exact readings の下で target scanner none が source hit obligation を要求することを Lean theorem として保証できない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualInducedStatusDropScannerHitting.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualInducedStatusDropScannerHitting`, and `lake build FormalAGResearch` passed. Axiom probe reported generic and complete-order theorem family uses standard `propext` only; selected witness and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: finite pre-H1 support without cohomology overclaim; cross-carrier status-drop minimality; scanner completeness under generated mapped edge orders; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualInducedStatusDropScannerHitting.lean`
+connects the Cycle 95 inducing atlas map laws with the Cycle 101 finite
+status-drop scanner.  Under `ResidualCutInducingAtlasMap`, supplied exact
+old/new residual status readings, and a complete supplied target edge order,
+Lean proves that target scanner `none` forces every old source status drop to
+be hit by one of the source-side hit predicates.
+
+The theorem is deliberately complete-order-relative.  It does not claim a
+canonical global target order.  Instead, it says that once a complete target
+scan order is supplied, a green target scanner result has a precise source-side
+explanation obligation.
+
+The selected witness builds the extended Option-carrier target scan order
+`[(some flat, some repairFrontier), (some repairFrontier, some flat)]`,
+proves it complete for the selected extended source/target map, and shows that
+the scanner finds the mapped frontier-to-flat status drop.  If that target
+scanner is assumed to return `none`, the source frontier-to-flat drop must be
+hit.
+
+Lean proves:
+
+- `residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropsHit`:
+  target scanner `none` under an inducing atlas map forces all old source
+  status drops to be hit.
+- `residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropHit`:
+  the pointwise version for a supplied source status-drop pair.
+- `selectedExtendedFrontierFlatScanOrder`: the selected extended target scan
+  order.
+- `selectedExtendedFrontierFlatScanOrder_complete`: complete order proof for
+  the selected extended source/target map.
+- `selectedExtended_firstResidualStatusDrop`: selected extended scanner hit.
+- `selectedExtended_firstResidualStatusDrop_canonicalNonzero`: selected
+  scanner hit gives canonical nonzero.
+- `selectedExtended_firstResidualStatusDrop_obstructs_transitionClosure`:
+  selected scanner hit obstructs transition closure.
+- `selectedExtended_firstResidualStatusDrop_obstructs_transitionCoherentData`:
+  selected scanner hit rules out transition-coherent data.
+- `selectedToExtended_targetScannerNone_requires_frontierFlatStatusHit`:
+  selected target scanner `none` requires a source frontier-to-flat hit.
+- `semanticResidualInducedStatusDropScannerHitting_package`: theorem package.
+
+This cycle is a `genius-support` bridge, not a `genius unlock`.  It proves
+that finite target scanner exactness can be pulled back through an inducing
+atlas map into source repair-hit obligations.  It does not prove hit
+sufficiency, repair synthesis, global minimality, vanishing-to-closure, true
+`H^1` / Cech / coboundary quotient, status extraction, ArchMap correctness,
+runtime repair synthesis, tooling runtime extraction, UI correctness,
+whole-codebase quality, or arbitrary atlas category/functoriality.
+
+### Next Frontier
+
+Cycle 102 後の total SCORE は 14402 であり、tracking Issue active threshold 15000 までは残り 598 SCORE である。
+次 cycle では、generated mapped edge-order scanner completeness、finite pre-H1 support without cohomology overclaim、target nonempty contradiction from scanner none、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 102 として、`ResidualCutInducingAtlasMap` と finite target status-drop scanner を接続し、complete supplied target edge order 上で target scanner `none` から source-side old status-drop hit obligation を引き戻す Lean theorem surface を追加しました。

SCORE は G1/G2/G3/G3.5/G4 監査後に +172 とし、`research/reports/G-aat-quality-surface-01.md` の total を 14230 から 14402 に更新しています。これは `genius-support` cycle であり、genius unlock は主張しません。

## 証明した定理

- `residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropsHit`
- `residualCutInducingAtlasMap_targetScannerNone_forces_oldStatusDropHit`
- `selectedExtendedFrontierFlatScanOrder_complete`
- `selectedExtended_firstResidualStatusDrop`
- `selectedExtended_firstResidualStatusDrop_canonicalNonzero`
- `selectedExtended_firstResidualStatusDrop_obstructs_transitionClosure`
- `selectedExtended_firstResidualStatusDrop_obstructs_transitionCoherentData`
- `selectedToExtended_targetScannerNone_requires_frontierFlatStatusHit`
- `semanticResidualInducedStatusDropScannerHitting_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-induced-status-drop-scanner-hitting.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualInducedStatusDropScannerHitting.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualInducedStatusDropScannerHitting`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
