### PR TITLE
Cycle 104 unhit status-drop scanner を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -100,3 +100,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropRepairH
 import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualInducedStatusDropScannerHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropScannerOrder
+import Formal.AG.Research.QualitySurface.SemanticResidualUnhitStatusDropScanner

--- a/Formal/AG/Research/QualitySurface/SemanticResidualUnhitStatusDropScanner.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualUnhitStatusDropScanner.lean
@@ -1,0 +1,720 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropScannerOrder
+
+/-!
+Cycle 104 evidence for `G-aat-quality-surface-01`.
+
+This file scans a source finite edge order for an old status drop that is
+untouched at all three repair-hit loci: edge, source index, and target index.
+Such an unhit old status drop maps to a target status drop under a mapped
+status-drop repair transport, giving target canonical nonzero and transition
+obstruction.  Conversely, when a complete source order scanner returns `none`,
+every old status drop is hit.
+
+The result is a finite repair-hit scanner exactness theorem.  It does not
+assert hit sufficiency, repair synthesis, global minimality, target-wide order
+canonicity, vanishing-to-closure, true H1/Cech/coboundary structure, status
+extraction, ArchMap correctness, tooling/runtime/UI correctness, or
+whole-codebase quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualUnhitStatusDropScanner
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasMorphism
+open SemanticResidualAtlasMapLaws
+open SemanticResidualCutRepairHitting
+open SemanticResidualMappedRepairHitting
+open SemanticResidualStatusDropAdapter
+open SemanticResidualStatusDropRepairHitting
+open SemanticResidualMappedStatusDropRepairHitting
+open SemanticResidualStatusDropScanner
+open SemanticResidualInducedStatusDropScannerHitting
+open SemanticResidualMappedStatusDropScannerOrder
+
+/-! ## Source-side unhit status-drop scanner -/
+
+/-- An old status drop that is untouched at all three source-side hit loci. -/
+def UnhitMappedOldStatusDropPair
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    (pair : LeftIndex × LeftIndex) : Prop :=
+  ResidualStatusDropPair oldReading pair /\
+    Not (edgeHit pair) /\
+      Not (sourceHit pair.1) /\
+        Not (targetHit pair.2)
+
+/-- The first old status drop that remains unhit by the repair predicates. -/
+def firstUnhitMappedOldStatusDrop?
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        edgeHit
+        sourceHit
+        targetHit)] :
+    List (LeftIndex × LeftIndex) -> Option (LeftIndex × LeftIndex)
+  | [] => none
+  | pair :: rest =>
+      if UnhitMappedOldStatusDropPair
+          oldReading edgeHit sourceHit targetHit pair then
+        some pair
+      else
+        firstUnhitMappedOldStatusDrop?
+          oldReading edgeHit sourceHit targetHit rest
+
+/-- A returned unhit status-drop pair is in the supplied source order. -/
+theorem firstUnhitMappedOldStatusDrop?_some_mem
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        edgeHit
+        sourceHit
+        targetHit)] :
+    forall {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+      {pair : LeftIndex × LeftIndex},
+      firstUnhitMappedOldStatusDrop?
+        oldReading edgeHit sourceHit targetHit sourceEdgeOrder =
+          some pair ->
+        pair ∈ sourceEdgeOrder
+  | [], _pair, hsome => by
+      cases hsome
+  | head :: rest, pair, hsome => by
+      by_cases hdrop :
+        UnhitMappedOldStatusDropPair
+          oldReading edgeHit sourceHit targetHit head
+      · have hpair : pair = head := by
+          simpa [firstUnhitMappedOldStatusDrop?, hdrop] using hsome.symm
+        subst pair
+        simp
+      · have htail :
+          firstUnhitMappedOldStatusDrop?
+            oldReading edgeHit sourceHit targetHit rest =
+              some pair := by
+          simpa [firstUnhitMappedOldStatusDrop?, hdrop] using hsome
+        exact List.mem_cons_of_mem head
+          (firstUnhitMappedOldStatusDrop?_some_mem
+            oldReading edgeHit sourceHit targetHit htail)
+
+/-- A returned pair is an old status drop with explicit unhit witnesses. -/
+theorem firstUnhitMappedOldStatusDrop?_some_pair
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        edgeHit
+        sourceHit
+        targetHit)] :
+    forall {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+      {pair : LeftIndex × LeftIndex},
+      firstUnhitMappedOldStatusDrop?
+        oldReading edgeHit sourceHit targetHit sourceEdgeOrder =
+          some pair ->
+        UnhitMappedOldStatusDropPair
+          oldReading edgeHit sourceHit targetHit pair
+  | [], _pair, hsome => by
+      cases hsome
+  | head :: rest, pair, hsome => by
+      by_cases hdrop :
+        UnhitMappedOldStatusDropPair
+          oldReading edgeHit sourceHit targetHit head
+      · have hpair : pair = head := by
+          simpa [firstUnhitMappedOldStatusDrop?, hdrop] using hsome.symm
+        subst pair
+        exact hdrop
+      · have htail :
+          firstUnhitMappedOldStatusDrop?
+            oldReading edgeHit sourceHit targetHit rest =
+              some pair := by
+          simpa [firstUnhitMappedOldStatusDrop?, hdrop] using hsome
+        exact firstUnhitMappedOldStatusDrop?_some_pair
+          oldReading edgeHit sourceHit targetHit htail
+
+/-- A returned unhit old status drop maps to a target status drop. -/
+theorem firstUnhitMappedOldStatusDrop?_some_maps_to_newStatusDrop
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit)]
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    {pair : LeftIndex × LeftIndex}
+    (hscan :
+      firstUnhitMappedOldStatusDrop?
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit
+        sourceEdgeOrder =
+          some pair) :
+    ResidualStatusDropPair newReading
+      (mapResidualPair transportMap.mapIndex pair) := by
+  have hpair :
+      UnhitMappedOldStatusDropPair
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit
+        pair :=
+    firstUnhitMappedOldStatusDrop?_some_pair
+      oldReading
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit
+      hscan
+  exact
+    unhit_oldStatusDrop_maps_to_newStatusDrop
+      transportMap
+      hpair.1
+      hpair.2.1
+      hpair.2.2.1
+      hpair.2.2.2
+
+/-- A returned unhit old status drop makes the target canonical class nonzero. -/
+theorem firstUnhitMappedOldStatusDrop?_some_mappedCanonicalNonzero
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit)]
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    {pair : LeftIndex × LeftIndex}
+    (hscan :
+      firstUnhitMappedOldStatusDrop?
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit
+        sourceEdgeOrder =
+          some pair) :
+    (canonicalResidualCutCochain new).CutNonzero := by
+  have htarget :
+      ResidualStatusDropPair newReading
+        (mapResidualPair transportMap.mapIndex pair) :=
+    firstUnhitMappedOldStatusDrop?_some_maps_to_newStatusDrop
+      transportMap
+      hscan
+  exact
+    (canonicalResidualCutClass_nonzero_iff_existsStatusDrop
+      newReading).mpr
+      ⟨mapResidualPair transportMap.mapIndex pair,
+        htarget.1,
+        htarget.2.1,
+        htarget.2.2⟩
+
+/-- A returned unhit old status drop obstructs target transition closure. -/
+theorem firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionClosure
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit)]
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    {pair : LeftIndex × LeftIndex}
+    (hscan :
+      firstUnhitMappedOldStatusDrop?
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit
+        sourceEdgeOrder =
+          some pair)
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (AtlasResidualTransitionClosed new transition) := by
+  exact
+    residualCutClass_nonzero_obstructs_atlasTransitionClosure
+      (canonicalResidualCutCochain new)
+      (firstUnhitMappedOldStatusDrop?_some_mappedCanonicalNonzero
+        transportMap
+        hscan)
+      transition
+
+/-- A returned unhit old status drop rules out target coherent data. -/
+theorem firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionCoherentData
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit)]
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    {pair : LeftIndex × LeftIndex}
+    (hscan :
+      firstUnhitMappedOldStatusDrop?
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit
+        sourceEdgeOrder =
+          some pair)
+    (transition : RightIndex -> RightIndex -> RightAtom -> RightAtom) :
+    Not (Nonempty (TransitionCoherentAtlasData new transition)) := by
+  exact
+    residualCutClass_nonzero_obstructs_transitionCoherentData
+      (canonicalResidualCutCochain new)
+      (firstUnhitMappedOldStatusDrop?_some_mappedCanonicalNonzero
+        transportMap
+        hscan)
+      transition
+
+/-! ## None exactness for repair hitting -/
+
+/-- No listed source pair is an unhit old status drop. -/
+def ListedUnhitMappedOldStatusDropsClear
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    (sourceEdgeOrder : List (LeftIndex × LeftIndex)) : Prop :=
+  forall pair,
+    pair ∈ sourceEdgeOrder ->
+      Not
+        (UnhitMappedOldStatusDropPair
+          oldReading edgeHit sourceHit targetHit pair)
+
+/-- The source unhit-status scanner returns `none` iff all listed pairs are clear. -/
+theorem firstUnhitMappedOldStatusDrop?_none_iff_listedClear
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    (oldReading : ResidualBooleanStatusReading old)
+    (edgeHit : LeftIndex × LeftIndex -> Prop)
+    (sourceHit targetHit : LeftIndex -> Prop)
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        edgeHit
+        sourceHit
+        targetHit)] :
+    forall sourceEdgeOrder,
+      firstUnhitMappedOldStatusDrop?
+        oldReading edgeHit sourceHit targetHit sourceEdgeOrder = none <->
+        ListedUnhitMappedOldStatusDropsClear
+          oldReading edgeHit sourceHit targetHit sourceEdgeOrder
+  | [] => by
+      constructor
+      · intro _ pair hmem _hunhit
+        cases hmem
+      · intro _
+        rfl
+  | head :: rest => by
+      constructor
+      · intro hnone pair hmem hunhitPair
+        by_cases hdrop :
+          UnhitMappedOldStatusDropPair
+            oldReading edgeHit sourceHit targetHit head
+        · have hsome :
+            firstUnhitMappedOldStatusDrop?
+              oldReading edgeHit sourceHit targetHit (head :: rest) =
+                some head := by
+            simp [firstUnhitMappedOldStatusDrop?, hdrop]
+          rw [hsome] at hnone
+          cases hnone
+        · have htail :
+            firstUnhitMappedOldStatusDrop?
+              oldReading edgeHit sourceHit targetHit rest = none := by
+            simpa [firstUnhitMappedOldStatusDrop?, hdrop] using hnone
+          cases hmem with
+          | head =>
+              exact hdrop hunhitPair
+          | tail _ hlisted =>
+              exact
+                ((firstUnhitMappedOldStatusDrop?_none_iff_listedClear
+                  oldReading edgeHit sourceHit targetHit rest).mp htail)
+                  pair
+                  hlisted
+                  hunhitPair
+      · intro hclear
+        by_cases hdrop :
+          UnhitMappedOldStatusDropPair
+            oldReading edgeHit sourceHit targetHit head
+        · have hnot :
+            Not
+              (UnhitMappedOldStatusDropPair
+                oldReading edgeHit sourceHit targetHit head) :=
+            hclear head (by simp)
+          exact False.elim (hnot hdrop)
+        · have hrestClear :
+            ListedUnhitMappedOldStatusDropsClear
+              oldReading edgeHit sourceHit targetHit rest := by
+            intro pair hmem hunhitPair
+            exact hclear pair (by simp [hmem]) hunhitPair
+          have htailNone :
+            firstUnhitMappedOldStatusDrop?
+              oldReading edgeHit sourceHit targetHit rest = none :=
+            (firstUnhitMappedOldStatusDrop?_none_iff_listedClear
+              oldReading edgeHit sourceHit targetHit rest).mpr hrestClear
+          simp [firstUnhitMappedOldStatusDrop?, hdrop, htailNone]
+
+/--
+On a complete source edge order, scanner `none` is exact for all old status
+drops being hit.
+-/
+theorem firstUnhitMappedOldStatusDrop?_none_iff_allMappedOldStatusDropsHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {edgeHit : LeftIndex × LeftIndex -> Prop}
+    {sourceHit targetHit : LeftIndex -> Prop}
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        edgeHit
+        sourceHit
+        targetHit)]
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    (hcomplete : ListedAtlasEdgesComplete old sourceEdgeOrder) :
+    firstUnhitMappedOldStatusDrop?
+      oldReading edgeHit sourceHit targetHit sourceEdgeOrder = none <->
+      AllMappedOldStatusDropsHit oldReading edgeHit sourceHit targetHit := by
+  constructor
+  · intro hnone pair hdrop hunhit
+    have hclear :
+        ListedUnhitMappedOldStatusDropsClear
+          oldReading edgeHit sourceHit targetHit sourceEdgeOrder :=
+      (firstUnhitMappedOldStatusDrop?_none_iff_listedClear
+        oldReading edgeHit sourceHit targetHit sourceEdgeOrder).mp hnone
+    exact hclear
+      pair
+      (hcomplete pair.1 pair.2 hdrop.1)
+      ⟨hdrop, hunhit⟩
+  · intro hall
+    exact
+      (firstUnhitMappedOldStatusDrop?_none_iff_listedClear
+        oldReading edgeHit sourceHit targetHit sourceEdgeOrder).mpr
+      (by
+        intro pair _hmem hunhitPair
+        exact (hall pair hunhitPair.1) hunhitPair.2)
+
+/-! ## Selected no-hit witness -/
+
+/-- The selected no-hit unhit-status predicate is decidable without choice. -/
+instance selectedUnhitMappedOldStatusDropPairDecidable :
+    DecidablePred
+      (UnhitMappedOldStatusDropPair
+        selectedFrontierFlatResidualStatusReading
+        selectedNoEdgeHit
+        selectedNoSourceHit
+        selectedNoTargetHit) := by
+  intro pair
+  cases pair with
+  | mk source target =>
+      cases source <;> cases target <;>
+        simp [UnhitMappedOldStatusDropPair,
+          ResidualStatusDropPair,
+          selectedFrontierFlatResidualStatusReading,
+          selectedFrontierFlatResidualStatus,
+          selectedFrontierFlatAtlasSkeleton,
+          selectedFrontierToFlatEdge,
+          selectedNoEdgeHit,
+          selectedNoSourceHit,
+          selectedNoTargetHit]
+        <;> infer_instance
+
+/--
+The selected-to-extended no-hit transport map unfolds to the selected no-hit
+predicates, so it has the same decidability instance.
+-/
+instance selectedToExtendedNoHitUnhitMappedOldStatusDropPairDecidable :
+    DecidablePred
+      (UnhitMappedOldStatusDropPair
+        selectedFrontierFlatResidualStatusReading
+        selectedToExtendedNoHitStatusDropRepairTransportMap.edgeHit
+        selectedToExtendedNoHitStatusDropRepairTransportMap.sourceHit
+        selectedToExtendedNoHitStatusDropRepairTransportMap.targetHit) := by
+  dsimp [selectedToExtendedNoHitStatusDropRepairTransportMap,
+    residualCutInducingAtlasMap_to_statusDropRepairTransportMap]
+  infer_instance
+
+/-- The selected source scanner finds the unhit frontier-to-flat status drop. -/
+theorem selected_firstUnhitMappedOldStatusDrop :
+    firstUnhitMappedOldStatusDrop?
+      selectedFrontierFlatResidualStatusReading
+      selectedNoEdgeHit
+      selectedNoSourceHit
+      selectedNoTargetHit
+      selectedFrontierFlatScanOrder =
+        some selectedFrontierFlatResidualCutPair := by
+  simp [selectedFrontierFlatScanOrder,
+    firstUnhitMappedOldStatusDrop?,
+    UnhitMappedOldStatusDropPair,
+    ResidualStatusDropPair,
+    selectedFrontierFlatResidualStatusReading,
+    selectedFrontierFlatResidualStatus,
+    selectedFrontierFlatAtlasSkeleton,
+    selectedFrontierToFlatEdge,
+    selectedNoEdgeHit,
+    selectedNoSourceHit,
+    selectedNoTargetHit,
+    selectedFrontierFlatResidualCutPair]
+
+/-- The selected unhit scanner hit maps to an extended target status drop. -/
+theorem selected_firstUnhitMappedOldStatusDrop_maps_to_extendedStatusDrop :
+    ResidualStatusDropPair
+      selectedExtendedFrontierFlatResidualStatusReading
+      (mapResidualPair
+        selectedToExtendedNoHitStatusDropRepairTransportMap.mapIndex
+        selectedFrontierFlatResidualCutPair) := by
+  exact
+    firstUnhitMappedOldStatusDrop?_some_maps_to_newStatusDrop
+      selectedToExtendedNoHitStatusDropRepairTransportMap
+      selected_firstUnhitMappedOldStatusDrop
+
+/-- The selected unhit scanner hit makes the extended target class nonzero. -/
+theorem selected_firstUnhitMappedOldStatusDrop_mappedCanonicalNonzero :
+    (canonicalResidualCutCochain
+      selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    firstUnhitMappedOldStatusDrop?_some_mappedCanonicalNonzero
+      selectedToExtendedNoHitStatusDropRepairTransportMap
+      selected_firstUnhitMappedOldStatusDrop
+
+/-- The selected unhit scanner hit obstructs extended target transition closure. -/
+theorem selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionClosure
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (AtlasResidualTransitionClosed
+        selectedExtendedFrontierFlatAtlasSkeleton
+        transition) := by
+  exact
+    firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionClosure
+      selectedToExtendedNoHitStatusDropRepairTransportMap
+      selected_firstUnhitMappedOldStatusDrop
+      transition
+
+/-- The selected unhit scanner hit rules out extended target coherent data. -/
+theorem selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionCoherentData
+    (transition :
+      SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+        RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom) :
+    Not
+      (Nonempty
+        (TransitionCoherentAtlasData
+          selectedExtendedFrontierFlatAtlasSkeleton
+          transition)) := by
+  exact
+    firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionCoherentData
+      selectedToExtendedNoHitStatusDropRepairTransportMap
+      selected_firstUnhitMappedOldStatusDrop
+      transition
+
+/-- On the selected complete order, scanner `none` is equivalent to all hits. -/
+theorem selected_firstUnhitMappedOldStatusDrop_none_iff_allHits :
+    firstUnhitMappedOldStatusDrop?
+      selectedFrontierFlatResidualStatusReading
+      selectedNoEdgeHit
+      selectedNoSourceHit
+      selectedNoTargetHit
+      selectedFrontierFlatScanOrder = none <->
+      AllMappedOldStatusDropsHit
+        selectedFrontierFlatResidualStatusReading
+        selectedNoEdgeHit
+        selectedNoSourceHit
+        selectedNoTargetHit := by
+  exact
+    firstUnhitMappedOldStatusDrop?_none_iff_allMappedOldStatusDropsHit
+      selectedFrontierFlatScanOrder_complete
+
+/-! ## Theorem package -/
+
+/--
+Cycle-104 theorem package: source-side unhit status-drop scanning is exact for
+repair-hit obligations and maps scanner hits into target obstruction.
+-/
+theorem semanticResidualUnhitStatusDropScanner_package :
+    (forall {LeftIndex : Type w}
+      {LeftAtom : Type u}
+      {RightIndex : Type x}
+      {RightAtom : Type v}
+      {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+      {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+      {oldReading : ResidualBooleanStatusReading old}
+      {newReading : ResidualBooleanStatusReading new},
+      forall transportMap :
+        ResidualStatusDropRepairTransportMap oldReading newReading,
+      forall
+        [_inst :
+          DecidablePred
+            (UnhitMappedOldStatusDropPair
+              oldReading
+              transportMap.edgeHit
+              transportMap.sourceHit
+              transportMap.targetHit)],
+      forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+      forall pair : LeftIndex × LeftIndex,
+        firstUnhitMappedOldStatusDrop?
+          oldReading
+          transportMap.edgeHit
+          transportMap.sourceHit
+          transportMap.targetHit
+          sourceEdgeOrder =
+            some pair ->
+          ResidualStatusDropPair newReading
+            (mapResidualPair transportMap.mapIndex pair)) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {edgeHit : LeftIndex × LeftIndex -> Prop}
+        {sourceHit targetHit : LeftIndex -> Prop},
+        forall
+          [_inst :
+            DecidablePred
+              (UnhitMappedOldStatusDropPair
+                oldReading
+                edgeHit
+                sourceHit
+                targetHit)],
+        forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+          ListedAtlasEdgesComplete old sourceEdgeOrder ->
+            (firstUnhitMappedOldStatusDrop?
+              oldReading edgeHit sourceHit targetHit sourceEdgeOrder =
+                none <->
+              AllMappedOldStatusDropsHit
+                oldReading edgeHit sourceHit targetHit)) /\
+      firstUnhitMappedOldStatusDrop?
+        selectedFrontierFlatResidualStatusReading
+        selectedNoEdgeHit
+        selectedNoSourceHit
+        selectedNoTargetHit
+        selectedFrontierFlatScanOrder =
+          some selectedFrontierFlatResidualCutPair /\
+      ResidualStatusDropPair
+        selectedExtendedFrontierFlatResidualStatusReading
+        (mapResidualPair
+          selectedToExtendedNoHitStatusDropRepairTransportMap.mapIndex
+          selectedFrontierFlatResidualCutPair) /\
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (AtlasResidualTransitionClosed
+            selectedExtendedFrontierFlatAtlasSkeleton
+            transition)) /\
+      (forall
+        transition :
+          SelectedExtendedOverlapIndex -> SelectedExtendedOverlapIndex ->
+            RefinedSemanticRepairAtom -> RefinedSemanticRepairAtom,
+        Not
+          (Nonempty
+            (TransitionCoherentAtlasData
+              selectedExtendedFrontierFlatAtlasSkeleton
+              transition))) /\
+      (firstUnhitMappedOldStatusDrop?
+        selectedFrontierFlatResidualStatusReading
+        selectedNoEdgeHit
+        selectedNoSourceHit
+        selectedNoTargetHit
+        selectedFrontierFlatScanOrder = none <->
+        AllMappedOldStatusDropsHit
+          selectedFrontierFlatResidualStatusReading
+          selectedNoEdgeHit
+          selectedNoSourceHit
+          selectedNoTargetHit) := by
+  exact
+    ⟨fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading}
+        transportMap _inst sourceEdgeOrder pair hscan =>
+        firstUnhitMappedOldStatusDrop?_some_maps_to_newStatusDrop
+          transportMap
+          hscan,
+      fun {_LeftIndex} {_LeftAtom} {_old} {_oldReading}
+        {_edgeHit} {_sourceHit} {_targetHit} _inst sourceEdgeOrder
+        hcomplete =>
+        firstUnhitMappedOldStatusDrop?_none_iff_allMappedOldStatusDropsHit
+          hcomplete,
+      selected_firstUnhitMappedOldStatusDrop,
+      selected_firstUnhitMappedOldStatusDrop_maps_to_extendedStatusDrop,
+      selected_firstUnhitMappedOldStatusDrop_mappedCanonicalNonzero,
+      selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionClosure,
+      selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionCoherentData,
+      selected_firstUnhitMappedOldStatusDrop_none_iff_allHits⟩
+
+end SemanticResidualUnhitStatusDropScanner
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-unhit-status-drop-scanner.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-unhit-status-drop-scanner.md
@@ -1,0 +1,148 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: repair-hit scanner exactness / unhit source obstruction detection / genius-support convergence
+candidate_type: unhit status-drop repair scanner theorem / mapped target obstruction certificate / all-hit exactness
+capability_category: semantic-obstruction / status-drop-scanner / repair-hit-exactness / mapped-target-obstruction / genius-support
+expected_base_score: 88
+expected_evidence_multiplier: 2.0
+expected_final_score: 176
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can list status drops or repair touches, but they do not prove that a finite source scanner is exact for all-hit repair obligations and that scanner hits map to target obstruction.
+origin: cycle-104
+tags: [quality-surface, semantic-repair, residual-cut, status-drop, scanner, repair-hitting, mapped-obstruction, genius-support]
+created: 2026-06-23
+cycle: 104
+lean: proved-in-research
+planned_report_section: "Cycle 104: Source unhit status-drop scanner exactness"
+---
+
+# Source Unhit Status-Drop Scanner Exactness
+
+## 主張
+
+source finite edge order 上で、old status drop かつ edge/source/target の三つの repair-hit loci がすべて
+unhit である pair を scan する。
+
+scanner が `some pair` を返すなら、その pair は explicit unhit old status drop であり、
+mapped status-drop repair transport の下で target status drop、target canonical nonzero、transition closure /
+transition-coherent data obstruction を与える。
+
+complete source edge order 上で scanner が `none` を返すなら、すべての old status drops は
+`ResidualCutHit` を満たす。逆に all-hit なら scanner は `none` である。
+
+これは finite source-order-relative な repair-hit exactness であり、hit sufficiency、repair synthesis、
+global minimality、target-wide order canonicity、vanishing-to-closure、true `H^1` / Cech / coboundary quotient、
+status extraction、ArchMap/tooling correctness、runtime/UI correctness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`unhit status-drop repair scanner theorem` / `mapped target obstruction certificate` / `all-hit exactness`
+
+## 依拠
+
+- Cycle 100: mapped status-drop repair-hitting transport。
+- Cycle 101: finite status-drop scanner exactness。
+- Cycle 103: generated mapped source-order scanner surface。
+
+## 非自明性
+
+この cycle は target scanner `none` の説明責務ではなく、source 側で repair-hit obligation の未解消 witness を直接 scan する。
+`some` は target obstruction certificate へ map され、`none` は complete source order に相対化して all-hit と同値になる。
+
+## 数学的興味
+
+repair-hit necessity を有限探索可能な exact scanner として切り出す。
+これは semantic repair-gluing obstruction theorem に向けて、未 hit の old status drop を target obstruction として抽出し、
+未検出なら all-hit obligation が成立する、という computational obstruction/explanation layer である。
+
+## GOAL への前進
+
+source certificate geometry 上で repair-hit obligations の failure witness を scan し、それを target obstruction へ transport できる。
+quality surface の「green claim」に対し、未 hit witness の存在 / all-hit の二分を Lean theorem として与えた。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は status drop や repair touch を列挙できる。
+しかし、source-complete finite scanner の `none` が all-hit と同値であり、`some` が mapped target obstruction を与えることを証明しない。
+
+## SCORE 見込み
+
+- `score_reason`: repair-hit obligation を直接 finite scanner exactness にし、some/none の両側を target obstruction / all-hit に接続した。
+- `dullness_risk`: scanner pattern の再利用に見える危険はある。unhit triple predicate、mapped target obstruction、all-hit exactness を一つの package にまとめて補強した。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualUnhitStatusDropScanner.lean` で source unhit scanner exactness と selected witness を証明する。
+
+## CS / SWE への帰結
+
+repair が説明すべき old status drops を finite order で scan し、未 hit なら target obstruction を具体化する。
+未検出なら all-hit obligation が成立するため、repair audit の green claim と red witness を同じ scanner surface で扱える。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualUnhitStatusDropScanner.lean` に固定した。
+
+- `UnhitMappedOldStatusDropPair`
+- `firstUnhitMappedOldStatusDrop?`
+- `firstUnhitMappedOldStatusDrop?_some_mem`
+- `firstUnhitMappedOldStatusDrop?_some_pair`
+- `firstUnhitMappedOldStatusDrop?_some_maps_to_newStatusDrop`
+- `firstUnhitMappedOldStatusDrop?_some_mappedCanonicalNonzero`
+- `firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionClosure`
+- `firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionCoherentData`
+- `ListedUnhitMappedOldStatusDropsClear`
+- `firstUnhitMappedOldStatusDrop?_none_iff_listedClear`
+- `firstUnhitMappedOldStatusDrop?_none_iff_allMappedOldStatusDropsHit`
+- `selectedUnhitMappedOldStatusDropPairDecidable`
+- `selected_firstUnhitMappedOldStatusDrop`
+- `selected_firstUnhitMappedOldStatusDrop_maps_to_extendedStatusDrop`
+- `selected_firstUnhitMappedOldStatusDrop_mappedCanonicalNonzero`
+- `selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionClosure`
+- `selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionCoherentData`
+- `selected_firstUnhitMappedOldStatusDrop_none_iff_allHits`
+- `semanticResidualUnhitStatusDropScanner_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualUnhitStatusDropScanner.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualUnhitStatusDropScanner`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: generic theorem family は標準 `propext` のみ。selected witness と package は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、finite source edge order、explicit unhit triple predicate、mapped transport、scanner some-to-target-obstruction、
+complete source order scanner none-to-all-hit exactness に限定する。
+unchecked: hit sufficiency、repair synthesis、global minimality、target-wide order canonicity、vanishing-to-closure、
+true H1/cohomology、Cech quotient、coboundary quotient、status extraction、ArchMap correctness、runtime/UI correctness、
+whole-codebase quality、arbitrary atlas category/functoriality。
+
+## 審判メモ
+
+- G1: accept。repair-hit obligation そのものを source 側で scan し、`some` を mapped target obstruction、`none` を complete source order 下の all-hit に接続する実用的前進として base 88 / final +176 を推奨。
+- G2: accept。rival は status drop と repair touch を列挙できても、`some` to mapped target obstruction certificate と `none iff all-hit` を同じ theorem surface として持たない。score range +172 to +176、提案 +176 は妥当。
+- strong genius-support。genius unlock ではなく、finite semantic repair-gluing obstruction theorem へ向けた support-cycle。
+
+## 追加 required fields
+
+- `mathematical_interest`: repair-hit obligation を finite scanner exactness と target obstruction transport に分解する。
+- `goal_advancement`: quality surface の unhit witness / all-hit explanation を同じ Lean scanner で扱える。
+- `planned_theorem_names`: `firstUnhitMappedOldStatusDrop?_none_iff_allMappedOldStatusDropsHit`, `firstUnhitMappedOldStatusDrop?_some_mappedCanonicalNonzero`, `semanticResidualUnhitStatusDropScanner_package`
+- `visible_projection`: source edge order、unhit repair loci、scanner some/none、mapped target obstruction。
+- `protected_structure`: explicit unhit triple、status-drop predicate、mapped transport preservation、all-hit exactness。
+- `exactness_or_minimality_claim`: complete source order に相対化した some/none exactness。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: scanner none without complete source order does not certify all-hit。
+- `previous_cycle_delta`: Cycle 103 の generated mapped order surface から、source-side unhit repair witness scanner へ進めた。
+- `rival_stress_test`: rival は repair touches を表示できても scanner none iff all-hit と some-to-target-obstruction を theorem として出さない。
+- `genius_potential`: strong support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の repair-hit scanner layer。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: unhit repair witness と all-hit explanation を finite scanner exactness として提供する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-status-drop-scanner.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-scanner-order.md`
+- planned report section: `Cycle 104: Source unhit status-drop scanner exactness`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 104 candidate として source unhit status-drop scanner exactness を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualUnhitStatusDropScanner.lean` に固定し、単体
+  `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 14570
+- total SCORE: 14746
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -108,8 +108,9 @@
   - semantic-obstruction / status-drop-scanner / computability / repair-necessity / genius-support: 176
   - semantic-obstruction / status-drop-scanner / atlas-map-induced / repair-necessity / genius-support: 172
   - semantic-obstruction / status-drop-scanner / generated-mapped-order / repair-necessity / genius-support: 168
+  - semantic-obstruction / status-drop-scanner / repair-hit-exactness / mapped-target-obstruction / genius-support: 176
 - evidence portfolio:
-  - proved-in-research: 103
+  - proved-in-research: 104
 
 ## Phase synthesis
 
@@ -125,7 +126,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-103 件の Lean-proved research artifacts は、次の paper seed を形成している。
+104 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -157,6 +158,7 @@ certificate の基本単位は
 - semantic residual status-drop scanner は、complete supplied edge order 上の finite scanner `none` が no-drop/canonical vanishing と同値であり、target scanner `none` が old/mapped old status-drop hit necessity を強制することを示す。
 - semantic residual induced status-drop scanner hitting は、ResidualCutInducingAtlasMap と complete target scanner `none` から source-side old status-drop hit obligation を直接読む bridge を与える。
 - semantic residual mapped status-drop scanner order は、source-complete edge order の map image 上の target scanner `none` だけで mapped old status-drop hit obligation を読めることを示す。
+- semantic residual unhit status-drop scanner は、source order 上の unhit old status drop scanner が some なら mapped target obstruction を、complete order 上の none なら all-hit exactness を与えることを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -220,8 +222,9 @@ Cycle 100 後の total SCORE は 14054 であり、tracking Issue active thresho
 Cycle 101 後の total SCORE は 14230 であり、tracking Issue active threshold 15000 までは残り 770 SCORE である。
 Cycle 102 後の total SCORE は 14402 であり、tracking Issue active threshold 15000 までは残り 598 SCORE である。
 Cycle 103 後の total SCORE は 14570 であり、tracking Issue active threshold 15000 までは残り 430 SCORE である。
+Cycle 104 後の total SCORE は 14746 であり、tracking Issue active threshold 15000 までは残り 254 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 103 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 104 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -257,7 +260,8 @@ semantic residual status-drop repair-hitting theorem、
 semantic residual mapped status-drop repair-hitting theorem、
 semantic residual status-drop scanner theorem、
 semantic residual induced status-drop scanner hitting theorem、
-semantic residual mapped status-drop scanner order theorem を含む。
+semantic residual mapped status-drop scanner order theorem、
+semantic residual unhit status-drop scanner theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5673,4 +5677,81 @@ whole-codebase quality, or arbitrary atlas category/functoriality.
 
 Cycle 103 後の total SCORE は 14570 であり、tracking Issue active threshold 15000 までは残り 430 SCORE である。
 次 cycle では、target nonempty contradiction from scanner none、finite pre-H1 support without cohomology overclaim、generated mapped order coverage for richer subfamilies、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 104: Source unhit status-drop scanner exactness
+
+```text
+candidate: Source unhit status-drop scanner exactness
+candidate_type: unhit status-drop repair scanner theorem / mapped target obstruction certificate / all-hit exactness
+evidence_stage: proved-in-research
+base_score: 88
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 176
+category: semantic-obstruction / status-drop-scanner / repair-hit-exactness / mapped-target-obstruction / genius-support
+goal_delta: repair-hit obligation の未解消 witness を source order 上で直接 scan し、some なら mapped target obstruction、complete source order 上の none なら all-hit exactness を得た。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、unhit old status-drop scanner、some-to-target-obstruction theorem、none-iff-all-hit theorem、selected no-hit witness、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は status drops や repair touches を列挙できても、finite scanner none iff all-hit と scanner hit to mapped target obstruction を Lean theorem として保証できない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualUnhitStatusDropScanner.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualUnhitStatusDropScanner`, and `lake build FormalAGResearch` passed. Axiom probe reported generic theorem family uses standard `propext` only; selected witness and package use standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: finite pre-H1 support without cohomology overclaim; scanner-derived local-pass/global-fail split; repair-hit minimality under source orders; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualUnhitStatusDropScanner.lean`
+adds a finite source-side scanner for old status drops that remain untouched at
+the edge, source-index, and target-index repair-hit loci.  The scanner returns
+the first such explicit unhit old status drop in a supplied source edge order.
+
+A scanner `some` result is a computational red witness.  Under any mapped
+status-drop repair transport, Lean proves that the returned old unhit pair maps
+to a target status drop, makes the target canonical residual cut class nonzero,
+obstructs target transition closure, and rules out transition-coherent target
+data.
+
+A scanner `none` result is a computational green explanation when the supplied
+source order is complete.  Lean proves that `none` is equivalent to
+`AllMappedOldStatusDropsHit`: every old status drop is hit at the edge, source
+index, or target index locus.  This exactness is source-order-relative; no
+repair sufficiency or global minimality is claimed.
+
+The selected no-hit witness shows the frontier-to-flat unhit status drop is
+found by the scanner, maps to the extended target status drop, remains
+canonical nonzero, and obstructs extended transition closure / coherent data.
+It also proves the selected complete-order `none iff all-hit` theorem.
+
+Lean proves:
+
+- `UnhitMappedOldStatusDropPair`: explicit old status drop with edge/source/target misses.
+- `firstUnhitMappedOldStatusDrop?`: source-side unhit status-drop scanner.
+- `firstUnhitMappedOldStatusDrop?_some_mem`: returned pair is listed.
+- `firstUnhitMappedOldStatusDrop?_some_pair`: returned pair is an explicit unhit old status drop.
+- `firstUnhitMappedOldStatusDrop?_some_maps_to_newStatusDrop`: scanner hit maps to a target status drop.
+- `firstUnhitMappedOldStatusDrop?_some_mappedCanonicalNonzero`: scanner hit gives target canonical nonzero.
+- `firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionClosure`: scanner hit obstructs target closure.
+- `firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionCoherentData`: scanner hit rules out target coherent data.
+- `firstUnhitMappedOldStatusDrop?_none_iff_listedClear`: scanner `none` iff listed unhit pairs are clear.
+- `firstUnhitMappedOldStatusDrop?_none_iff_allMappedOldStatusDropsHit`: complete source order `none` iff all old status drops are hit.
+- `selected_firstUnhitMappedOldStatusDrop`: selected scanner finds the frontier-to-flat unhit drop.
+- `selected_firstUnhitMappedOldStatusDrop_maps_to_extendedStatusDrop`: selected hit maps to extended target drop.
+- `selected_firstUnhitMappedOldStatusDrop_mappedCanonicalNonzero`: selected hit gives extended canonical nonzero.
+- `selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionClosure`: selected hit obstructs extended closure.
+- `selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionCoherentData`: selected hit rules out extended coherent data.
+- `selected_firstUnhitMappedOldStatusDrop_none_iff_allHits`: selected complete source order `none` iff all hits.
+- `semanticResidualUnhitStatusDropScanner_package`: theorem package.
+
+This cycle is a strong `genius-support` bridge, not a `genius unlock`.  It
+turns repair-hit necessity into an exact finite scanner whose `some` side
+produces mapped target obstruction and whose `none` side certifies all-hit
+repair explanation.  It does not prove hit sufficiency, repair synthesis,
+global minimality, target-wide order canonicity, vanishing-to-closure, true
+`H^1` / Cech / coboundary quotient, status extraction, ArchMap correctness,
+runtime repair synthesis, tooling runtime extraction, UI correctness,
+whole-codebase quality, or arbitrary atlas category/functoriality.
+
+### Next Frontier
+
+Cycle 104 後の total SCORE は 14746 であり、tracking Issue active threshold 15000 までは残り 254 SCORE である。
+次 cycle では、finite pre-H1 support without cohomology overclaim、scanner-derived local-pass/global-fail split、repair-hit minimality under source orders、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 104 として、source order 上で explicit unhit old status drop を scan する finite repair-hit scanner exactness を追加しました。scanner `some` は mapped target status drop / canonical nonzero / transition closure and coherent-data obstruction を与え、complete source order 上の scanner `none` は `AllMappedOldStatusDropsHit` と同値です。

SCORE は G1/G2/G3/G3.5/G4 監査後に +176 とし、`research/reports/G-aat-quality-surface-01.md` の total を 14570 から 14746 に更新しています。これは strong `genius-support` cycle であり、genius unlock は主張しません。

## 証明した定理

- `firstUnhitMappedOldStatusDrop?_some_maps_to_newStatusDrop`
- `firstUnhitMappedOldStatusDrop?_some_mappedCanonicalNonzero`
- `firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionClosure`
- `firstUnhitMappedOldStatusDrop?_some_obstructs_mappedTransitionCoherentData`
- `firstUnhitMappedOldStatusDrop?_none_iff_listedClear`
- `firstUnhitMappedOldStatusDrop?_none_iff_allMappedOldStatusDropsHit`
- `selected_firstUnhitMappedOldStatusDrop`
- `selected_firstUnhitMappedOldStatusDrop_maps_to_extendedStatusDrop`
- `selected_firstUnhitMappedOldStatusDrop_mappedCanonicalNonzero`
- `selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionClosure`
- `selected_firstUnhitMappedOldStatusDrop_obstructs_extendedTransitionCoherentData`
- `selected_firstUnhitMappedOldStatusDrop_none_iff_allHits`
- `semanticResidualUnhitStatusDropScanner_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-unhit-status-drop-scanner.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualUnhitStatusDropScanner.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualUnhitStatusDropScanner`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
