### PR TITLE
Cycle 105 unhit to target scanner bridge を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -101,3 +101,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualStatusDropScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualInducedStatusDropScannerHitting
 import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropScannerOrder
 import Formal.AG.Research.QualitySurface.SemanticResidualUnhitStatusDropScanner
+import Formal.AG.Research.QualitySurface.SemanticResidualUnhitToTargetScannerBridge

--- a/Formal/AG/Research/QualitySurface/SemanticResidualUnhitToTargetScannerBridge.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualUnhitToTargetScannerBridge.lean
@@ -1,0 +1,380 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualUnhitStatusDropScanner
+
+/-!
+Cycle 105 evidence for `G-aat-quality-surface-01`.
+
+This file connects the source-side unhit status-drop scanner to the generated
+mapped target status-drop scanner.  If the source scanner finds an explicit
+unhit old status drop, the generated mapped target scanner cannot return
+`none`; equivalently, it has a target scanner hit.  Conversely, target scanner
+`none` on the generated mapped source order forces source unhit scanner `none`
+on a complete source order.
+
+The result is an alarm bridge, not a repair synthesis theorem.  It does not
+assert target-wide order completeness, hit sufficiency, global minimality,
+vanishing-to-closure, true H1/Cech/coboundary structure, ArchMap correctness,
+tooling/runtime/UI correctness, or whole-codebase quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualUnhitToTargetScannerBridge
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasMorphism
+open SemanticResidualAtlasMapLaws
+open SemanticResidualCutRepairHitting
+open SemanticResidualMappedRepairHitting
+open SemanticResidualStatusDropAdapter
+open SemanticResidualStatusDropRepairHitting
+open SemanticResidualMappedStatusDropRepairHitting
+open SemanticResidualStatusDropScanner
+open SemanticResidualInducedStatusDropScannerHitting
+open SemanticResidualMappedStatusDropScannerOrder
+open SemanticResidualUnhitStatusDropScanner
+
+/-! ## Source unhit scanner to generated target scanner -/
+
+/--
+If the source unhit scanner returns a witness, the generated mapped target
+scanner cannot be `none`.
+-/
+theorem sourceUnhitScannerSome_forces_mappedTargetScannerNotNone
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit)]
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    (hcomplete : ListedAtlasEdgesComplete old sourceEdgeOrder)
+    {pair : LeftIndex × LeftIndex}
+    (hsource :
+      firstUnhitMappedOldStatusDrop?
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit
+        sourceEdgeOrder =
+          some pair) :
+    Not
+      (firstResidualStatusDrop?
+        newReading
+        (mapResidualEdgeOrder transportMap.mapIndex sourceEdgeOrder) =
+          none) := by
+  intro htargetNone
+  have hall :
+      AllMappedOldStatusDropsHit
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit :=
+    targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit
+      transportMap
+      hcomplete
+      htargetNone
+  have hunhit :
+      UnhitMappedOldStatusDropPair
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit
+        pair :=
+    firstUnhitMappedOldStatusDrop?_some_pair
+      oldReading
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit
+      hsource
+  exact (hall pair hunhit.1) hunhit.2
+
+/--
+A source unhit scanner witness gives an actual hit of the generated mapped
+target status-drop scanner.
+-/
+theorem sourceUnhitScannerSome_gives_mappedTargetScannerHit
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit)]
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    (hcomplete : ListedAtlasEdgesComplete old sourceEdgeOrder)
+    {pair : LeftIndex × LeftIndex}
+    (hsource :
+      firstUnhitMappedOldStatusDrop?
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit
+        sourceEdgeOrder =
+          some pair) :
+    Exists fun targetPair =>
+      firstResidualStatusDrop?
+        newReading
+        (mapResidualEdgeOrder transportMap.mapIndex sourceEdgeOrder) =
+          some targetPair := by
+  have hnotNone :
+      Not
+        (firstResidualStatusDrop?
+          newReading
+          (mapResidualEdgeOrder transportMap.mapIndex sourceEdgeOrder) =
+            none) :=
+    sourceUnhitScannerSome_forces_mappedTargetScannerNotNone
+      transportMap
+      hcomplete
+      hsource
+  cases hscan :
+    firstResidualStatusDrop?
+      newReading
+      (mapResidualEdgeOrder transportMap.mapIndex sourceEdgeOrder) with
+  | none =>
+      exact False.elim (hnotNone hscan)
+  | some targetPair =>
+      exact ⟨targetPair, rfl⟩
+
+/--
+Generated mapped target scanner `none` forces the source unhit scanner to
+return `none` on a complete source order.
+-/
+theorem mappedTargetScannerNone_forces_sourceUnhitScannerNone
+    {LeftIndex : Type w}
+    {LeftAtom : Type u}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {oldReading : ResidualBooleanStatusReading old}
+    {newReading : ResidualBooleanStatusReading new}
+    (transportMap :
+      ResidualStatusDropRepairTransportMap oldReading newReading)
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    [DecidablePred
+      (UnhitMappedOldStatusDropPair
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit)]
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    (hcomplete : ListedAtlasEdgesComplete old sourceEdgeOrder)
+    (htargetNone :
+      firstResidualStatusDrop?
+        newReading
+        (mapResidualEdgeOrder transportMap.mapIndex sourceEdgeOrder) =
+          none) :
+    firstUnhitMappedOldStatusDrop?
+      oldReading
+      transportMap.edgeHit
+      transportMap.sourceHit
+      transportMap.targetHit
+      sourceEdgeOrder =
+        none := by
+  have hall :
+      AllMappedOldStatusDropsHit
+        oldReading
+        transportMap.edgeHit
+        transportMap.sourceHit
+        transportMap.targetHit :=
+    targetMappedSourceOrderScannerNone_forces_allMappedOldStatusDropsHit
+      transportMap
+      hcomplete
+      htargetNone
+  exact
+    (firstUnhitMappedOldStatusDrop?_none_iff_allMappedOldStatusDropsHit
+      hcomplete).mpr hall
+
+/-! ## Selected alarm bridge -/
+
+/-- The selected source unhit witness forces a generated mapped target hit. -/
+theorem selected_sourceUnhitScannerSome_gives_generatedTargetScannerHit :
+    Exists fun targetPair =>
+      firstResidualStatusDrop?
+        selectedExtendedFrontierFlatResidualStatusReading
+        (mapResidualEdgeOrder
+          selectedToExtendedIndex
+          selectedFrontierFlatScanOrder) =
+          some targetPair := by
+  simpa [selectedToExtendedNoHitStatusDropRepairTransportMap,
+    residualCutInducingAtlasMap_to_statusDropRepairTransportMap]
+    using
+      sourceUnhitScannerSome_gives_mappedTargetScannerHit
+        selectedToExtendedNoHitStatusDropRepairTransportMap
+        selectedFrontierFlatScanOrder_complete
+        selected_firstUnhitMappedOldStatusDrop
+
+/-- The selected generated mapped target scanner cannot be `none`. -/
+theorem selected_generatedTargetScanner_not_none :
+    Not
+      (firstResidualStatusDrop?
+        selectedExtendedFrontierFlatResidualStatusReading
+        (mapResidualEdgeOrder
+          selectedToExtendedIndex
+          selectedFrontierFlatScanOrder) =
+          none) := by
+  intro hnone
+  have hsourceNone :
+      firstUnhitMappedOldStatusDrop?
+        selectedFrontierFlatResidualStatusReading
+        selectedNoEdgeHit
+        selectedNoSourceHit
+        selectedNoTargetHit
+        selectedFrontierFlatScanOrder =
+          none :=
+    by
+      simpa [selectedToExtendedNoHitStatusDropRepairTransportMap,
+        residualCutInducingAtlasMap_to_statusDropRepairTransportMap]
+        using
+          mappedTargetScannerNone_forces_sourceUnhitScannerNone
+            selectedToExtendedNoHitStatusDropRepairTransportMap
+            selectedFrontierFlatScanOrder_complete
+            hnone
+  rw [selected_firstUnhitMappedOldStatusDrop] at hsourceNone
+  cases hsourceNone
+
+/-! ## Theorem package -/
+
+/-- Cycle-105 theorem package: source unhit alarms and generated target scans agree. -/
+theorem semanticResidualUnhitToTargetScannerBridge_package :
+    (forall {LeftIndex : Type w}
+      {LeftAtom : Type u}
+      {RightIndex : Type x}
+      {RightAtom : Type v}
+      {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+      {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+      {oldReading : ResidualBooleanStatusReading old}
+      {newReading : ResidualBooleanStatusReading new},
+      forall transportMap :
+        ResidualStatusDropRepairTransportMap oldReading newReading,
+      forall [_targetInst : DecidablePred (ResidualStatusDropPair newReading)],
+      forall
+        [_sourceInst :
+          DecidablePred
+            (UnhitMappedOldStatusDropPair
+              oldReading
+              transportMap.edgeHit
+              transportMap.sourceHit
+              transportMap.targetHit)],
+      forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+      forall pair : LeftIndex × LeftIndex,
+        ListedAtlasEdgesComplete old sourceEdgeOrder ->
+          firstUnhitMappedOldStatusDrop?
+            oldReading
+            transportMap.edgeHit
+            transportMap.sourceHit
+            transportMap.targetHit
+            sourceEdgeOrder =
+              some pair ->
+          Exists fun targetPair =>
+            firstResidualStatusDrop?
+              newReading
+              (mapResidualEdgeOrder
+                transportMap.mapIndex
+                sourceEdgeOrder) =
+                some targetPair) /\
+      (forall {LeftIndex : Type w}
+        {LeftAtom : Type u}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {old : FiniteSemanticRepairAtlasSkeleton LeftIndex LeftAtom}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {oldReading : ResidualBooleanStatusReading old}
+        {newReading : ResidualBooleanStatusReading new},
+        forall transportMap :
+          ResidualStatusDropRepairTransportMap oldReading newReading,
+        forall [_targetInst : DecidablePred (ResidualStatusDropPair newReading)],
+        forall
+          [_sourceInst :
+            DecidablePred
+              (UnhitMappedOldStatusDropPair
+                oldReading
+                transportMap.edgeHit
+                transportMap.sourceHit
+                transportMap.targetHit)],
+        forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+          ListedAtlasEdgesComplete old sourceEdgeOrder ->
+            firstResidualStatusDrop?
+              newReading
+              (mapResidualEdgeOrder
+                transportMap.mapIndex
+                sourceEdgeOrder) =
+                none ->
+            firstUnhitMappedOldStatusDrop?
+              oldReading
+              transportMap.edgeHit
+              transportMap.sourceHit
+              transportMap.targetHit
+              sourceEdgeOrder =
+                none) /\
+      (Exists fun targetPair =>
+        firstResidualStatusDrop?
+          selectedExtendedFrontierFlatResidualStatusReading
+          (mapResidualEdgeOrder
+            selectedToExtendedIndex
+            selectedFrontierFlatScanOrder) =
+            some targetPair) /\
+      Not
+        (firstResidualStatusDrop?
+          selectedExtendedFrontierFlatResidualStatusReading
+          (mapResidualEdgeOrder
+            selectedToExtendedIndex
+            selectedFrontierFlatScanOrder) =
+            none) := by
+  exact
+    ⟨fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading}
+        transportMap _targetInst _sourceInst sourceEdgeOrder pair
+        hcomplete hsource =>
+        sourceUnhitScannerSome_gives_mappedTargetScannerHit
+          transportMap
+          hcomplete
+          hsource,
+      fun {_LeftIndex} {_LeftAtom} {_RightIndex} {_RightAtom}
+        {_old} {_new} {_oldReading} {_newReading}
+        transportMap _targetInst _sourceInst sourceEdgeOrder hcomplete
+        htargetNone =>
+        mappedTargetScannerNone_forces_sourceUnhitScannerNone
+          transportMap
+          hcomplete
+          htargetNone,
+      selected_sourceUnhitScannerSome_gives_generatedTargetScannerHit,
+      selected_generatedTargetScanner_not_none⟩
+
+end SemanticResidualUnhitToTargetScannerBridge
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-unhit-to-target-scanner-bridge.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-unhit-to-target-scanner-bridge.md
@@ -1,0 +1,128 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: source-unhit to target-scanner alarm bridge / repair-hit scanner integration / genius-support convergence
+candidate_type: source unhit scanner to generated target scanner bridge / alarm consistency theorem
+capability_category: semantic-obstruction / status-drop-scanner / alarm-bridge / mapped-target-scanner / genius-support
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can show source repair witnesses and target scan results separately, but they do not prove that a source unhit scanner witness forces generated target scanner nonempty, nor that target scanner none forces source unhit scanner none.
+origin: cycle-105
+tags: [quality-surface, semantic-repair, residual-cut, status-drop, scanner, alarm-bridge, mapped-target, genius-support]
+created: 2026-06-23
+cycle: 105
+lean: proved-in-research
+planned_report_section: "Cycle 105: Source unhit to generated target scanner bridge"
+---
+
+# Source Unhit To Generated Target Scanner Bridge
+
+## 主張
+
+Cycle 104 の source unhit status-drop scanner と、Cycle 103 の generated mapped target scanner を接続する。
+
+source scanner が explicit unhit old status drop を `some` として返すなら、generated mapped target scanner は
+`none` ではありえず、実際に `some targetPair` を返す。逆に generated mapped target scanner が `none` なら、
+complete source order 上で source unhit scanner も `none` になる。
+
+これは alarm consistency bridge であり、target-wide order completeness、hit sufficiency、repair synthesis、
+global minimality、vanishing-to-closure、true `H^1` / Cech / coboundary quotient、ArchMap/tooling correctness、
+runtime/UI correctness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`source unhit scanner to generated target scanner bridge` / `alarm consistency theorem`
+
+## 依拠
+
+- Cycle 103: generated mapped target scanner order。
+- Cycle 104: source unhit status-drop scanner exactness。
+
+## 非自明性
+
+source-side red witness と target-side generated scanner を別々の artifact にせず、同じ finite order bridge で接続する。
+source unhit `some` と target scanner `none` が同時に成立しないことを Lean theorem として固定した。
+
+## 数学的興味
+
+repair-hit scanner の red/green surface を mapped target scanner surface と整合させる。
+これは future semantic repair-gluing obstruction theorem の diagnostic layer で、source witness と target obstruction alarm の整合性を保証する。
+
+## GOAL への前進
+
+source certificate geometry の unhit witness が target generated scanner の nonempty alarm に必ず現れることを示した。
+quality surface の scanner 群が互いに矛盾しないことを、proof-level bridge として加えた。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は source-side repair witness と target scan result を並べられる。
+しかし、source unhit scanner hit が generated target scanner hit を強制し、target scanner `none` が source unhit scanner `none` を強制することを証明しない。
+
+## SCORE 見込み
+
+- `score_reason`: Cycle 103/104 の scanner surfaces を alarm bridge として接続し、source red witness と target generated scanner の整合性を証明した。
+- `dullness_risk`: 既存 theorem の合成に近い。selected witness と theorem package で proof surface を固定したが、score は support-cycle として抑える。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualUnhitToTargetScannerBridge.lean` で source-to-target scanner bridge を証明する。
+
+## CS / SWE への帰結
+
+repair audit で source unhit witness が見つかった場合、target generated scan が green になることはない。
+target generated scan が green なら、complete source order 上では source unhit scanner も green になる。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualUnhitToTargetScannerBridge.lean` に固定した。
+
+- `sourceUnhitScannerSome_forces_mappedTargetScannerNotNone`
+- `sourceUnhitScannerSome_gives_mappedTargetScannerHit`
+- `mappedTargetScannerNone_forces_sourceUnhitScannerNone`
+- `selected_sourceUnhitScannerSome_gives_generatedTargetScannerHit`
+- `selected_generatedTargetScanner_not_none`
+- `semanticResidualUnhitToTargetScannerBridge_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualUnhitToTargetScannerBridge.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualUnhitToTargetScannerBridge`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: theorem family は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、complete source order、source unhit scanner `some` / `none`、generated mapped target scanner
+`some` / `none` の alarm consistency に限定する。
+unchecked: target-wide order completeness、hit sufficiency、repair synthesis、global minimality、vanishing-to-closure、
+true H1/cohomology、Cech quotient、coboundary quotient、ArchMap correctness、runtime/UI correctness、whole-codebase quality。
+
+## 審判メモ
+
+- G1: accept。新 obstruction 本体ではないが、source red witness と target generated scanner `none` の同時成立不能性を固定する diagnostic layer として base 70 / final +140 は妥当。
+- G2: accept。score range +136 to +144、提案 +140 は妥当。rival は source witness と target scan を並べられても alarm consistency を証明しない。
+- genius unlock ではなく、finite semantic repair-gluing obstruction theorem へ向けた support-cycle。
+
+## 追加 required fields
+
+- `mathematical_interest`: source unhit scanner と generated target scanner の alarm consistency を証明する。
+- `goal_advancement`: source red witness が target generated scan に現れることを保証する。
+- `planned_theorem_names`: `sourceUnhitScannerSome_gives_mappedTargetScannerHit`, `mappedTargetScannerNone_forces_sourceUnhitScannerNone`, `semanticResidualUnhitToTargetScannerBridge_package`
+- `visible_projection`: source unhit scanner、generated mapped target scanner、some/non-none/none。
+- `protected_structure`: explicit source unhit witness、complete source order、mapped generated target order。
+- `exactness_or_minimality_claim`: alarm consistency。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: target scanner none without complete source order does not certify source unhit scanner none。
+- `previous_cycle_delta`: Cycle 104 の source scanner exactness を Cycle 103 の generated target scanner と接続した。
+- `rival_stress_test`: rival は二つの scanner result を表示できても相互矛盾不能性を theorem として出さない。
+- `genius_potential`: support-cycle。1000 点 unlock ではなく、future finite semantic repair-gluing obstruction theorem の diagnostic consistency layer。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: source red witness と target generated scanner alarm の整合性を保証する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-unhit-status-drop-scanner.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-scanner-order.md`
+- planned report section: `Cycle 105: Source unhit to generated target scanner bridge`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 105 candidate として source unhit to generated target scanner bridge を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualUnhitToTargetScannerBridge.lean` に固定し、単体
+  `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 14746
+- total SCORE: 14886
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -109,8 +109,9 @@
   - semantic-obstruction / status-drop-scanner / atlas-map-induced / repair-necessity / genius-support: 172
   - semantic-obstruction / status-drop-scanner / generated-mapped-order / repair-necessity / genius-support: 168
   - semantic-obstruction / status-drop-scanner / repair-hit-exactness / mapped-target-obstruction / genius-support: 176
+  - semantic-obstruction / status-drop-scanner / alarm-bridge / mapped-target-scanner / genius-support: 140
 - evidence portfolio:
-  - proved-in-research: 104
+  - proved-in-research: 105
 
 ## Phase synthesis
 
@@ -126,7 +127,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-104 件の Lean-proved research artifacts は、次の paper seed を形成している。
+105 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -159,6 +160,7 @@ certificate の基本単位は
 - semantic residual induced status-drop scanner hitting は、ResidualCutInducingAtlasMap と complete target scanner `none` から source-side old status-drop hit obligation を直接読む bridge を与える。
 - semantic residual mapped status-drop scanner order は、source-complete edge order の map image 上の target scanner `none` だけで mapped old status-drop hit obligation を読めることを示す。
 - semantic residual unhit status-drop scanner は、source order 上の unhit old status drop scanner が some なら mapped target obstruction を、complete order 上の none なら all-hit exactness を与えることを示す。
+- semantic residual unhit-to-target scanner bridge は、source unhit scanner hit が generated mapped target scanner nonempty を強制し、target scanner none が source unhit scanner none を強制することを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -223,8 +225,9 @@ Cycle 101 後の total SCORE は 14230 であり、tracking Issue active thresho
 Cycle 102 後の total SCORE は 14402 であり、tracking Issue active threshold 15000 までは残り 598 SCORE である。
 Cycle 103 後の total SCORE は 14570 であり、tracking Issue active threshold 15000 までは残り 430 SCORE である。
 Cycle 104 後の total SCORE は 14746 であり、tracking Issue active threshold 15000 までは残り 254 SCORE である。
+Cycle 105 後の total SCORE は 14886 であり、tracking Issue active threshold 15000 までは残り 114 SCORE である。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 104 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 105 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -261,7 +264,8 @@ semantic residual mapped status-drop repair-hitting theorem、
 semantic residual status-drop scanner theorem、
 semantic residual induced status-drop scanner hitting theorem、
 semantic residual mapped status-drop scanner order theorem、
-semantic residual unhit status-drop scanner theorem を含む。
+semantic residual unhit status-drop scanner theorem、
+semantic residual unhit-to-target scanner bridge theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5754,4 +5758,62 @@ whole-codebase quality, or arbitrary atlas category/functoriality.
 
 Cycle 104 後の total SCORE は 14746 であり、tracking Issue active threshold 15000 までは残り 254 SCORE である。
 次 cycle では、finite pre-H1 support without cohomology overclaim、scanner-derived local-pass/global-fail split、repair-hit minimality under source orders、または genuine semantic repair-gluing obstruction theorem を狙う。
+genius unlock はまだ成立していない。
+
+## Cycle 105: Source unhit to generated target scanner bridge
+
+```text
+candidate: Source unhit to generated target scanner bridge
+candidate_type: source unhit scanner to generated target scanner bridge / alarm consistency theorem
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: semantic-obstruction / status-drop-scanner / alarm-bridge / mapped-target-scanner / genius-support
+goal_delta: Cycle 104 の source unhit scanner と Cycle 103 の generated mapped target scanner を接続し、source red witness が target generated scanner nonempty を強制することを示した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、source-unhit-to-target-scanner non-none theorem、target-none-to-source-none theorem、selected alarm bridge、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は source witness と target scan result を並べられるが、source unhit hit と target scanner none の相互矛盾不能性を Lean theorem として保証できない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualUnhitToTargetScannerBridge.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualUnhitToTargetScannerBridge`, and `lake build FormalAGResearch` passed. Axiom probe reported standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: scanner-derived local-pass/global-fail split; finite pre-H1 support without cohomology overclaim; repair-hit minimality under source orders; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualUnhitToTargetScannerBridge.lean`
+connects the source-side unhit status-drop scanner to the generated mapped
+target status-drop scanner.  If the source scanner returns `some pair`, the
+generated mapped target scanner cannot return `none`; by case analysis on the
+target scanner option, Lean extracts an actual `some targetPair`.
+
+Conversely, if the generated mapped target scanner returns `none` on the
+mapped source order, Cycle 103 forces all mapped old status drops to be hit,
+and Cycle 104 then forces the source unhit scanner to return `none` on a
+complete source order.
+
+The selected witness shows the selected source frontier-to-flat unhit scanner
+hit gives a generated target scanner hit, and that the selected generated
+target scanner cannot be `none`.
+
+Lean proves:
+
+- `sourceUnhitScannerSome_forces_mappedTargetScannerNotNone`: source unhit scanner hit rules out generated target scanner `none`.
+- `sourceUnhitScannerSome_gives_mappedTargetScannerHit`: source unhit scanner hit gives a generated target scanner hit.
+- `mappedTargetScannerNone_forces_sourceUnhitScannerNone`: generated target scanner `none` forces source unhit scanner `none`.
+- `selected_sourceUnhitScannerSome_gives_generatedTargetScannerHit`: selected source hit gives selected generated target hit.
+- `selected_generatedTargetScanner_not_none`: selected generated target scanner cannot be `none`.
+- `semanticResidualUnhitToTargetScannerBridge_package`: theorem package.
+
+This cycle is a `genius-support` bridge, not a `genius unlock`.  It aligns two
+finite diagnostic scanner surfaces and proves their red/green alarms are
+consistent.  It does not prove target-wide order completeness, hit sufficiency,
+repair synthesis, global minimality, vanishing-to-closure, true `H^1` / Cech /
+coboundary quotient, ArchMap correctness, runtime repair synthesis, tooling
+runtime extraction, UI correctness, whole-codebase quality, or arbitrary atlas
+category/functoriality.
+
+### Next Frontier
+
+Cycle 105 後の total SCORE は 14886 であり、tracking Issue active threshold 15000 までは残り 114 SCORE である。
+次 cycle では、scanner-derived local-pass/global-fail split、finite pre-H1 support without cohomology overclaim、repair-hit minimality under source orders、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 105 として、source unhit scanner と generated mapped target scanner の alarm consistency bridge を追加しました。source scanner `some` は generated target scanner `none` を否定し、実際の target scanner hit を与えます。generated target scanner `none` は complete source order 上で source unhit scanner `none` を強制します。

SCORE は G1/G2/G3/G3.5/G4 監査後に +140 とし、`research/reports/G-aat-quality-surface-01.md` の total を 14746 から 14886 に更新しています。これは `genius-support` cycle であり、genius unlock は主張しません。

## 証明した定理

- `sourceUnhitScannerSome_forces_mappedTargetScannerNotNone`
- `sourceUnhitScannerSome_gives_mappedTargetScannerHit`
- `mappedTargetScannerNone_forces_sourceUnhitScannerNone`
- `selected_sourceUnhitScannerSome_gives_generatedTargetScannerHit`
- `selected_generatedTargetScanner_not_none`
- `semanticResidualUnhitToTargetScannerBridge_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-unhit-to-target-scanner-bridge.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualUnhitToTargetScannerBridge.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualUnhitToTargetScannerBridge`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
