### PR TITLE
Cycle 103 generated status-drop scanner order を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -99,3 +99,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropRepairHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualInducedStatusDropScannerHitting
+import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropScannerOrder

--- a/Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropScannerOrder.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropScannerOrder.lean
@@ -1,0 +1,473 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualInducedStatusDropScannerHitting
+
+/-!
+Cycle 103 evidence for `G-aat-quality-surface-01`.
+
+This file removes one hand-supplied-order layer from the finite status-drop
+scanner bridge.  A source-side finite edge order can be mapped into a target
+edge order.  If the source order covers all source active edges, then the
+mapped target order covers every mapped old status drop.  Therefore target
+scanner `none` on this generated mapped order already forces source-side
+old status-drop hit obligations.
+
+The result is source-order-relative and mapped-old-drop-relative.  It does
+not assert that the generated order covers all target edges, does not assert a
+canonical global edge order, hit sufficiency, repair synthesis, global
+minimality, vanishing-to-closure, true H1/Cech/coboundary structure, status
+extraction, ArchMap correctness, tooling/runtime/UI correctness, or
+whole-codebase quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualMappedStatusDropScannerOrder
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasMorphism
+open SemanticResidualAtlasMapLaws
+open SemanticResidualCutRepairHitting
+open SemanticResidualMappedRepairHitting
+open SemanticResidualStatusDropAdapter
+open SemanticResidualStatusDropRepairHitting
+open SemanticResidualMappedStatusDropRepairHitting
+open SemanticResidualStatusDropScanner
+open SemanticResidualInducedStatusDropScannerHitting
+
+/-! ## Generated mapped scanner orders -/
+
+/-- Map a source finite edge order into the target carrier. -/
+def mapResidualEdgeOrder
+    {LeftIndex : Type w}
+    {RightIndex : Type x}
+    (mapIndex : LeftIndex -> RightIndex)
+    (sourceEdgeOrder : List (LeftIndex × LeftIndex)) :
+    List (RightIndex × RightIndex) :=
+  sourceEdgeOrder.map (mapResidualPair mapIndex)
+
+/-- The target order contains every mapped old status drop. -/
+def MappedOldStatusDropsCovered
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (mapIndex : LeftIndex -> RightIndex)
+    (targetEdgeOrder : List (RightIndex × RightIndex)) : Prop :=
+  forall pair,
+    ResidualStatusDropPair oldReading pair ->
+      mapResidualPair mapIndex pair ∈ targetEdgeOrder
+
+/--
+A source edge order complete for the old atlas covers every mapped old status
+drop after applying `mapIndex`.
+-/
+theorem mapResidualEdgeOrder_covers_mappedOldStatusDrops
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    (mapIndex : LeftIndex -> RightIndex)
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    (hcomplete : ListedAtlasEdgesComplete old sourceEdgeOrder) :
+    MappedOldStatusDropsCovered
+      oldReading
+      mapIndex
+      (mapResidualEdgeOrder mapIndex sourceEdgeOrder) := by
+  intro pair hdrop
+  exact
+    List.mem_map.mpr
+      ⟨pair, hcomplete pair.1 pair.2 hdrop.1, rfl⟩
+
+/--
+If a target scanner reports `none` on the mapped source order, then every old
+status drop whose mapped pair is covered by that order must be hit.
+-/
+theorem targetMappedCoveredScannerNone_forces_allMappedOldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    {targetEdgeOrder : List (RightIndex × RightIndex)}
+    (hcovered :
+      MappedOldStatusDropsCovered
+        oldReading
+        transportMap.mapIndex
+        targetEdgeOrder)
+    (hscan : firstResidualStatusDrop? newReading targetEdgeOrder = none) :
+    AllMappedOldStatusDropsHit
+      oldReading
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit := by
+  intro pair hdrop hunhit
+  have hnewDrop :
+      ResidualStatusDropPair newReading
+        (mapResidualPair transportMap.mapIndex pair) :=
+    unhit_oldStatusDrop_maps_to_newStatusDrop
+      transportMap
+      hdrop
+      hunhit.1
+      hunhit.2.1
+      hunhit.2.2
+  have hclear :
+      ListedResidualStatusDropsClear newReading targetEdgeOrder :=
+    (firstResidualStatusDrop?_none_iff_listedStatusDropsClear
+      newReading
+      targetEdgeOrder).mp hscan
+  exact hclear
+    (mapResidualPair transportMap.mapIndex pair)
+    (hcovered pair hdrop)
+    hnewDrop
+
+/--
+The mapped image of a complete source order is sufficient: target scanner
+`none` on that generated order forces all old status drops to be hit.
+-/
+theorem targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    (hcomplete : ListedAtlasEdgesComplete old sourceEdgeOrder)
+    (hscan :
+      firstResidualStatusDrop?
+        newReading
+        (mapResidualEdgeOrder transportMap.mapIndex sourceEdgeOrder) =
+          none) :
+    AllMappedOldStatusDropsHit
+      oldReading
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit := by
+  exact
+    targetMappedCoveredScannerNone_forces_allMappedOldStatusDropsHit
+      transportMap
+      (mapResidualEdgeOrder_covers_mappedOldStatusDrops
+        transportMap.mapIndex
+        hcomplete)
+      hscan
+
+/--
+Pointwise version for a generated mapped source order.
+-/
+theorem targetMappedSourceOrderScannerNone_forces_mappedOldStatusDropHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    (hcomplete : ListedAtlasEdgesComplete old sourceEdgeOrder)
+    (hscan :
+      firstResidualStatusDrop?
+        newReading
+        (mapResidualEdgeOrder transportMap.mapIndex sourceEdgeOrder) =
+          none)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair) :
+    ResidualCutHit
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit
+      pair := by
+  exact
+    (targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit
+      transportMap
+      hcomplete
+      hscan)
+      pair
+      hdrop
+
+/-! ## Induced atlas-map versions -/
+
+/--
+Under an inducing atlas map, target scanner `none` on the mapped source order
+forces every old source status drop to be hit.
+-/
+theorem residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    (hcomplete : ListedAtlasEdgesComplete old sourceEdgeOrder)
+    (hscan :
+      firstResidualStatusDrop?
+        newReading
+        (mapResidualEdgeOrder atlasMap.mapIndex sourceEdgeOrder) =
+          none) :
+    AllMappedOldStatusDropsHit oldReading edgeHit sourceHit targetHit := by
+  exact
+    targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit
+      (residualCutInducingAtlasMap_to_statusDropRepairTransportMap
+        (oldReading := oldReading)
+        (newReading := newReading)
+        atlasMap edgeHit sourceHit targetHit)
+      hcomplete
+      hscan
+
+/-- Pointwise induced-map version for a generated mapped source order. -/
+theorem residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (atlasMap : ResidualCutInducingAtlasMap old new)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    (hcomplete : ListedAtlasEdgesComplete old sourceEdgeOrder)
+    (hscan :
+      firstResidualStatusDrop?
+        newReading
+        (mapResidualEdgeOrder atlasMap.mapIndex sourceEdgeOrder) =
+          none)
+    {pair : LeftIndex × LeftIndex}
+    (hdrop : ResidualStatusDropPair oldReading pair) :
+    ResidualCutHit edgeHit sourceHit targetHit pair := by
+  exact
+    (residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropsHit
+      atlasMap
+      edgeHit
+      sourceHit
+      targetHit
+      hcomplete
+      hscan)
+      pair
+      hdrop
+
+/-! ## Selected generated-order witness -/
+
+/-- The selected source scan order covers every selected active edge. -/
+theorem selectedFrontierFlatScanOrder_complete :
+    ListedAtlasEdgesComplete
+      selectedFrontierFlatAtlasSkeleton
+      selectedFrontierFlatScanOrder := by
+  intro source target hedge
+  cases source <;> cases target <;>
+    simp [selectedFrontierFlatScanOrder,
+      selectedFrontierFlatAtlasSkeleton,
+      selectedFrontierToFlatEdge] at hedge ⊢
+
+/-- The generated selected mapped source order is the selected extended order. -/
+theorem selectedGeneratedMappedStatusDropScanOrder_eq :
+    mapResidualEdgeOrder
+      selectedToExtendedIndex
+      selectedFrontierFlatScanOrder =
+        selectedExtendedFrontierFlatScanOrder := by
+  rfl
+
+/-- The selected generated mapped source order returns the mapped drop. -/
+theorem selectedGeneratedMapped_firstResidualStatusDrop :
+    firstResidualStatusDrop?
+      selectedExtendedFrontierFlatResidualStatusReading
+      (mapResidualEdgeOrder
+        selectedToExtendedIndex
+        selectedFrontierFlatScanOrder) =
+        some
+          (mapResidualPair
+            selectedToExtendedIndex
+            selectedFrontierFlatResidualCutPair) := by
+  simpa [selectedGeneratedMappedStatusDropScanOrder_eq]
+    using selectedExtended_firstResidualStatusDrop
+
+/--
+If the selected generated mapped-order scanner returned `none`, the selected
+source frontier-to-flat status drop would have to be hit.
+-/
+theorem selectedGeneratedMapped_targetScannerNone_requires_frontierFlatStatusHit
+    {edgeHit :
+      SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+    {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop}
+    (hscan :
+      firstResidualStatusDrop?
+        selectedExtendedFrontierFlatResidualStatusReading
+        (mapResidualEdgeOrder
+          selectedToExtendedIndex
+          selectedFrontierFlatScanOrder) = none) :
+    ResidualCutHit
+      edgeHit
+      sourceHit
+      targetHit
+      selectedFrontierFlatResidualCutPair := by
+  exact
+    residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropHit
+      selectedToExtendedResidualCutInducingMap
+      edgeHit
+      sourceHit
+      targetHit
+      selectedFrontierFlatScanOrder_complete
+      hscan
+      selectedFrontierFlat_statusDropPair
+
+/-! ## Theorem package -/
+
+/--
+Cycle-103 theorem package: mapped source edge orders are sufficient scanner
+surfaces for mapped-old-drop repair-hit obligations.
+-/
+theorem semanticResidualMappedStatusDropScannerOrder_package :
+    (forall {LeftIndex : Type w}
+      {LeftAtom : Type u}
+      {RightIndex : Type x}
+      {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+      {oldReading : ResidualBooleanStatusReading old},
+      forall mapIndex : LeftIndex -> RightIndex,
+      forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+        ListedAtlasEdgesComplete old sourceEdgeOrder ->
+          MappedOldStatusDropsCovered
+            oldReading
+            mapIndex
+            (mapResidualEdgeOrder mapIndex sourceEdgeOrder)) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new}
+        {_inst : DecidablePred (ResidualStatusDropPair newReading)},
+        forall transportMap :
+          ResidualStatusDropRepairTransportMap oldReading newReading,
+        forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+          ListedAtlasEdgesComplete old sourceEdgeOrder ->
+            firstResidualStatusDrop?
+              newReading
+              (mapResidualEdgeOrder
+                transportMap.mapIndex
+                sourceEdgeOrder) =
+                none ->
+              AllMappedOldStatusDropsHit
+                oldReading
+                transportMap.edgeHit
+                transportMap.sourceHit
+                transportMap.targetHit) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new}
+        {_inst : DecidablePred (ResidualStatusDropPair newReading)},
+        forall _atlasMap : ResidualCutInducingAtlasMap old new,
+        forall edgeHit : LeftIndex × LeftIndex -> Prop,
+        forall sourceHit targetHit : LeftIndex -> Prop,
+        forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+          ListedAtlasEdgesComplete old sourceEdgeOrder ->
+            firstResidualStatusDrop?
+              newReading
+              (mapResidualEdgeOrder _atlasMap.mapIndex sourceEdgeOrder) =
+                none ->
+              AllMappedOldStatusDropsHit oldReading edgeHit sourceHit targetHit) /\
+      mapResidualEdgeOrder
+        selectedToExtendedIndex
+        selectedFrontierFlatScanOrder =
+          selectedExtendedFrontierFlatScanOrder /\
+      firstResidualStatusDrop?
+        selectedExtendedFrontierFlatResidualStatusReading
+        (mapResidualEdgeOrder
+          selectedToExtendedIndex
+          selectedFrontierFlatScanOrder) =
+          some
+            (mapResidualPair
+              selectedToExtendedIndex
+              selectedFrontierFlatResidualCutPair) /\
+      (forall
+        {edgeHit :
+          SelectedSemanticOverlapIndex × SelectedSemanticOverlapIndex -> Prop}
+        {sourceHit targetHit : SelectedSemanticOverlapIndex -> Prop},
+        firstResidualStatusDrop?
+          selectedExtendedFrontierFlatResidualStatusReading
+          (mapResidualEdgeOrder
+            selectedToExtendedIndex
+            selectedFrontierFlatScanOrder) = none ->
+          ResidualCutHit
+            edgeHit
+            sourceHit
+            targetHit
+            selectedFrontierFlatResidualCutPair) := by
+  exact
+    ⟨fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_old} {_oldReading}
+        mapIndex sourceEdgeOrder hcomplete =>
+        mapResidualEdgeOrder_covers_mappedOldStatusDrops
+          (oldReading := _oldReading)
+          mapIndex
+          hcomplete,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading} {_inst}
+        transportMap sourceEdgeOrder hcomplete hscan =>
+        targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit
+          transportMap
+          hcomplete
+          hscan,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading} {_inst}
+        atlasMap edgeHit sourceHit targetHit sourceEdgeOrder hcomplete
+        hscan =>
+        residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropsHit
+          atlasMap
+          edgeHit
+          sourceHit
+          targetHit
+          hcomplete
+          hscan,
+      selectedGeneratedMappedStatusDropScanOrder_eq,
+      selectedGeneratedMapped_firstResidualStatusDrop,
+      fun {_edgeHit} {_sourceHit} {_targetHit} hscan =>
+        selectedGeneratedMapped_targetScannerNone_requires_frontierFlatStatusHit
+          hscan⟩
+
+end SemanticResidualMappedStatusDropScannerOrder
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-scanner-order.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-scanner-order.md
@@ -1,0 +1,142 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: generated mapped scanner order / source-order induced target scan / genius-support convergence
+candidate_type: mapped source-order status-drop scanner theorem / generated target-order bridge / repair-necessity
+capability_category: semantic-obstruction / status-drop-scanner / generated-mapped-order / repair-necessity / genius-support
+expected_base_score: 84
+expected_evidence_multiplier: 2.0
+expected_final_score: 168
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can display mapped target edges, but they do not prove that a source-complete order mapped into the target carrier is sufficient to force source hit obligations from target scanner none.
+origin: cycle-103
+tags: [quality-surface, semantic-repair, residual-cut, status-drop, scanner, mapped-order, repair-hitting, genius-support]
+created: 2026-06-23
+cycle: 103
+lean: proved-in-research
+planned_report_section: "Cycle 103: Generated mapped status-drop scanner order"
+---
+
+# Generated Mapped Status-Drop Scanner Order
+
+## 主張
+
+source 側の finite edge order が old atlas の active edges を cover しているなら、その edge order を
+`mapResidualPair mapIndex` で target carrier へ写した generated mapped order は、すべての mapped old
+status drops を cover する。
+
+したがって target scanner がこの generated mapped order 上で `none` を返すなら、target 全体の complete
+edge order を仮定しなくても、source-side old status-drop hit obligations を強制できる。
+
+これは source-order-relative / mapped-old-drop-relative な必要条件であり、generated order が全 target edges を
+cover すること、canonical global order、hit sufficiency、repair synthesis、global minimality、
+vanishing-to-closure、true `H^1` / Cech / coboundary quotient、status extraction、ArchMap/tooling correctness、
+runtime/UI correctness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`mapped source-order status-drop scanner theorem` / `generated target-order bridge` / `repair-necessity`
+
+## 依拠
+
+- Cycle 100: mapped status-drop repair-hitting transport。
+- Cycle 101: finite status-drop scanner exactness on listed orders。
+- Cycle 102: induced atlas-map scanner-hit bridge。
+
+## 非自明性
+
+Cycle 102 では complete target edge order を手で供給した。
+Cycle 103 では source-complete edge order を map した generated target order だけで、mapped old status drops
+に対する scanner-hit necessity が成立することを示す。
+
+## 数学的興味
+
+finite scanner exactness を target 全体の complete order ではなく、source order の image に相対化する。
+これは semantic repair-gluing obstruction theorem に必要な computable target scan surface を、
+source certificate geometry から生成できることを示す support layer である。
+
+## GOAL への前進
+
+target-side green scan の説明責務を、hand-supplied target order ではなく source-side certificate order の
+map image から読めるようにした。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は mapped target edge list を表示できる。
+しかし、source-complete order の map image 上の scanner `none` が source old status-drop hit obligations を
+強制することを定理として与えない。
+
+## SCORE 見込み
+
+- `score_reason`: complete target order 依存を弱め、source-generated mapped order による scanner-hit necessity を証明した。
+- `dullness_risk`: Cycle 101/102 の scanner bridge の order-variant に見える危険がある。mapped-old-drop coverage predicate と generated-order selected witness で補強した。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropScannerOrder.lean` で generated mapped order と scanner none theorem を証明する。
+
+## CS / SWE への帰結
+
+target schema / carrier に移った後の status scan surface を、source 側の finite certificate order から機械的に生成できる。
+target 全体の scan order を別途完全化しなくても、mapped old drop obligations の説明責務を検出できる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropScannerOrder.lean` に固定した。
+
+- `mapResidualEdgeOrder`
+- `MappedOldStatusDropsCovered`
+- `mapResidualEdgeOrder_covers_mappedOldStatusDrops`
+- `targetMappedCoveredScannerNone_forces_allMappedOldStatusDropsHit`
+- `targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit`
+- `targetMappedSourceOrderScannerNone_forces_mappedOldStatusDropHit`
+- `residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropsHit`
+- `residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropHit`
+- `selectedFrontierFlatScanOrder_complete`
+- `selectedGeneratedMappedStatusDropScanOrder_eq`
+- `selectedGeneratedMapped_firstResidualStatusDrop`
+- `selectedGeneratedMapped_targetScannerNone_requires_frontierFlatStatusHit`
+- `semanticResidualMappedStatusDropScannerOrder_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropScannerOrder.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropScannerOrder`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: theorem family は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、source-complete edge order の map image、mapped old status-drop coverage、target scanner
+`none` から source hit necessity への bridge に限定する。
+unchecked: generated order covers all target edges、canonical global order、hit sufficiency、repair synthesis、
+global minimality、vanishing-to-closure、true H1/cohomology、Cech quotient、coboundary quotient、status extraction、
+ArchMap correctness、runtime/UI correctness、whole-codebase quality、arbitrary atlas category/functoriality。
+
+## 審判メモ
+
+- G1: accept。novelty は中程度だが、source certificate order から target scanner surface を生成する実用的前進として base 84 / final +168 を推奨。
+- G2: accept。rival は mapped edge list を表示できても、source-complete order の map image 上の scanner `none` から source hit obligation を theorem として引き戻せない。score range +164 to +168、提案 +168 は妥当。
+- genius unlock ではなく、finite semantic repair-gluing obstruction theorem へ向けた support-cycle。
+
+## 追加 required fields
+
+- `mathematical_interest`: source-complete order の map image が mapped old status drops を cover することを scanner theorem に接続する。
+- `goal_advancement`: target scan surface の生成を source certificate order から与える。
+- `planned_theorem_names`: `targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit`, `residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropsHit`, `semanticResidualMappedStatusDropScannerOrder_package`
+- `visible_projection`: source edge order、map image target order、target scanner none、source hit loci。
+- `protected_structure`: source order completeness、mapped-old-drop coverage、scanner none exactness、source hit necessity。
+- `exactness_or_minimality_claim`: mapped old drops に相対化した generated-order exactness。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: generated order が全 target edges を cover しなくても mapped old drop obligations だけは読める。
+- `previous_cycle_delta`: Cycle 102 の complete target order bridge を source-generated mapped order bridge に弱めた。
+- `rival_stress_test`: rival は generated mapped edge list を表示できても scanner none から source hit obligation を証明しない。
+- `genius_potential`: support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の generated scanner order layer。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: source certificate order から target scanner surface を生成する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-scanner.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-induced-status-drop-scanner-hitting.md`
+- planned report section: `Cycle 103: Generated mapped status-drop scanner order`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 103 candidate として generated mapped status-drop scanner order を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualMappedStatusDropScannerOrder.lean` に固定し、単体
+  `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 14402
+- total SCORE: 14570
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -107,8 +107,9 @@
   - semantic-obstruction / status-drop-adapter / repair-necessity / cross-carrier-transport / genius-support: 180
   - semantic-obstruction / status-drop-scanner / computability / repair-necessity / genius-support: 176
   - semantic-obstruction / status-drop-scanner / atlas-map-induced / repair-necessity / genius-support: 172
+  - semantic-obstruction / status-drop-scanner / generated-mapped-order / repair-necessity / genius-support: 168
 - evidence portfolio:
-  - proved-in-research: 102
+  - proved-in-research: 103
 
 ## Phase synthesis
 
@@ -124,7 +125,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-102 件の Lean-proved research artifacts は、次の paper seed を形成している。
+103 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -155,6 +156,7 @@ certificate の基本単位は
 - semantic residual mapped status-drop repair hitting は、exact status readings と mapIndex 付き unhit preservation laws により、status-drop repair-hitting necessity が finite carrier/schema change をまたいで transport されることを示す。
 - semantic residual status-drop scanner は、complete supplied edge order 上の finite scanner `none` が no-drop/canonical vanishing と同値であり、target scanner `none` が old/mapped old status-drop hit necessity を強制することを示す。
 - semantic residual induced status-drop scanner hitting は、ResidualCutInducingAtlasMap と complete target scanner `none` から source-side old status-drop hit obligation を直接読む bridge を与える。
+- semantic residual mapped status-drop scanner order は、source-complete edge order の map image 上の target scanner `none` だけで mapped old status-drop hit obligation を読めることを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -217,8 +219,9 @@ Cycle 99 後の total SCORE は 13874 であり、tracking Issue active threshol
 Cycle 100 後の total SCORE は 14054 であり、tracking Issue active threshold 15000 までは残り 946 SCORE である。
 Cycle 101 後の total SCORE は 14230 であり、tracking Issue active threshold 15000 までは残り 770 SCORE である。
 Cycle 102 後の total SCORE は 14402 であり、tracking Issue active threshold 15000 までは残り 598 SCORE である。
+Cycle 103 後の total SCORE は 14570 であり、tracking Issue active threshold 15000 までは残り 430 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 102 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 103 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -253,7 +256,8 @@ semantic residual status-drop adapter theorem、
 semantic residual status-drop repair-hitting theorem、
 semantic residual mapped status-drop repair-hitting theorem、
 semantic residual status-drop scanner theorem、
-semantic residual induced status-drop scanner hitting theorem を含む。
+semantic residual induced status-drop scanner hitting theorem、
+semantic residual mapped status-drop scanner order theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5600,4 +5604,73 @@ whole-codebase quality, or arbitrary atlas category/functoriality.
 
 Cycle 102 後の total SCORE は 14402 であり、tracking Issue active threshold 15000 までは残り 598 SCORE である。
 次 cycle では、generated mapped edge-order scanner completeness、finite pre-H1 support without cohomology overclaim、target nonempty contradiction from scanner none、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 103: Generated mapped status-drop scanner order
+
+```text
+candidate: Generated mapped status-drop scanner order
+candidate_type: mapped source-order status-drop scanner theorem / generated target-order bridge / repair-necessity
+evidence_stage: proved-in-research
+base_score: 84
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 168
+category: semantic-obstruction / status-drop-scanner / generated-mapped-order / repair-necessity / genius-support
+goal_delta: Cycle 102 の complete target edge-order bridge を、source-complete edge order の map image 上の target scanner none bridge へ弱めた。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、generated mapped edge order、mapped old status-drop coverage、scanner none to hit theorem、selected generated-order witness、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は mapped target edge list を表示できても、source-complete order の map image 上の scanner none が source hit obligations を強制することを Lean theorem として保証できない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropScannerOrder.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropScannerOrder`, and `lake build FormalAGResearch` passed. Axiom probe reported standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: generated order coverage for richer target subfamilies; finite pre-H1 support without cohomology overclaim; target nonempty contradiction from scanner none; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropScannerOrder.lean`
+turns a source-side finite edge order into a target scanner surface by mapping
+each source edge pair through `mapResidualPair`.  If the source order is
+complete for the old atlas, Lean proves that the generated mapped target order
+covers every mapped old status drop.
+
+This weakens the hand-supplied target-order assumption used in Cycle 102.  The
+target order no longer has to cover every target active edge.  It only has to
+cover the mapped old status drops that can witness failure of source-side
+repair hitting.  Therefore target scanner `none` on the generated mapped order
+forces all old status drops to be hit.
+
+The induced-atlas-map version specializes this to `ResidualCutInducingAtlasMap`.
+The selected witness proves that the selected source scan order maps exactly to
+the selected extended target scan order, the generated scanner returns the
+mapped frontier-to-flat drop, and a generated-order target scanner `none` claim
+would require the source frontier-to-flat hit.
+
+Lean proves:
+
+- `mapResidualEdgeOrder`: maps a source finite edge order into the target carrier.
+- `MappedOldStatusDropsCovered`: coverage predicate for mapped old status drops.
+- `mapResidualEdgeOrder_covers_mappedOldStatusDrops`: source order completeness gives mapped old status-drop coverage.
+- `targetMappedCoveredScannerNone_forces_allMappedOldStatusDropsHit`: scanner `none` on a covered target order forces all old hits.
+- `targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit`: generated mapped source order version.
+- `targetMappedSourceOrderScannerNone_forces_mappedOldStatusDropHit`: pointwise generated-order version.
+- `residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropsHit`: induced-atlas-map generated-order version.
+- `residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropHit`: pointwise induced-atlas-map version.
+- `selectedFrontierFlatScanOrder_complete`: selected source order completeness.
+- `selectedGeneratedMappedStatusDropScanOrder_eq`: selected generated mapped order equals the selected extended order.
+- `selectedGeneratedMapped_firstResidualStatusDrop`: selected generated scanner hit.
+- `selectedGeneratedMapped_targetScannerNone_requires_frontierFlatStatusHit`: selected generated-order scanner `none` requires source hit.
+- `semanticResidualMappedStatusDropScannerOrder_package`: theorem package.
+
+This cycle is a `genius-support` bridge, not a `genius unlock`.  It proves
+that a computable target scanner surface can be generated from source
+certificate geometry for mapped old status-drop obligations.  It does not
+prove the generated order covers all target edges, canonical global order, hit
+sufficiency, repair synthesis, global minimality, vanishing-to-closure, true
+`H^1` / Cech / coboundary quotient, status extraction, ArchMap correctness,
+runtime repair synthesis, tooling runtime extraction, UI correctness,
+whole-codebase quality, or arbitrary atlas category/functoriality.
+
+### Next Frontier
+
+Cycle 103 後の total SCORE は 14570 であり、tracking Issue active threshold 15000 までは残り 430 SCORE である。
+次 cycle では、target nonempty contradiction from scanner none、finite pre-H1 support without cohomology overclaim、generated mapped order coverage for richer subfamilies、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 103 として、source-complete finite edge order を `mapResidualPair` で target order に写した generated mapped order が、mapped old status drops を cover することを Lean で証明しました。この generated mapped order 上の target scanner `none` から、target 全体の complete order を仮定せずに source-side old status-drop hit obligations を引き戻します。

SCORE は G1/G2/G3/G3.5/G4 監査後に +168 とし、`research/reports/G-aat-quality-surface-01.md` の total を 14402 から 14570 に更新しています。これは `genius-support` cycle であり、genius unlock は主張しません。

## 証明した定理

- `mapResidualEdgeOrder_covers_mappedOldStatusDrops`
- `targetMappedCoveredScannerNone_forces_allMappedOldStatusDropsHit`
- `targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit`
- `targetMappedSourceOrderScannerNone_forces_mappedOldStatusDropHit`
- `residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropsHit`
- `residualCutInducingAtlasMap_mappedSourceOrderScannerNone_forces_oldStatusDropHit`
- `selectedFrontierFlatScanOrder_complete`
- `selectedGeneratedMappedStatusDropScanOrder_eq`
- `selectedGeneratedMapped_firstResidualStatusDrop`
- `selectedGeneratedMapped_targetScannerNone_requires_frontierFlatStatusHit`
- `semanticResidualMappedStatusDropScannerOrder_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-scanner-order.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualMappedStatusDropScannerOrder.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropScannerOrder`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
