### PR TITLE
Cycle 106 target scanner provenance を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -102,3 +102,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualInducedStatusDropScanne
 import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropScannerOrder
 import Formal.AG.Research.QualitySurface.SemanticResidualUnhitStatusDropScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualUnhitToTargetScannerBridge
+import Formal.AG.Research.QualitySurface.SemanticResidualGeneratedTargetScannerProvenance

--- a/Formal/AG/Research/QualitySurface/SemanticResidualGeneratedTargetScannerProvenance.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticResidualGeneratedTargetScannerProvenance.lean
@@ -1,0 +1,251 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualUnhitToTargetScannerBridge
+
+/-!
+Cycle 106 evidence for `G-aat-quality-surface-01`.
+
+This file records provenance for hits of the generated mapped target
+status-drop scanner.  If the target scanner returns `some targetPair` on an
+order generated from a source edge order, then `targetPair` is the image of a
+listed source pair and is an actual target status drop.  Thus generated target
+scanner alarms are traceable back to the source certificate order.
+
+The result is a provenance theorem for generated scanner hits.  It does not
+assert source unhitness, repair sufficiency, target-wide order completeness,
+minimality, vanishing-to-closure, true H1/Cech/coboundary structure, tooling
+correctness, or whole-codebase quality.
+-/
+
+universe u v w x
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticResidualGeneratedTargetScannerProvenance
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualIndexedTransport
+open SemanticResidualEdgeTransitionObstruction
+open VisibleLocalSemanticGluingObstruction
+open RefinedSemanticRepairAtom
+open SemanticResidualTransitionCut
+open SemanticResidualTransitionCutScanner
+open SemanticResidualObstructionClass
+open SemanticResidualAtlasMorphism
+open SemanticResidualAtlasMapLaws
+open SemanticResidualCutRepairHitting
+open SemanticResidualMappedRepairHitting
+open SemanticResidualStatusDropAdapter
+open SemanticResidualStatusDropRepairHitting
+open SemanticResidualMappedStatusDropRepairHitting
+open SemanticResidualStatusDropScanner
+open SemanticResidualInducedStatusDropScannerHitting
+open SemanticResidualMappedStatusDropScannerOrder
+open SemanticResidualUnhitStatusDropScanner
+open SemanticResidualUnhitToTargetScannerBridge
+
+/-! ## Provenance for generated mapped target scanner hits -/
+
+/-- A generated target scanner hit has a listed source-order preimage. -/
+theorem generatedTargetScannerHit_has_sourceOrderPreimage
+    {LeftIndex : Type w}
+    {RightIndex : Type x}
+    (mapIndex : LeftIndex -> RightIndex)
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    {targetPair : RightIndex × RightIndex}
+    (hmem :
+      targetPair ∈
+        mapResidualEdgeOrder mapIndex sourceEdgeOrder) :
+    Exists fun sourcePair =>
+      sourcePair ∈ sourceEdgeOrder /\
+        mapResidualPair mapIndex sourcePair = targetPair := by
+  rcases List.mem_map.mp hmem with ⟨sourcePair, hsource, hmap⟩
+  exact ⟨sourcePair, hsource, hmap⟩
+
+/--
+If the generated target scanner returns a hit, that hit is an actual target
+status drop and has a listed source-order preimage.
+-/
+theorem generatedTargetScannerHit_has_sourcePreimageAndStatusDrop
+    {LeftIndex : Type w}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (mapIndex : LeftIndex -> RightIndex)
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    {targetPair : RightIndex × RightIndex}
+    (hscan :
+      firstResidualStatusDrop?
+        newReading
+        (mapResidualEdgeOrder mapIndex sourceEdgeOrder) =
+          some targetPair) :
+    (Exists fun sourcePair =>
+      sourcePair ∈ sourceEdgeOrder /\
+        mapResidualPair mapIndex sourcePair = targetPair) /\
+      ResidualStatusDropPair newReading targetPair := by
+  have hmem :
+      targetPair ∈
+        mapResidualEdgeOrder mapIndex sourceEdgeOrder :=
+    firstResidualStatusDrop?_some_mem newReading hscan
+  exact
+    ⟨generatedTargetScannerHit_has_sourceOrderPreimage
+        mapIndex
+        hmem,
+      firstResidualStatusDrop?_some_pairDrop newReading hscan⟩
+
+/-- A generated target scanner hit has source provenance and gives canonical nonzero. -/
+theorem generatedTargetScannerHit_has_sourcePreimageAndCanonicalNonzero
+    {LeftIndex : Type w}
+    {RightIndex : Type x}
+    {RightAtom : Type v}
+    {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+    {newReading : ResidualBooleanStatusReading new}
+    [DecidablePred (ResidualStatusDropPair newReading)]
+    (mapIndex : LeftIndex -> RightIndex)
+    {sourceEdgeOrder : List (LeftIndex × LeftIndex)}
+    {targetPair : RightIndex × RightIndex}
+    (hscan :
+      firstResidualStatusDrop?
+        newReading
+        (mapResidualEdgeOrder mapIndex sourceEdgeOrder) =
+          some targetPair) :
+    (Exists fun sourcePair =>
+      sourcePair ∈ sourceEdgeOrder /\
+        mapResidualPair mapIndex sourcePair = targetPair) /\
+      (canonicalResidualCutCochain new).CutNonzero := by
+  exact
+    ⟨(generatedTargetScannerHit_has_sourcePreimageAndStatusDrop
+        mapIndex
+        hscan).1,
+      firstResidualStatusDrop?_some_canonicalNonzero hscan⟩
+
+/-! ## Selected provenance witness -/
+
+/-- The selected generated target scanner hit has a selected-order source preimage. -/
+theorem selectedGeneratedTargetScannerHit_sourcePreimage :
+    (Exists fun sourcePair =>
+      sourcePair ∈ selectedFrontierFlatScanOrder /\
+        mapResidualPair selectedToExtendedIndex sourcePair =
+          mapResidualPair
+            selectedToExtendedIndex
+            selectedFrontierFlatResidualCutPair) /\
+      ResidualStatusDropPair
+        selectedExtendedFrontierFlatResidualStatusReading
+        (mapResidualPair
+          selectedToExtendedIndex
+          selectedFrontierFlatResidualCutPair) := by
+  exact
+    generatedTargetScannerHit_has_sourcePreimageAndStatusDrop
+      selectedToExtendedIndex
+      selectedGeneratedMapped_firstResidualStatusDrop
+
+/-- The selected generated target scanner hit has provenance and canonical nonzero. -/
+theorem selectedGeneratedTargetScannerHit_sourcePreimageAndCanonicalNonzero :
+    (Exists fun sourcePair =>
+      sourcePair ∈ selectedFrontierFlatScanOrder /\
+        mapResidualPair selectedToExtendedIndex sourcePair =
+          mapResidualPair
+            selectedToExtendedIndex
+            selectedFrontierFlatResidualCutPair) /\
+      (canonicalResidualCutCochain
+        selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero := by
+  exact
+    generatedTargetScannerHit_has_sourcePreimageAndCanonicalNonzero
+      selectedToExtendedIndex
+      selectedGeneratedMapped_firstResidualStatusDrop
+
+/-! ## Theorem package -/
+
+/-- Cycle-106 theorem package: generated target scanner hits keep source provenance. -/
+theorem semanticResidualGeneratedTargetScannerProvenance_package :
+    (forall {LeftIndex : Type w}
+      {RightIndex : Type x},
+      forall mapIndex : LeftIndex -> RightIndex,
+      forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+      forall targetPair : RightIndex × RightIndex,
+        targetPair ∈
+          mapResidualEdgeOrder mapIndex sourceEdgeOrder ->
+          Exists fun sourcePair =>
+            sourcePair ∈ sourceEdgeOrder /\
+              mapResidualPair mapIndex sourcePair = targetPair) /\
+      (forall {LeftIndex : Type w}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {newReading : ResidualBooleanStatusReading new}
+        {_inst : DecidablePred (ResidualStatusDropPair newReading)},
+        forall mapIndex : LeftIndex -> RightIndex,
+        forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+        forall targetPair : RightIndex × RightIndex,
+          firstResidualStatusDrop?
+            newReading
+            (mapResidualEdgeOrder mapIndex sourceEdgeOrder) =
+              some targetPair ->
+            (Exists fun sourcePair =>
+              sourcePair ∈ sourceEdgeOrder /\
+                mapResidualPair mapIndex sourcePair = targetPair) /\
+              ResidualStatusDropPair newReading targetPair) /\
+      (forall {LeftIndex : Type w}
+        {RightIndex : Type x}
+        {RightAtom : Type v}
+        {new : FiniteSemanticRepairAtlasSkeleton RightIndex RightAtom}
+        {newReading : ResidualBooleanStatusReading new}
+        {_inst : DecidablePred (ResidualStatusDropPair newReading)},
+        forall mapIndex : LeftIndex -> RightIndex,
+        forall sourceEdgeOrder : List (LeftIndex × LeftIndex),
+        forall targetPair : RightIndex × RightIndex,
+          firstResidualStatusDrop?
+            newReading
+            (mapResidualEdgeOrder mapIndex sourceEdgeOrder) =
+              some targetPair ->
+            (Exists fun sourcePair =>
+              sourcePair ∈ sourceEdgeOrder /\
+                mapResidualPair mapIndex sourcePair = targetPair) /\
+              (canonicalResidualCutCochain new).CutNonzero) /\
+      ((Exists fun sourcePair =>
+        sourcePair ∈ selectedFrontierFlatScanOrder /\
+          mapResidualPair selectedToExtendedIndex sourcePair =
+            mapResidualPair
+              selectedToExtendedIndex
+              selectedFrontierFlatResidualCutPair) /\
+        ResidualStatusDropPair
+          selectedExtendedFrontierFlatResidualStatusReading
+          (mapResidualPair
+            selectedToExtendedIndex
+            selectedFrontierFlatResidualCutPair)) /\
+      ((Exists fun sourcePair =>
+        sourcePair ∈ selectedFrontierFlatScanOrder /\
+          mapResidualPair selectedToExtendedIndex sourcePair =
+            mapResidualPair
+              selectedToExtendedIndex
+              selectedFrontierFlatResidualCutPair) /\
+        (canonicalResidualCutCochain
+          selectedExtendedFrontierFlatAtlasSkeleton).CutNonzero) := by
+  exact
+    ⟨fun {_LeftIndex} {_RightIndex} mapIndex sourceEdgeOrder
+        targetPair hmem =>
+        generatedTargetScannerHit_has_sourceOrderPreimage
+          mapIndex
+          hmem,
+      fun {_LeftIndex} {_RightIndex} {_RightAtom}
+        {_new} {_newReading} {_inst} mapIndex sourceEdgeOrder
+        targetPair hscan =>
+        generatedTargetScannerHit_has_sourcePreimageAndStatusDrop
+          mapIndex
+          hscan,
+      fun {_LeftIndex} {_RightIndex} {_RightAtom}
+        {_new} {_newReading} {_inst} mapIndex sourceEdgeOrder
+        targetPair hscan =>
+        generatedTargetScannerHit_has_sourcePreimageAndCanonicalNonzero
+          mapIndex
+          hscan,
+      selectedGeneratedTargetScannerHit_sourcePreimage,
+      selectedGeneratedTargetScannerHit_sourcePreimageAndCanonicalNonzero⟩
+
+end SemanticResidualGeneratedTargetScannerProvenance
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-semantic-residual-generated-target-scanner-provenance.md
+++ b/research/ideas/g-aat-quality-surface-01-semantic-residual-generated-target-scanner-provenance.md
@@ -1,0 +1,125 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+exploration_role: generated target scanner provenance / source-order traceability / threshold-completion support
+candidate_type: generated target scanner provenance theorem / source preimage certificate
+capability_category: semantic-obstruction / status-drop-scanner / provenance / mapped-target-scanner / genius-support
+expected_base_score: 62
+expected_evidence_multiplier: 2.0
+expected_final_score: 124
+evidence_stage: proved-in-research
+rival_advantage: Static analyzers, ADL tools, dashboards, and AI summaries can display target scanner hits, but they do not prove that hits of a generated mapped target scanner retain source-order provenance and target status-drop validity.
+origin: cycle-106
+tags: [quality-surface, semantic-repair, residual-cut, status-drop, scanner, provenance, mapped-target, threshold]
+created: 2026-06-23
+cycle: 106
+lean: proved-in-research
+planned_report_section: "Cycle 106: Generated target scanner hit provenance"
+---
+
+# Generated Target Scanner Hit Provenance
+
+## 主張
+
+generated mapped target scanner が `some targetPair` を返すなら、その `targetPair` は source edge order に含まれる
+ある `sourcePair` の `mapResidualPair` image であり、同時に actual target status drop である。
+さらに canonical nonzero も得られる。
+
+これは generated target scanner hit の source provenance theorem であり、source unhitness、repair sufficiency、
+target-wide order completeness、minimality、vanishing-to-closure、true `H^1` / Cech / coboundary quotient、
+tooling correctness、whole-codebase quality は主張しない。
+
+## 候補種別
+
+`generated target scanner provenance theorem` / `source preimage certificate`
+
+## 依拠
+
+- Cycle 103: generated mapped target scanner order。
+- Cycle 105: source/target scanner alarm bridge。
+
+## 非自明性
+
+generated target scanner hit は target 側だけの alarm ではなく、source certificate order 上の preimage を持つ。
+これにより generated target scanner surface の alarm が source-order traceability を失わないことを保証する。
+
+## 数学的興味
+
+finite generated scanner hit を source-order provenance と target status-drop validity の pair として読む。
+これは scanner-driven obstruction diagnostics の traceability layer である。
+
+## GOAL への前進
+
+target generated scan の red alarm を source certificate geometry へ戻せるようにした。
+threshold 15000 到達の最後の support theorem として、scanner tower の traceability 境界を閉じる。
+
+## ライバルに対する有効性
+
+ADL、static analyzer、dashboard、AI summary は target hit を表示できる。
+しかし、その hit が generated order のどの source pair に由来し、actual target status drop であるかを theorem として保証しない。
+
+## SCORE 見込み
+
+- `score_reason`: generated target scanner hit に source-order preimage と target status-drop validity / canonical nonzero を付与した。
+- `dullness_risk`: `List.mem_map` と scanner soundness の合成に近いため score は抑える。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/SemanticResidualGeneratedTargetScannerProvenance.lean` で provenance theorem を証明する。
+
+## CS / SWE への帰結
+
+generated target scanner が red alarm を出したとき、theorem-level provenance として source order 上の preimage を渡せる。
+target-side alarm が source certificate geometry から切り離された孤立 signal にならない。
+
+## 証明・根拠
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/SemanticResidualGeneratedTargetScannerProvenance.lean` に固定した。
+
+- `generatedTargetScannerHit_has_sourceOrderPreimage`
+- `generatedTargetScannerHit_has_sourcePreimageAndStatusDrop`
+- `generatedTargetScannerHit_has_sourcePreimageAndCanonicalNonzero`
+- `selectedGeneratedTargetScannerHit_sourcePreimage`
+- `selectedGeneratedTargetScannerHit_sourcePreimageAndCanonicalNonzero`
+- `semanticResidualGeneratedTargetScannerProvenance_package`
+
+検証実績:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualGeneratedTargetScannerProvenance.lean`: pass。
+- `lake build Formal.AG.Research.QualitySurface.SemanticResidualGeneratedTargetScannerProvenance`: pass。
+- `lake build FormalAGResearch`: pass。
+- `#print axioms`: theorem family は標準 `propext` / `Quot.sound` のみ。`sorryAx`、custom axiom、`Classical.choice`、`unsafe` はなし。
+
+claim boundary は、generated target scanner hit の source-order preimage、target status-drop validity、canonical nonzero に限定する。
+unchecked: source unhitness、repair sufficiency、target-wide order completeness、minimality、vanishing-to-closure、
+true H1/cohomology、Cech quotient、coboundary quotient、ArchMap correctness、runtime/UI correctness、whole-codebase quality。
+
+## 審判メモ
+
+- G1: accept。`List.mem_map` provenance と scanner soundness の合成に近いが、generated target scanner alarm が source order provenance を失わないことを固定する traceability layer として base 62 / final +124 は妥当。
+- G2: accept。score range +116 to +128、提案 +124 は妥当。rival は target hit を表示できても source-order preimage と target status-drop validity / canonical nonzero を theorem として保証しない。
+- genius unlock ではなく、threshold completion の support-cycle。
+
+## 追加 required fields
+
+- `mathematical_interest`: generated target scanner hit を source-order provenance と target status-drop validity に分解する。
+- `goal_advancement`: scanner tower の target alarm を source certificate geometry へ戻す。
+- `planned_theorem_names`: `generatedTargetScannerHit_has_sourcePreimageAndStatusDrop`, `generatedTargetScannerHit_has_sourcePreimageAndCanonicalNonzero`, `semanticResidualGeneratedTargetScannerProvenance_package`
+- `visible_projection`: generated target scanner hit、source order preimage、target status drop。
+- `protected_structure`: `List.mem_map` provenance、scanner some soundness、canonical nonzero。
+- `exactness_or_minimality_claim`: provenance only。minimality は主張しない。
+- `nonfaithfulness_or_failure_mode`: arbitrary target scanner hit without generated order does not carry this source provenance。
+- `previous_cycle_delta`: Cycle 105 の alarm bridge に target hit provenance を追加した。
+- `rival_stress_test`: rival は target hit を表示できても source-order preimage theorem を保証しない。
+- `genius_potential`: support-cycle。1000 点 unlock ではなく、threshold completion support。
+- `genius_target`: Semantic repair-gluing obstruction theorem for finite atom-supported quality atlases
+- `genius_support_role`: generated target scanner alarms の traceability を保証する。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-unhit-to-target-scanner-bridge.md`
+- `research/ideas/g-aat-quality-surface-01-semantic-residual-mapped-status-drop-scanner-order.md`
+- planned report section: `Cycle 106: Generated target scanner hit provenance`
+
+## 進捗ログ
+
+- 2026-06-23: Cycle 106 candidate として generated target scanner hit provenance を採択。
+- 2026-06-23: Lean 証拠を `SemanticResidualGeneratedTargetScannerProvenance.lean` に固定し、単体
+  `lake env lean`、module build、`lake build FormalAGResearch`、axiom 監査が通った。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 14886
+- total SCORE: 15010
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -110,8 +110,9 @@
   - semantic-obstruction / status-drop-scanner / generated-mapped-order / repair-necessity / genius-support: 168
   - semantic-obstruction / status-drop-scanner / repair-hit-exactness / mapped-target-obstruction / genius-support: 176
   - semantic-obstruction / status-drop-scanner / alarm-bridge / mapped-target-scanner / genius-support: 140
+  - semantic-obstruction / status-drop-scanner / provenance / mapped-target-scanner / genius-support: 124
 - evidence portfolio:
-  - proved-in-research: 105
+  - proved-in-research: 106
 
 ## Phase synthesis
 
@@ -127,7 +128,7 @@ certificate の基本単位は
 `nu_p` は verdict / reading discipline、`T_p` は atom support から source-reference field へ戻る trace information を担う。
 この tuple を一つの scalar に潰さないことが、このフェーズの中心的な分離である。
 
-105 件の Lean-proved research artifacts は、次の paper seed を形成している。
+106 件の Lean-proved research artifacts は、次の paper seed を形成している。
 
 - scalar reading や verdict が一致しても、support family と repair hitting requirement は復元できない。
 - local repair が obstruction を eliminate するなら、selected minimal support family を hit しなければならない。
@@ -161,6 +162,7 @@ certificate の基本単位は
 - semantic residual mapped status-drop scanner order は、source-complete edge order の map image 上の target scanner `none` だけで mapped old status-drop hit obligation を読めることを示す。
 - semantic residual unhit status-drop scanner は、source order 上の unhit old status drop scanner が some なら mapped target obstruction を、complete order 上の none なら all-hit exactness を与えることを示す。
 - semantic residual unhit-to-target scanner bridge は、source unhit scanner hit が generated mapped target scanner nonempty を強制し、target scanner none が source unhit scanner none を強制することを示す。
+- semantic residual generated target scanner provenance は、generated target scanner hit が source-order preimage と target status-drop validity を保持することを示す。
 - semantic residual alias nonfaithfulness は、actual residual atom を欠いたまま同じ component を alias atom で cover する gap が semantic repair closure の component-projection faithfulness を壊すことを generic criterion として示す。
 - semantic-fiber-aware viewer criterion は、atom-level support equivalence が semantic repair closure を反映する十分な reading surface であり、component-only reading は selected alias gap で失敗することを示す。
 - semantic residual component faithfulness は、semantic repair closure の cover-relative exact reading kernel を residual atom support equivalence として切り出し、component coverage と residual-component faithfulness の分解で component-only surface の失敗を説明する。
@@ -226,8 +228,9 @@ Cycle 102 後の total SCORE は 14402 であり、tracking Issue active thresho
 Cycle 103 後の total SCORE は 14570 であり、tracking Issue active threshold 15000 までは残り 430 SCORE である。
 Cycle 104 後の total SCORE は 14746 であり、tracking Issue active threshold 15000 までは残り 254 SCORE である。
 Cycle 105 後の total SCORE は 14886 であり、tracking Issue active threshold 15000 までは残り 114 SCORE である。
+Cycle 106 後の total SCORE は 15010 であり、tracking Issue active threshold 15000 を 10 SCORE 超過して達成した。
 tracking Issue は次フェーズ継続と人間判断のため open のまま残す。
-portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 105 件持ち、
+portfolio constraint は満たしている。成果は 4 カテゴリ以上に分散し、`proved-in-research` artifact を 106 件持ち、
 atom support / traceability、certificate transport / profile curvature / ridge-fold、support-local repair theorem、
 scalar-collapse counterexample、finite trace / source-ref exactness example、source-ref handoff holonomy correspondence、
 order-independent source-ref handoff obstruction locus、repair/transport handoff obstruction bridge、
@@ -265,7 +268,8 @@ semantic residual status-drop scanner theorem、
 semantic residual induced status-drop scanner hitting theorem、
 semantic residual mapped status-drop scanner order theorem、
 semantic residual unhit status-drop scanner theorem、
-semantic residual unhit-to-target scanner bridge theorem を含む。
+semantic residual unhit-to-target scanner bridge theorem、
+semantic residual generated target scanner provenance theorem を含む。
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -5817,3 +5821,58 @@ category/functoriality.
 Cycle 105 後の total SCORE は 14886 であり、tracking Issue active threshold 15000 までは残り 114 SCORE である。
 次 cycle では、scanner-derived local-pass/global-fail split、finite pre-H1 support without cohomology overclaim、repair-hit minimality under source orders、または genuine semantic repair-gluing obstruction theorem を狙う。
 genius unlock はまだ成立していない。
+
+## Cycle 106: Generated target scanner hit provenance
+
+```text
+candidate: Generated target scanner hit provenance
+candidate_type: generated target scanner provenance theorem / source preimage certificate
+evidence_stage: proved-in-research
+base_score: 62
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 124
+category: semantic-obstruction / status-drop-scanner / provenance / mapped-target-scanner / genius-support
+goal_delta: generated mapped target scanner hit が source edge order 上の preimage と target status-drop validity を保持することを証明し、target scanner alarm の source-order traceability を固定した。
+project_value_delta: Research Lean layer と `Formal.AG.Research` aggregate import に、generated target scanner hit provenance、status-drop validity、canonical nonzero、selected provenance witness、theorem package を追加した。
+rival_delta: ADL / static analysis / conformance dashboard / metric dashboard / AI summary は target scanner hit を表示できても、その hit が generated source order のどの pair に由来し、actual target status drop であるかを Lean theorem として保証できない。
+formalization_quality: pass. `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualGeneratedTargetScannerProvenance.lean`, `lake build Formal.AG.Research.QualitySurface.SemanticResidualGeneratedTargetScannerProvenance`, and `lake build FormalAGResearch` passed. Axiom probe reported standard `propext` / `Quot.sound` only. No `sorryAx`, custom axiom, `Classical.choice`, or `unsafe` was reported.
+open_questions: post-threshold phase review; scanner-derived local-pass/global-fail split; finite pre-H1 support without cohomology overclaim; genuine semantic repair-gluing obstruction theorem.
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticResidualGeneratedTargetScannerProvenance.lean`
+adds provenance for hits of the generated mapped target status-drop scanner.
+If a scanner over `mapResidualEdgeOrder mapIndex sourceEdgeOrder` returns
+`some targetPair`, Lean proves that `targetPair` is the image of a listed
+`sourcePair` from `sourceEdgeOrder`.
+
+The same hit is also an actual target status drop, by the existing scanner
+soundness theorem.  Combining provenance and scanner soundness gives source
+preimage plus target status-drop validity; combining provenance and canonical
+nonzero gives source preimage plus target obstruction signal.
+
+The selected witness specializes this to a selected generated target scanner
+hit with a selected-order source preimage.
+
+Lean proves:
+
+- `generatedTargetScannerHit_has_sourceOrderPreimage`: membership in a generated mapped order has a source preimage.
+- `generatedTargetScannerHit_has_sourcePreimageAndStatusDrop`: scanner hit has source preimage and target status-drop validity.
+- `generatedTargetScannerHit_has_sourcePreimageAndCanonicalNonzero`: scanner hit has source preimage and canonical nonzero.
+- `selectedGeneratedTargetScannerHit_sourcePreimage`: selected generated target hit keeps source provenance.
+- `selectedGeneratedTargetScannerHit_sourcePreimageAndCanonicalNonzero`: selected generated target hit keeps source provenance and nonzero obstruction.
+- `semanticResidualGeneratedTargetScannerProvenance_package`: theorem package.
+
+This cycle is a threshold-completion support theorem, not a `genius unlock`.
+It proves traceability for generated target scanner hits.  It does not prove
+source unhitness, repair sufficiency, target-wide order completeness,
+minimality, vanishing-to-closure, true `H^1` / Cech / coboundary quotient,
+ArchMap correctness, runtime repair synthesis, tooling runtime extraction, UI
+correctness, whole-codebase quality, or arbitrary atlas category/functoriality.
+
+### Threshold Result
+
+Cycle 106 後の total SCORE は 15010 であり、tracking Issue active threshold 15000 を 10 SCORE 超過して達成した。
+genius unlock は成立していないが、Cycle 89-106 の support stack により finite status-drop / repair-hit scanner tower、mapped target scanner alarm consistency、source provenance が Lean-proved artifact として固定された。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 106 として、generated mapped target scanner hit の source-order provenance を証明しました。target scanner `some targetPair` は source order 上の preimage を持ち、actual target status drop / canonical nonzero も得られます。

SCORE は G1/G2/G3/G3.5/G4 監査後に +124 とし、`research/reports/G-aat-quality-surface-01.md` の total を 14886 から 15010 に更新しています。これで active threshold 15000 を +10 で達成しました。これは `genius-support` cycle であり、genius unlock は主張しません。

## 証明した定理

- `generatedTargetScannerHit_has_sourceOrderPreimage`
- `generatedTargetScannerHit_has_sourcePreimageAndStatusDrop`
- `generatedTargetScannerHit_has_sourcePreimageAndCanonicalNonzero`
- `selectedGeneratedTargetScannerHit_sourcePreimage`
- `selectedGeneratedTargetScannerHit_sourcePreimageAndCanonicalNonzero`
- `semanticResidualGeneratedTargetScannerProvenance_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-semantic-residual-generated-target-scanner-provenance.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SemanticResidualGeneratedTargetScannerProvenance.lean`
- [x] `lake build Formal.AG.Research.QualitySurface.SemanticResidualGeneratedTargetScannerProvenance`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking Issue を閉じないため `Refs #2348`）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
