### PR TITLE
研究: G-02 finite semantic repair-gluing descent を証明

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -103,3 +103,4 @@ import Formal.AG.Research.QualitySurface.SemanticResidualMappedStatusDropScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualUnhitStatusDropScanner
 import Formal.AG.Research.QualitySurface.SemanticResidualUnhitToTargetScannerBridge
 import Formal.AG.Research.QualitySurface.SemanticResidualGeneratedTargetScannerProvenance
+import Formal.AG.Research.QualitySurface.SemanticRepairGluingComplex

--- a/Formal/AG/Research/QualitySurface/SemanticRepairGluingComplex.lean
+++ b/Formal/AG/Research/QualitySurface/SemanticRepairGluingComplex.lean
@@ -1,0 +1,421 @@
+import Formal.AG.Research.QualitySurface.SemanticResidualObstructionClass
+import Formal.AG.Research.QualitySurface.SemanticResidualComponentFaithfulness
+import Formal.AG.Research.QualitySurface.SemanticResidualTransportNaturality
+
+/-!
+Cycle 1 evidence for `G-aat-quality-surface-02`.
+
+This file introduces a finite Cech-style semantic repair-gluing complex.  The
+degree-zero data are local repair primitives, the degree-one data are residual
+repair-gluing cochains, and `B1` is the image of `delta0`.  Vanishing of the
+finite obstruction class means that the selected residual lies in `B1`.
+
+The sufficiency direction is deliberately not a bare algebraic statement.  A
+boundary primitive must also satisfy semantic faithfulness: it must cover the
+residual components and be faithful back to the actual residual atoms.  Existing
+Cycle 83/85 bridge theorems justify that this is the semantic content required
+to turn a formal primitive into a real semantic repair certificate.
+
+The result is finite and hypothesis-relative.  It does not assert arbitrary
+site/sheaf cohomology, source extraction completeness, ArchMap correctness,
+runtime repair synthesis, global minimality, or whole-codebase quality.
+-/
+
+universe u v w x y
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SemanticRepairGluingComplex
+
+open HeterogeneousRouteInteraction
+open HeterogeneousRouteInteraction.BridgeComponent
+open HandoffCechExactness
+open HandoffCechOverlapBasis
+open SemanticSupportProjectionKernel
+open SemanticResidualComponentFaithfulness
+open SemanticResidualTransportNaturality
+open VisibleLocalSemanticGluingObstruction
+
+/-! ## Finite semantic repair-gluing complexes -/
+
+/--
+A finite semantic repair-gluing complex.
+
+`C0` contains local repair primitive families, `C1` contains residual
+repair-gluing cochains, and `delta0` is the finite restriction-difference map.
+The chart / overlap lists and `delta0_exact` field record the finite Cech-style
+atlas boundary without claiming an arbitrary site or true sheaf-cohomology
+construction.
+-/
+structure FiniteSemanticRepairGluingComplex
+    (Atom : Type u) where
+  Chart : Type v
+  Overlap : Chart -> Chart -> Type w
+  chartOrder : List Chart
+  chart_complete : forall chart, chart ∈ chartOrder
+  C0 : Type x
+  C1 : Type y
+  c0Order : List C0
+  c0_complete : forall primitive, primitive ∈ c0Order
+  c1Order : List C1
+  c1_complete : forall cochain, cochain ∈ c1Order
+  projection : Atom -> BridgeComponent
+  cover : HandoffCechCover
+  supportOf : C0 -> Atom -> Prop
+  leftRestriction :
+    C0 -> forall {source target}, Overlap source target -> Atom -> Prop
+  rightRestriction :
+    C0 -> forall {source target}, Overlap source target -> Atom -> Prop
+  cochainAt :
+    C1 -> forall {source target}, Overlap source target -> Atom -> Prop
+  delta0 : C0 -> C1
+  delta0_exact :
+    forall primitive source target (overlap : Overlap source target) atom,
+      cochainAt (delta0 primitive) overlap atom <->
+        (leftRestriction primitive overlap atom /\
+          Not (rightRestriction primitive overlap atom)) \/
+        (rightRestriction primitive overlap atom /\
+          Not (leftRestriction primitive overlap atom))
+  residual : C1
+
+/-- The finite restriction-difference law defining `delta0` on every overlap. -/
+theorem delta0_support_exact
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom)
+    (primitive : K.C0)
+    {source target : K.Chart}
+    (overlap : K.Overlap source target)
+    (atom : Atom) :
+    K.cochainAt (K.delta0 primitive) overlap atom <->
+      (K.leftRestriction primitive overlap atom /\
+        Not (K.rightRestriction primitive overlap atom)) \/
+      (K.rightRestriction primitive overlap atom /\
+        Not (K.leftRestriction primitive overlap atom)) :=
+  K.delta0_exact primitive source target overlap atom
+
+/-- The finite `B1` subgroup/predicate: cochains that are `delta0` boundaries. -/
+def B1
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom)
+    (cochain : K.C1) : Prop :=
+  exists primitive, K.delta0 primitive = cochain
+
+/-- The finite obstruction class vanishes when the residual cochain is a boundary. -/
+def ObstructionClassVanishes
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom) : Prop :=
+  B1 K K.residual
+
+/-- Nonzero obstruction is the failure of finite boundary vanishing. -/
+def ObstructionClassNonzero
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom) : Prop :=
+  Not (ObstructionClassVanishes K)
+
+/--
+A primitive is semantically closed when its semantic support closes every
+residual atom of the supplied cover.  This reuses the existing semantic support
+closure predicate rather than defining global coherence as a bare proposition.
+-/
+def PrimitiveSemanticallyClosed
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom)
+    (primitive : K.C0) : Prop :=
+  SemanticRepairClosed K.projection K.cover (K.supportOf primitive)
+
+/--
+Global semantic repair coherence: a boundary primitive exists and is a real
+semantic repair certificate.
+-/
+def GlobalSemanticRepairCoherent
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom) : Prop :=
+  exists primitive,
+    K.delta0 primitive = K.residual /\
+      PrimitiveSemanticallyClosed K primitive
+
+/--
+Semantic faithfulness hypotheses for the sufficiency direction.
+
+The hypotheses do not return a global certificate directly.  They say that any
+primitive whose `delta0` is the selected residual has residual component
+coverage and residual-component faithfulness.  The existing Cycle 83 theorem
+then converts these two semantic facts into `SemanticRepairClosed`.
+-/
+structure SemanticFaithfulnessHypotheses
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom) where
+  component_covered_of_boundary :
+    forall primitive,
+      K.delta0 primitive = K.residual ->
+        ResidualComponentCoveredSupport
+          K.projection K.cover (K.supportOf primitive)
+  component_faithful_of_boundary :
+    forall primitive,
+      K.delta0 primitive = K.residual ->
+        ResidualComponentFaithfulSupport
+          K.projection K.cover (K.supportOf primitive)
+
+/-! ## Semantic faithfulness bridge -/
+
+/--
+Residual component coverage plus residual-component faithfulness is exactly the
+semantic content needed for a primitive to be a real repair certificate.
+-/
+theorem primitive_semanticRepairClosed_of_faithful_delta0
+    {Atom : Type u}
+    {K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom}
+    (hfaithful : SemanticFaithfulnessHypotheses K)
+    {primitive : K.C0}
+    (hboundary : K.delta0 primitive = K.residual) :
+    PrimitiveSemanticallyClosed K primitive := by
+  exact
+    (semanticRepairClosed_iff_residualComponentCovered_and_faithful).mpr
+      ⟨hfaithful.component_covered_of_boundary primitive hboundary,
+        hfaithful.component_faithful_of_boundary primitive hboundary⟩
+
+/-- Existing component-faithfulness bridge, exposed for the descent package. -/
+theorem residualComponentFaithfulness_bridge_for_descent
+    {Atom : Type u}
+    {projection : Atom -> BridgeComponent}
+    {cover : HandoffCechCover}
+    {support : Atom -> Prop} :
+    SemanticRepairClosed projection cover support <->
+      ResidualComponentCoveredSupport projection cover support /\
+        ResidualComponentFaithfulSupport projection cover support := by
+  exact semanticRepairClosed_iff_residualComponentCovered_and_faithful
+
+/-- Existing residual-support transport bridge, exposed for the descent package. -/
+theorem residualSupportTransport_bridge_for_descent
+    {Source : Type u}
+    {Target : Type v}
+    {sourceProjection : Source -> BridgeComponent}
+    {sourceCover : HandoffCechCover}
+    {sourceSupport : Source -> Prop}
+    {targetProjection : Target -> BridgeComponent}
+    {targetCover : HandoffCechCover}
+    {targetSupport : Target -> Prop}
+    (transport :
+      ResidualSupportTransport
+        sourceProjection sourceCover sourceSupport
+        targetProjection targetCover targetSupport) :
+    SemanticRepairClosed sourceProjection sourceCover sourceSupport <->
+      SemanticRepairClosed targetProjection targetCover targetSupport := by
+  exact residualSupportTransport_semanticRepairClosed_iff transport
+
+/-! ## Necessity, contrapositive, and sufficiency -/
+
+/-- A coherent global semantic repair primitive forces the obstruction class to vanish. -/
+theorem globalRepairCoherent_forces_obstructionVanishes
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom) :
+    GlobalSemanticRepairCoherent K -> ObstructionClassVanishes K := by
+  intro hglobal
+  rcases hglobal with ⟨primitive, hboundary, _hclosed⟩
+  exact ⟨primitive, hboundary⟩
+
+/-- Nonzero obstruction rules out global semantic repair coherence. -/
+theorem no_globalRepairCoherent_of_nonzero_obstruction
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom) :
+    ObstructionClassNonzero K -> Not (GlobalSemanticRepairCoherent K) := by
+  intro hnonzero hglobal
+  exact hnonzero (globalRepairCoherent_forces_obstructionVanishes K hglobal)
+
+/--
+Under explicit semantic faithfulness hypotheses, obstruction vanishing builds a
+global semantic repair certificate.
+-/
+theorem globalRepairCoherent_of_obstructionVanishes
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom)
+    (hfaithful : SemanticFaithfulnessHypotheses K) :
+    ObstructionClassVanishes K -> GlobalSemanticRepairCoherent K := by
+  intro hvanishes
+  rcases hvanishes with ⟨primitive, hboundary⟩
+  exact
+    ⟨primitive, hboundary,
+      primitive_semanticRepairClosed_of_faithful_delta0
+        hfaithful hboundary⟩
+
+/-- Finite semantic repair-gluing descent equivalence under faithfulness. -/
+theorem finiteSemanticRepairGluingDescent_iff
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom)
+    (hfaithful : SemanticFaithfulnessHypotheses K) :
+    GlobalSemanticRepairCoherent K <-> ObstructionClassVanishes K := by
+  constructor
+  · exact globalRepairCoherent_forces_obstructionVanishes K
+  · exact globalRepairCoherent_of_obstructionVanishes K hfaithful
+
+/-! ## Visible/local witness validation -/
+
+/--
+The selected visible/local witness remains a nontrivial validation boundary:
+component-level declared clearance and visible/local repair transport do not
+reflect semantic repair-gluing exactness.
+-/
+theorem visibleLocalSemanticGluing_witness_validation :
+    VisibleLocalDeclaredClearanceSemanticObstruction
+        RepairTransportCechCommutatorCurvature.selectedRepairTransportCechCommutatorCell
+        ComponentClearanceSemanticObstruction.traceRepairFrontierDeclaredPlan /\
+      Not
+        (forall cell : RepairTransportCechCommutatorCurvature.RepairTransportCechCommutatorCell,
+          forall plan : HandoffRepairTransversalTheorem.HandoffRepairPlan,
+            VisibleLocalDeclaredClearanceProfile cell plan ->
+              SemanticRepairCocycleWitness.SemanticRepairGluingExact cell.flatPath ->
+                SemanticRepairCocycleWitness.SemanticRepairGluingExact cell.curvedPath) /\
+      Not
+        (ResidualComponentFaithfulSupport
+          SemanticSupportProjectionKernel.refinedSemanticComponent
+          HandoffCechOverlapBasis.repairFrontierOverlapBasisCover
+          SemanticSupportProjectionKernel.surfaceRepairSupport) /\
+      Not
+        (SemanticRepairClosed
+          SemanticSupportProjectionKernel.refinedSemanticComponent
+          HandoffCechOverlapBasis.repairFrontierOverlapBasisCover
+          SemanticSupportProjectionKernel.surfaceRepairSupport) := by
+  exact
+    ⟨selected_visibleLocalDeclaredClearance_semanticObstruction,
+      visibleLocalDeclaredClearance_not_reflect_semanticGluingExact,
+      Formal.AG.Research.QualitySurface.SemanticResidualComponentFaithfulness.surfaceRepairSupport_componentCovered_not_faithful.2,
+      SemanticSupportProjectionKernel.surfaceRepairSupport_not_semanticRepairClosed⟩
+
+/--
+A concrete finite complex attached to the selected visible/local witness.
+
+Its single visible primitive has the surface support, while the selected
+residual is not a `delta0` boundary.  This is a calibration instance: the
+finite `B1` quotient is not allowed to erase the Cycle 80 semantic residual by
+visible/component clearance alone.
+-/
+def selectedVisibleLocalWitnessComplex :
+    FiniteSemanticRepairGluingComplex RefinedSemanticRepairAtom where
+  Chart := Unit
+  Overlap := fun _ _ => Unit
+  chartOrder := [()]
+  chart_complete := by
+    intro chart
+    cases chart
+    simp
+  C0 := Unit
+  C1 := Bool
+  c0Order := [()]
+  c0_complete := by
+    intro primitive
+    cases primitive
+    simp
+  c1Order := [false, true]
+  c1_complete := by
+    intro cochain
+    cases cochain <;> simp
+  projection := refinedSemanticComponent
+  cover := repairFrontierOverlapBasisCover
+  supportOf := fun _ => surfaceRepairSupport
+  leftRestriction := fun _ {_source} {_target} _overlap _atom => False
+  rightRestriction := fun _ {_source} {_target} _overlap _atom => False
+  cochainAt := fun cochain {_source} {_target} _overlap atom =>
+    cochain = true /\ atom = RefinedSemanticRepairAtom.repairFrontierObligation
+  delta0 := fun _ => false
+  delta0_exact := by
+    intro primitive source target overlap atom
+    cases primitive
+    cases source
+    cases target
+    cases overlap
+    cases atom <;> simp
+  residual := true
+
+/-- The selected calibration complex has no primitive whose boundary is residual. -/
+theorem selectedVisibleLocalWitness_boundary_not_residual
+    (primitive : selectedVisibleLocalWitnessComplex.C0) :
+    Not
+      (selectedVisibleLocalWitnessComplex.delta0 primitive =
+        selectedVisibleLocalWitnessComplex.residual) := by
+  cases primitive
+  intro hboundary
+  cases hboundary
+
+/--
+The selected visible/local calibration complex has nonzero finite obstruction:
+its residual is not in `B1`.
+-/
+theorem selectedVisibleLocalWitness_obstructionNonzero :
+    ObstructionClassNonzero selectedVisibleLocalWitnessComplex := by
+  intro hvanishes
+  rcases hvanishes with ⟨primitive, hboundary⟩
+  exact selectedVisibleLocalWitness_boundary_not_residual primitive hboundary
+
+/-- The selected nonzero finite obstruction rules out global semantic repair coherence. -/
+theorem selectedVisibleLocalWitness_noGlobalRepairCoherent :
+    Not (GlobalSemanticRepairCoherent selectedVisibleLocalWitnessComplex) := by
+  intro hglobal
+  rcases hglobal with ⟨primitive, hboundary, _hclosed⟩
+  exact selectedVisibleLocalWitness_boundary_not_residual primitive hboundary
+
+/-! ## Theorem package -/
+
+/--
+Finite Semantic Repair-Gluing Descent theorem package.
+
+The package keeps the three target directions separate:
+necessity, the nonzero-obstruction contrapositive, and sufficiency under
+explicit semantic faithfulness hypotheses.
+-/
+theorem finiteSemanticRepairGluingDescent_package
+    {Atom : Type u}
+    (K : FiniteSemanticRepairGluingComplex.{u, v, w, x, y} Atom)
+    (hfaithful : SemanticFaithfulnessHypotheses K) :
+    (GlobalSemanticRepairCoherent K -> ObstructionClassVanishes K) /\
+      (ObstructionClassNonzero K -> Not (GlobalSemanticRepairCoherent K)) /\
+      (ObstructionClassVanishes K -> GlobalSemanticRepairCoherent K) /\
+      (GlobalSemanticRepairCoherent K <-> ObstructionClassVanishes K) /\
+      (forall {Atom' : Type u}
+        {projection : Atom' -> BridgeComponent}
+        {cover : HandoffCechCover}
+        {support : Atom' -> Prop},
+        SemanticRepairClosed projection cover support <->
+          ResidualComponentCoveredSupport projection cover support /\
+            ResidualComponentFaithfulSupport projection cover support) /\
+      (forall {Source : Type u}
+        {Target : Type v}
+        {sourceProjection : Source -> BridgeComponent}
+        {sourceCover : HandoffCechCover}
+        {sourceSupport : Source -> Prop}
+        {targetProjection : Target -> BridgeComponent}
+        {targetCover : HandoffCechCover}
+        {targetSupport : Target -> Prop},
+        ResidualSupportTransport
+            sourceProjection sourceCover sourceSupport
+            targetProjection targetCover targetSupport ->
+          (SemanticRepairClosed sourceProjection sourceCover sourceSupport <->
+            SemanticRepairClosed targetProjection targetCover targetSupport)) /\
+      VisibleLocalDeclaredClearanceSemanticObstruction
+        RepairTransportCechCommutatorCurvature.selectedRepairTransportCechCommutatorCell
+        ComponentClearanceSemanticObstruction.traceRepairFrontierDeclaredPlan /\
+      ObstructionClassNonzero selectedVisibleLocalWitnessComplex /\
+      Not (GlobalSemanticRepairCoherent selectedVisibleLocalWitnessComplex) /\
+      Not
+        (forall cell : RepairTransportCechCommutatorCurvature.RepairTransportCechCommutatorCell,
+          forall plan : HandoffRepairTransversalTheorem.HandoffRepairPlan,
+            VisibleLocalDeclaredClearanceProfile cell plan ->
+              SemanticRepairCocycleWitness.SemanticRepairGluingExact cell.flatPath ->
+                SemanticRepairCocycleWitness.SemanticRepairGluingExact cell.curvedPath) := by
+  exact
+    ⟨globalRepairCoherent_forces_obstructionVanishes K,
+      no_globalRepairCoherent_of_nonzero_obstruction K,
+      globalRepairCoherent_of_obstructionVanishes K hfaithful,
+      finiteSemanticRepairGluingDescent_iff K hfaithful,
+      fun {_Atom'} {_projection} {_cover} {_support} =>
+        residualComponentFaithfulness_bridge_for_descent,
+      fun {_Source} {_Target} {_sourceProjection} {_sourceCover} {_sourceSupport}
+          {_targetProjection} {_targetCover} {_targetSupport} transport =>
+      residualSupportTransport_bridge_for_descent transport,
+      visibleLocalSemanticGluing_witness_validation.1,
+      selectedVisibleLocalWitness_obstructionNonzero,
+      selectedVisibleLocalWitness_noGlobalRepairCoherent,
+      visibleLocalSemanticGluing_witness_validation.2.1⟩
+
+end SemanticRepairGluingComplex
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-02-finite-semantic-repair-gluing-descent-package.md
+++ b/research/ideas/g-aat-quality-surface-02-finite-semantic-repair-gluing-descent-package.md
@@ -1,0 +1,140 @@
+---
+status: picked
+goal: G-aat-quality-surface-02
+exploration_role: closer/unifier/wildcard synthesis
+candidate_type: target-proof
+capability_category: semantic-faithfulness / repair-coherence / global-gluing / semantic-obstruction / finite-complex
+expected_base_score: 95
+expected_evidence_multiplier: 2.0
+expected_final_score: 190
+evidence_stage: proved-in-research
+rival_advantage: ADL, static analyzers, conformance checkers, metric dashboards, and strong AI review can represent local pass / component repair / review plans, but they do not by themselves certify when a finite obstruction primitive is a genuine semantic global repair certificate.
+genius_potential: no
+genius_target: not-applicable
+genius_support_role: not-applicable
+target_theorem: Finite Semantic Repair-Gluing Descent Theorem
+target_support_node: Stage 2 finite complex / B1 plus Stage 2.5 sufficiency / semantic faithfulness bridge
+target_progress: target-proof-candidate
+proof_obligation_delta: added finite complex, B1 vanishing, necessity, contrapositive, sufficiency under explicit residual-component faithfulness hypotheses, and visible/local witness validation package.
+target_completion_role: target theorem package candidate; completion still requires axiom audit, G3.5 sync, G4 audit, G5 review, and G6 target completion judgment.
+origin: G-aat-quality-surface-02
+tags: [target-theorem, semantic-repair, gluing, descent, finite-complex, faithfulness]
+created: 2026-06-23
+lean: proved-in-research
+lean_files:
+  - Formal/AG/Research/QualitySurface/SemanticRepairGluingComplex.lean
+lean_declarations:
+  - FiniteSemanticRepairGluingComplex
+  - B1
+  - ObstructionClassVanishes
+  - ObstructionClassNonzero
+  - PrimitiveSemanticallyClosed
+  - GlobalSemanticRepairCoherent
+  - SemanticFaithfulnessHypotheses
+  - delta0_support_exact
+  - primitive_semanticRepairClosed_of_faithful_delta0
+  - residualComponentFaithfulness_bridge_for_descent
+  - residualSupportTransport_bridge_for_descent
+  - globalRepairCoherent_forces_obstructionVanishes
+  - no_globalRepairCoherent_of_nonzero_obstruction
+  - globalRepairCoherent_of_obstructionVanishes
+  - finiteSemanticRepairGluingDescent_iff
+  - visibleLocalSemanticGluing_witness_validation
+  - selectedVisibleLocalWitnessComplex
+  - selectedVisibleLocalWitness_boundary_not_residual
+  - selectedVisibleLocalWitness_obstructionNonzero
+  - selectedVisibleLocalWitness_noGlobalRepairCoherent
+  - finiteSemanticRepairGluingDescent_package
+---
+
+# Finite Semantic Repair-Gluing Descent Package
+
+## 主張
+
+有限 semantic repair atlas / complex `K` に対して、`C0` を local repair primitive family、`C1` を residual repair-gluing cochain carrier、`delta0 : C0 -> C1` を overlap restriction difference、`B1` を `delta0` の像として置く。`K.residual` が `B1` に入ることを obstruction vanish と読む。
+
+明示された semantic faithfulness hypotheses が、`delta0` primitive に residual component coverage と residual-component faithfulness を与えるなら、次を同じ Lean theorem package として証明する。
+
+- `globalRepairCoherent_forces_obstructionVanishes`
+- `no_globalRepairCoherent_of_nonzero_obstruction`
+- `globalRepairCoherent_of_obstructionVanishes`
+- `finiteSemanticRepairGluingDescent_package`
+
+さらに `selectedVisibleLocalWitnessComplex` を concrete calibration instance として置き、selected visible/local witness の residual が `B1` に入らず `GlobalSemanticRepairCoherent` を持たないことを証明する。
+
+これは Stage 1 / 2 の necessity と Stage 2.5 の sufficiency を区別しつつ、target theorem の有限版同値を証明する候補である。G2 A の revise 要求を受け、`SemanticFaithfulnessHypotheses` は primitive を global certificate へ直接持ち上げる循環的仮定ではなく、`ResidualComponentCoveredSupport` と `ResidualComponentFaithfulSupport` を `delta0` boundary primitive に要求する形で実装した。G3 形式化品質監査の指摘を受け、`leftRestriction`、`rightRestriction`、`cochainAt`、`delta0_exact`、`delta0_support_exact` により、`delta0` が任意 map ではなく finite overlap 上の restriction-difference law を持つことも型に出した。
+
+## 候補種別
+
+`target-proof`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-02`
+- `docs/note/aat_semantic_repair_gluing_complex.md`
+- `Formal/AG/Research/QualitySurface/SemanticRepairCocycleWitness.lean`
+- `Formal/AG/Research/QualitySurface/SemanticSupportProjectionKernel.lean`
+- `Formal/AG/Research/QualitySurface/SemanticResidualComponentFaithfulness.lean`
+- `Formal/AG/Research/QualitySurface/SemanticResidualTransportNaturality.lean`
+- `Formal/AG/Research/QualitySurface/VisibleLocalSemanticGluingObstruction.lean`
+- `Formal/AG/Research/QualitySurface/SemanticResidualObstructionClass.lean`
+
+## 非自明性
+
+`ObstructionClass = 0` を単なる green verdict や scanner absence と同一視しない。finite `B1 = im delta0` の primitive と、semantic global repair certificate の間に faithfulness bridge を置く。component projection や local visible pass だけでは semantic closure を反映できないことは既存の projection-kernel / component-faithfulness witness が示しており、候補はその失敗を避ける仮説を Lean theorem の前提として明示する。
+
+## 数学的興味
+
+有限 Cech-style algebra、semantic atom support、residual-component faithfulness、transport naturality をひとつの descent theorem package に圧縮する。難所は cochain 代数そのものではなく、形式 primitive が意味論上の repair certificate であることを示す bridge である。
+
+## GOAL への前進
+
+Stage 2 の finite complex / `B1` と Stage 2.5 の sufficiency direction を同時に進め、target theorem の proof distance を直接縮める。
+
+## ライバルに対する有効性
+
+ADL は component / connector / view / constraint を扱えるが、semantic residual atom identity と faithfulness bridge を finite theorem package として持たない。静的解析器と conformance checker は local pass / fail と rule violation を返せるが、finite obstruction primitive が semantic global repair certificate へ descent する条件を証明しない。metric dashboard は vanish / primitive / semantic coherence を潰す。強い AI reviewer は repair plan を提案できても、supplied finite hypotheses 下で axiom-audited theorem package を返すわけではない。
+
+## SCORE 見込み
+
+- `score_reason`: target theorem の本体方向である necessity / sufficiency package を弱めずに狙う。G2 A の厳密性 revise を反映し、base は 95 に調整する。
+- `dullness_risk`: `B1` を広く定義して全 residual を boundary にする、または primitive を semantic repair と無証明に同一視すると失格。faithfulness hypotheses と visible/local witness validation を分けて記録する必要がある。
+- `proof_or_evidence_plan`: `FiniteSemanticRepairGluingComplex`、restriction-difference `delta0` law、`B1`、`ObstructionClassNonzero`、`GlobalSemanticRepairCoherent`、`SemanticFaithfulnessHypotheses` を `Formal/AG/Research/QualitySurface/SemanticRepairGluingComplex.lean` に置き、既存の faithfulness / transport / visible-local obstruction theorem を package に接続した。`lake env lean Formal/AG/Research/QualitySurface/SemanticRepairGluingComplex.lean` と対象 module build は通過済み。
+
+## Target Theorem 寄与
+
+- `target_theorem`: `Finite Semantic Repair-Gluing Descent Theorem`
+- `target_support_node`: Stage 2 finite complex / `B1`; Stage 2.5 sufficiency / semantic faithfulness bridge; witness validation sync
+- `target_progress`: `target-proof-candidate`
+- `proof_obligation_delta`: target proof artifacts に `FiniteSemanticRepairGluingComplex`、`delta0`、`B1`、`ObstructionClassNonzero`、necessity、contrapositive、sufficiency、package theorem、visible/local witness validation、concrete nonzero calibration witness を追加した。
+- `target_completion_role`: target theorem package の本体候補。completion criteria は G3-G6 で別途判定する。
+
+## CS / SWE への帰結
+
+local repair success や component-level green を、そのまま global semantic repair success と呼べない境界を保ったまま、どの有限仮説があれば local primitive を global semantic certificate へ持ち上げられるかを明示できる。
+
+## 証明・根拠の見込み
+
+Lean では有限 complex を抽象 record として置いた。`delta0` は `leftRestriction` と `rightRestriction` の symmetric difference として `delta0_exact` で拘束される。`obstructionVanishes` は `K.residual ∈ B1`、`ObstructionClassNonzero` はその否定として定義する。`GlobalSemanticRepairCoherent` から vanish は semantic-closed primitive で示し、対偶は命題論理で得る。逆向きは `SemanticFaithfulnessHypotheses` が boundary primitive に residual component coverage と residual-component faithfulness を与え、既存 theorem `semanticRepairClosed_iff_residualComponentCovered_and_faithful` で `SemanticRepairClosed` を構成することで示す。
+
+既存 artifact は、faithfulness 仮説が空虚でないことと、visible/local/component projection だけでは不十分であることの validation package として接続する。
+
+axiom audit では、core descent theorem 群は axiom-free、`visibleLocalSemanticGluing_witness_validation` と `finiteSemanticRepairGluingDescent_package` は既存 witness 由来の `propext` / `Quot.sound` に依存、selected witness nonzero theorem 群は concrete finite record 展開由来の `propext` に依存し、`sorryAx` はない。
+
+## 審判メモ
+
+- 厳密性: G2 A は初回 revise。循環的 faithfulness、広すぎる `B1`、自明化した `GlobalSemanticRepairCoherent` を避けることを要求。実装では `SemanticFaithfulnessHypotheses` を component coverage + residual-component faithfulness に分解し、さらに `delta0_exact` / `delta0_support_exact` と concrete selected witness を追加した後、再審判で accept。
+- 研究価値: G2 B は accept / base_score 100 / target-proof-candidate。ただし通常枠であり genius ではない。
+- repo 全体価値: G2 C は accept / base_score 95 / target-proof-candidate。
+- ライバル比較: G2 D は accept / base_score 95 / target-proof-candidate。`B1` と faithfulness が結論の言い換えでないことを evidence として要求。
+
+## 関連
+
+G1 候補 pool では closer / unifier / wildcard が Stage 2.5 sufficiency bridge を最有力、obstruction が faithfulness gap と `B1` 自明化ガードを最重要 blocker とした。
+
+## 進捗ログ
+
+- 2026-06-23: G1 候補 pool から target-proof package として作成。
+- 2026-06-23: `SemanticRepairGluingComplex.lean` を追加し、対象 file の `lake env lean` を通過。
+- 2026-06-23: concrete selected witness complex と nonzero / no-global theorem を追加し、対象 module build と axiom audit を再通過。
+- 2026-06-23: `delta0_exact` / `delta0_support_exact` を追加し、`delta0` を overlap restriction-difference law として明示化。対象 module build と axiom audit を再通過。

--- a/research/reports/G-aat-quality-surface-02.md
+++ b/research/reports/G-aat-quality-surface-02.md
@@ -1,0 +1,87 @@
+# G-aat-quality-surface-02 report
+
+この report は、finite semantic repair-gluing descent theorem の証明へ向けた研究成果を記録する。状態の正本は GitHub tracking Issue に置き、ここには SCORE 監査を通った成果だけを載せる。
+
+## Current SCORE
+
+- total SCORE: 190
+- category scores:
+  - semantic-faithfulness / repair-coherence / global-gluing / semantic-obstruction / finite-complex: 190
+- evidence portfolio:
+  - proved-in-research: 1
+
+## Target Proof State
+
+- target theorem: `Finite Semantic Repair-Gluing Descent Theorem`
+- proof state: finite / explicit-faithfulness descent package proved in research
+- completed support nodes:
+  - Stage 2 finite complex / `B1`
+  - Stage 2.5 sufficiency / semantic faithfulness bridge
+  - Stage 1 necessity and nonzero-obstruction contrapositive inside the finite package
+  - visible/local witness validation and concrete nonzero calibration witness
+- open support nodes:
+  - literal finite overlap-family enumeration as `overlapOrder`
+  - restriction functoriality / coefficient structure for stricter Cech formulation
+  - future true site/sheaf `H^1` upgrade
+- target completion status: pending G4 / G5 / G6 judgment; do not treat this report alone as completion
+
+## Cycle 1: Finite Semantic Repair-Gluing Descent Package
+
+```text
+candidate: Finite Semantic Repair-Gluing Descent Package
+candidate_type: target-proof
+evidence_stage: proved-in-research
+base_score: 95
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 190
+category: semantic-faithfulness / repair-coherence / global-gluing / semantic-obstruction / finite-complex
+goal_delta: finite semantic repair-gluing descent を、`C0` / `C1` / `delta0` / `B1` / obstruction vanish / nonzero obstruction / explicit semantic faithfulness hypotheses / global semantic repair coherence の theorem package として固定した。
+project_value_delta: G-01 の semantic residual / faithfulness / transport / visible-local obstruction tower を、G-02 の target theorem proof artifact へ集約した。AAT が local green や review summary ではなく、有限 obstruction と semantic descent condition を持つことを Lean-backed に示す。
+rival_delta: ADL、静的解析器、conformance checker、metric dashboard、強い AI review agent が扱う local pass / component repair / review plan を尊重しつつ、それらだけでは保証できない residual atom faithfulness と global repair gluing coherence を有限 theorem として分離する。
+formalization_quality: pass。`delta0_exact` / `delta0_support_exact` により `delta0` は overlap restriction-difference law として拘束され、`SemanticFaithfulnessHypotheses` は boundary primitive に residual component coverage と residual-component faithfulness を要求する非循環な形になっている。
+target_progress: target-proof-candidate
+proof_obligation_delta: `FiniteSemanticRepairGluingComplex`、`B1`、`ObstructionClassVanishes`、`ObstructionClassNonzero`、`GlobalSemanticRepairCoherent`、`delta0_support_exact`、bridge helper、necessity / contrapositive / sufficiency theorem、selected witness nonzero / no-global theorem、`finiteSemanticRepairGluingDescent_package` を追加した。
+open_questions: true site/sheaf `H^1` への昇格、overlap family の明示列挙、restriction functoriality、係数構造、strict finite-atlas formulation。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SemanticRepairGluingComplex.lean` は、有限 semantic repair-gluing complex を導入する。`C0` は local repair primitive family、`C1` は residual repair-gluing cochain carrier、`delta0` は overlap restriction difference、`B1` は `delta0` の像である。`delta0_exact` と `delta0_support_exact` は、`delta0` が各 overlap / atom 上で left / right restriction の symmetric difference として読めることを固定する。
+
+Lean 証拠は三方向に分かれる。
+
+- `globalRepairCoherent_forces_obstructionVanishes`: global semantic repair coherent primitive は obstruction vanish を強制する。
+- `no_globalRepairCoherent_of_nonzero_obstruction`: nonzero obstruction は global semantic repair coherence を否定する。
+- `globalRepairCoherent_of_obstructionVanishes`: explicit semantic faithfulness hypotheses の下で、obstruction vanish は global semantic repair coherent certificate を構成する。
+
+ここで `SemanticFaithfulnessHypotheses` は、boundary primitive を直接 global certificate と同一視しない。代わりに residual component coverage と residual-component faithfulness を要求し、既存の `semanticRepairClosed_iff_residualComponentCovered_and_faithful` により semantic repair closure を構成する。
+
+`selectedVisibleLocalWitnessComplex` は calibration witness である。visible / local / component clearance だけでは selected residual を `B1` に入れられないことを `selectedVisibleLocalWitness_obstructionNonzero` として示し、`selectedVisibleLocalWitness_noGlobalRepairCoherent` により nonzero finite obstruction が global coherence を阻むことを確認する。
+
+### Axiom Audit
+
+Core descent theorem:
+
+- `delta0_support_exact`: axiom-free
+- `primitive_semanticRepairClosed_of_faithful_delta0`: axiom-free
+- `residualComponentFaithfulness_bridge_for_descent`: axiom-free
+- `residualSupportTransport_bridge_for_descent`: axiom-free
+- `globalRepairCoherent_forces_obstructionVanishes`: axiom-free
+- `no_globalRepairCoherent_of_nonzero_obstruction`: axiom-free
+- `globalRepairCoherent_of_obstructionVanishes`: axiom-free
+- `finiteSemanticRepairGluingDescent_iff`: axiom-free
+
+Witness / package surface:
+
+- `visibleLocalSemanticGluing_witness_validation`: depends on `propext`, `Quot.sound`
+- `selectedVisibleLocalWitness_boundary_not_residual`: depends on `propext`
+- `selectedVisibleLocalWitness_obstructionNonzero`: depends on `propext`
+- `selectedVisibleLocalWitness_noGlobalRepairCoherent`: depends on `propext`
+- `finiteSemanticRepairGluingDescent_package`: depends on `propext`, `Quot.sound`
+
+No reported declaration depends on `sorryAx`, non-consulted `axiom`, `admit`, or `unsafe`.
+
+### Target Boundary
+
+This result is finite and hypothesis-relative. It does not claim arbitrary site / sheaf cohomology, source extraction completeness, ArchMap correctness, runtime repair synthesis, global minimality, or whole-codebase quality. It proves the finite explicit-faithfulness descent package required for G-02, while leaving a stricter finite-atlas and true `H^1` formulation as future frontier.


### PR DESCRIPTION
## 概要

Refs #2476

G-aat-quality-surface-02 の target theorem に向けて、finite semantic repair atlas 上の repair-gluing descent theorem package を Lean で追加しました。

この PR は tracking issue を閉じません。research-loop の target theorem completion 判定と merge 後の台帳更新が残るため、Issue #2476 は追跡用に維持します。

## 証明した定理

- `delta0_support_exact`
- `primitive_semanticRepairClosed_of_faithful_delta0`
- `residualComponentFaithfulness_bridge_for_descent`
- `residualSupportTransport_bridge_for_descent`
- `globalRepairCoherent_forces_obstructionVanishes`
- `no_globalRepairCoherent_of_nonzero_obstruction`
- `globalRepairCoherent_of_obstructionVanishes`
- `finiteSemanticRepairGluingDescent_iff`
- `visibleLocalSemanticGluing_witness_validation`
- `selectedVisibleLocalWitness_boundary_not_residual`
- `selectedVisibleLocalWitness_obstructionNonzero`
- `selectedVisibleLocalWitness_noGlobalRepairCoherent`
- `finiteSemanticRepairGluingDescent_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-02-finite-semantic-repair-gluing-descent-package.md`
- `research/reports/G-aat-quality-surface-02.md`

## 実施したテスト

- [x] `lake build Formal.AG.Research.QualitySurface.SemanticRepairGluingComplex`
- [x] `lake env lean .tmp/semantic_repair_gluing_axioms.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

`Closes #2476` は意図的に未記載です。Issue #2476 は research-loop の tracking issue であり、merge 後の G6 判定まで台帳として使います。
